### PR TITLE
Add the original request name to clones

### DIFF
--- a/resubmit.py
+++ b/resubmit.py
@@ -170,8 +170,9 @@ def cloneWorkflow(workflow, user, group, verbose=False, backfill=False):
     """
     # Get info about the workflow to be cloned
     helper = reqMgrClient.retrieveSchema(workflow, reqmgrCouchURL)
-    # get info from reqMgr
+    # Adapt schema and add original request to it
     schema = modifySchema(helper, user, group, backfill)
+    schema['OriginalRequest'] = workflow
     if verbose:
         pprint(schema)
     print 'Submitting workflow'


### PR DESCRIPTION
As discussed with Dima, he only wants to know the original workflow from which a clone was created (not the real first workflow injected into the system for that prepId/etc).
