### PR TITLE
Handle jobs not coming from WMAgent

### DIFF
--- a/CondorMonitoring/JobCounter.py
+++ b/CondorMonitoring/JobCounter.py
@@ -575,6 +575,11 @@ def main():
                 
                 id = str(job['ClusterID']) + '.' + str(job['ProcId'])
                 status = int(job['JobStatus'])
+                
+                if 'WMAgent_SubTaskName' not in job:
+                    print 'I found a job not coming from WMAgent: %s' % id
+                    continue
+                    
                 workflow = job['WMAgent_SubTaskName'].split('/')[1]
                 task = job['WMAgent_SubTaskName'].split('/')[-1]
                 type = job['CMS_JobType']


### PR DESCRIPTION
Some test jobs or dev jobs dont have all the classadds that the monitoring script needs to account them
Ignore jobs like this for now.