### PR TITLE
Adapt resubmit to OriginalRequestName

### DIFF
--- a/resubmit.py
+++ b/resubmit.py
@@ -172,7 +172,7 @@ def cloneWorkflow(workflow, user, group, verbose=False, backfill=False):
     helper = reqMgrClient.retrieveSchema(workflow, reqmgrCouchURL)
     # Adapt schema and add original request to it
     schema = modifySchema(helper, user, group, backfill)
-    schema['OriginalRequest'] = workflow
+    schema['OriginalRequestName'] = workflow
     if verbose:
         pprint(schema)
     print 'Submitting workflow'


### PR DESCRIPTION
@julianbadillo @ticoann I tested clones with OriginalRequestName and this view works like a charm
https://cmsweb-testbed.cern.ch/couchdb/reqmgr_workload_cache/_design/ReqMgr/_view/byoriginalrequest

@drkovalskyi , "key" is the original request and "value" (or "id") is the new one (clone)