### PR TITLE
temp fix for reqmgr2 call getting 500 errors

### DIFF
--- a/reqMgrClient.py
+++ b/reqMgrClient.py
@@ -450,8 +450,20 @@ def getWorkflowInfo(url, workflow):
     """
     Retrieves workflow information
     """
-    request = requestManagerGet(url,'/reqmgr2/data/request?name='+workflow)
-    return request['result'][0][workflow]
+    return getWorkloadCache(url, workflow)
+
+def getMultiWorkflowInfo(url, workflows):
+    """
+    Retrieves workflow information
+    """
+    if isinstance(workflows, basestring):
+        workflows = [workflows]
+    result = requestManagerPost(url,'/couchdb/reqmgr_workload_cache/_all_docs?include_docs=true', {"keys": workflows})
+    resultDict = {}
+    couchResult = json.loads(result)
+    for row in couchResult['rows']:
+        resultDict[row['key']] = row['doc']
+    return resultDict
 
 def isRequestMgr2Request(url, workflow):
     result = getWorkflowInfo(url, workflow)


### PR DESCRIPTION
Also added bulk request call. If possible please use bulk request call 'getMultiWorkflowInfo'
insteade of 'getWorkflowInfo'.  I am not sure what would be right bulk size but it seem 20 at a time could be OK. If you put too many workflows at one time the memory usage will be higher. 
The performance will improve a lot (~20 times), it will have much less load on the server if it doesn't get called too often.