### PR TITLE
More fixes to assign.py, redo memory option in reject.py and resubmit.py

### DIFF
--- a/assign.py
+++ b/assign.py
@@ -128,7 +128,6 @@ def assignRequest(url, workflow, team, sites, era, procversion, activity, lfn, p
     if verbose:
         print res
 
-
 def getRequestDict(url, workflow):
     conn = httplib.HTTPSConnection(url, cert_file=os.getenv(
         'X509_USER_PROXY'), key_file=os.getenv('X509_USER_PROXY'))
@@ -197,11 +196,11 @@ def main():
     # parse site list
     if options.sites:
         if options.sites == "t1":
-            sites = T1_SITES
+            sites = SI.sites_T1s
         elif options.sites == "t2":
-            sites = T2_SITES
-        else:
-            sites = SI.sites_T1s + SI.sites_T2s
+            sites = SI.sites_T2s
+        else: 
+            sites = [site for site in options.sites.split(',')]
     else: 
         sites = SI.sites_T1s + SI.sites_T2s
     if options.team:
@@ -258,13 +257,15 @@ def main():
         elif not taskchain:
             era = wf.info['AcquisitionEra']
         #Set era and procstring to none for merge ACDCs inside a task chain
-        if schema["RequestType"] == "Resubmission" and wf.info["PrepID"].startswith("task") and "Merge" in schema["InitialTaskPath"].split("/")[-2]:
+        if schema["RequestType"] == "Resubmission" and wf.info["PrepID"].startswith("task") and "Merge" in schema["InitialTaskPath"].split("/")[-1]:
             era = None
             procstring = None
 
         # Must use --lfn option, otherwise workflow won't be assigned
         if options.lfn:
             lfn = options.lfn
+        elif "MergedLFNBase" in wf.info:
+            lfn = wf.info['MergedLFNBase']
         else:
             print "Can't assign the workflow! Please include workflow lfn using --lfn option."
             sys.exit(0)

--- a/reject.py
+++ b/reject.py
@@ -29,6 +29,7 @@ def main():
     parser.add_option('-i', '--invalidate', help='Invalidate datasets? The default value is False',action="store_true", dest='invalidate', default=False)
     parser.add_option("-u", "--user", dest="user",help="The user for creating the clone, if empty it will use the OS user running the script")
     parser.add_option("-g", "--group", dest="group", default='DATAOPS',help="The group for creating the clone, if empty it will, use 'DATAOPS' by default")
+    parser.add_option("-m", "--memory", dest="memory", help="Set max memory for the clone. At assignment, this will be used to calculate maxRSS = memory*1024")
     (options, args) = parser.parse_args()
 
     # Check the arguments, get info from them
@@ -44,7 +45,7 @@ def main():
     else:
         parser.error("Provide the workflow of a file of workflows")
         sys.exit(1)
-
+ 
     if not options.user:
         # get os username by default
         uinfo = pwd.getpwuid(os.getuid())
@@ -73,7 +74,11 @@ def main():
         # clones workflow
         if options.clone:
             print("Cloning workflow: "+ workflow)
-            cloned = resubmit.cloneWorkflow(workflow, user, options.group)
+            if options.memory:
+                mem = options.memory
+            else:
+                mem = workflowInfo.info["Memory"]
+            cloned = resubmit.cloneWorkflow(workflow, user, options.group, memory=mem)
     sys.exit(0);
 
 if __name__ == "__main__":

--- a/reject.py
+++ b/reject.py
@@ -29,7 +29,6 @@ def main():
     parser.add_option('-i', '--invalidate', help='Invalidate datasets? The default value is False',action="store_true", dest='invalidate', default=False)
     parser.add_option("-u", "--user", dest="user",help="The user for creating the clone, if empty it will use the OS user running the script")
     parser.add_option("-g", "--group", dest="group", default='DATAOPS',help="The group for creating the clone, if empty it will, use 'DATAOPS' by default")
-    parser.add_option("-m", "--memory", dest="memory", help="Set max memory for the clone. At assignment, this will be used to calculate maxRSS = memory*1024")
     (options, args) = parser.parse_args()
 
     # Check the arguments, get info from them
@@ -45,7 +44,7 @@ def main():
     else:
         parser.error("Provide the workflow of a file of workflows")
         sys.exit(1)
- 
+
     if not options.user:
         # get os username by default
         uinfo = pwd.getpwuid(os.getuid())
@@ -74,11 +73,7 @@ def main():
         # clones workflow
         if options.clone:
             print("Cloning workflow: "+ workflow)
-            if options.memory:
-                mem = options.memory
-            else:
-                mem = workflowInfo.info["Memory"]
-            cloned = resubmit.cloneWorkflow(workflow, user, options.group, memory=mem)
+            cloned = resubmit.cloneWorkflow(workflow, user, options.group)
     sys.exit(0);
 
 if __name__ == "__main__":

--- a/reject.py
+++ b/reject.py
@@ -29,7 +29,7 @@ def main():
     parser.add_option('-i', '--invalidate', help='Invalidate datasets? The default value is False',action="store_true", dest='invalidate', default=False)
     parser.add_option("-u", "--user", dest="user",help="The user for creating the clone, if empty it will use the OS user running the script")
     parser.add_option("-g", "--group", dest="group", default='DATAOPS',help="The group for creating the clone, if empty it will, use 'DATAOPS' by default")
-    parser.add_option("-m", "--memory", dest="memory", help="Set max memory for the clone. At assignment, this will be used to calculate maxRSS = memory*1024")
+    parser.add_option("-m", "--memory", dest="memory", help="Set max memory for the clone. At assignment, this will be used to set maxRSS to memory*1024")
     (options, args) = parser.parse_args()
 
     # Check the arguments, get info from them
@@ -75,10 +75,10 @@ def main():
         if options.clone:
             print("Cloning workflow: "+ workflow)
             if options.memory:
-                mem = options.memory
+                memo = options.memory
             else:
-                mem = workflowInfo.info["Memory"]
-            cloned = resubmit.cloneWorkflow(workflow, user, options.group, memory=mem)
+                memo = workflowInfo.info["Memory"]
+            cloned = resubmit.cloneWorkflow(workflow, user, options.group, memory=memo)
     sys.exit(0);
 
 if __name__ == "__main__":

--- a/reject.py
+++ b/reject.py
@@ -79,7 +79,7 @@ def main():
                 mem = options.memory
             else:
                 mem = workflowInfo.info["Memory"]
-                cloned = resubmit.cloneWorkflow(workflow, user, options.group, memory=mem)
+            cloned = resubmit.cloneWorkflow(workflow, user, options.group, memory=mem)
     sys.exit(0);
 
 if __name__ == "__main__":

--- a/reject.py
+++ b/reject.py
@@ -29,6 +29,8 @@ def main():
     parser.add_option('-i', '--invalidate', help='Invalidate datasets? The default value is False',action="store_true", dest='invalidate', default=False)
     parser.add_option("-u", "--user", dest="user",help="The user for creating the clone, if empty it will use the OS user running the script")
     parser.add_option("-g", "--group", dest="group", default='DATAOPS',help="The group for creating the clone, if empty it will, use 'DATAOPS' by default")
+    parser.add_option("-m", "--memory", dest="memory", help="Set max memory for the clone. At assignment, this will be used to calculate maxRSS = memory*1024")
+
     (options, args) = parser.parse_args()
 
     # Check the arguments, get info from them
@@ -73,7 +75,11 @@ def main():
         # clones workflow
         if options.clone:
             print("Cloning workflow: "+ workflow)
-            cloned = resubmit.cloneWorkflow(workflow, user, options.group)
+            if options.memory:
+                mem = options.memory
+            else:
+                mem = workflowInfo.info["Memory"]
+                cloned = resubmit.cloneWorkflow(workflow, user, options.group, memory=mem)
     sys.exit(0);
 
 if __name__ == "__main__":

--- a/reject.py
+++ b/reject.py
@@ -45,7 +45,7 @@ def main():
     else:
         parser.error("Provide the workflow of a file of workflows")
         sys.exit(1)
-
+ 
     if not options.user:
         # get os username by default
         uinfo = pwd.getpwuid(os.getuid())

--- a/resubmit.py
+++ b/resubmit.py
@@ -322,7 +322,7 @@ url = 'cmsweb.cern.ch'
 url_tb = 'cmsweb-testbed.cern.ch'
 reqmgrCouchURL = "https://" + url + "/couchdb/reqmgr_workload_cache"
 
-
+ 
 def main():
 
     # Create option parser

--- a/resubmit.py
+++ b/resubmit.py
@@ -41,7 +41,7 @@ DELTA_EVENTS = 1000
 DELTA_LUMIS = 200
 
 
-def modifySchema(helper, workflow, user, group, cache, events, firstLumi, backfill=False):
+def modifySchema(helper, workflow, user, group, cache, events, firstLumi, backfill=False, memory=None):
     """
     Adapts schema to right parameters.
     If the original workflow points to DBS2, DBS3 URL is fixed instead.
@@ -55,6 +55,12 @@ def modifySchema(helper, workflow, user, group, cache, events, firstLumi, backfi
             result['ConfigCacheID'] = value
         elif key == 'RequestSizeEvents':
             result['RequestSizeEvents'] = value
+        #Set memory
+        elif key == 'Memory':
+            if memory != None:
+                result['Memory'] = memory
+            else:
+                result['Memory'] = value
         #requestor info
         elif key == 'Requestor':
             result['Requestor'] = user
@@ -100,6 +106,56 @@ def modifySchema(helper, workflow, user, group, cache, events, firstLumi, backfi
         # Update the request priority
         if cache and 'RequestPriority' in cache:
             result['RequestPriority'] = cache['RequestPriority']
+    # check MonteCarlo
+    if result['RequestType'] == 'MonteCarlo':
+        # check assigning parameters
+        # seek for events per job on helper
+        try:
+            splitting = helper.listJobSplittingParametersByTask()
+        except AttributeError:
+            splitting = {}
+
+        eventsPerJob = 120000
+        eventsPerLumi = 100000
+        for k, v in splitting.items():
+            # print k,":",v
+            if k.endswith('/Production'):
+                if 'events_per_job' in v:
+                    eventsPerJob = v['events_per_job']
+                elif 'events_per_lumi' in v:
+                    eventsPerLumi = v['events_per_lumi']
+        # result['EventsPerJob'] = eventsPerJob
+        # result['EventsPerLumi'] = eventsPerLumi
+    # check MonteCarloFromGen
+    elif result['RequestType'] == 'MonteCarloFromGEN':
+        # seek for lumis per job on helper
+        splitting = helper.listJobSplittingParametersByTask()
+        lumisPerJob = 300
+        for k, v in splitting.items():
+            if k.endswith('/Production'):
+                if 'lumis_per_job' in v:
+                    lumisPerJob = v['lumis_per_job']
+        result['LumisPerJob'] = lumisPerJob
+        # Algorithm = lumi based?
+        result["SplittingAlgo"] = "LumiBased"
+    elif result['RequestType'] == "TaskChain":
+        # Now changing the parameters according to HG1309
+        x = 1
+        # on every task
+        while x <= result['TaskChain']:
+            task = 'Task' + str(x)
+            for (key, value) in result[task].iteritems():
+                if key == "SplittingAlgorithm":
+                    result[task]['SplittingAlgo'] = value
+                    del result[task]['SplittingAlgorithm']
+                elif key == "SplittingArguments":
+                    for (k2, v2) in result[task][key].iteritems():
+                        if k2 == "lumis_per_job":
+                            result[task]["LumisPerJob"] = v2
+                        elif k2 == "events_per_job":
+                            result[task]["EventsPerJob"] = v2
+                        del result[task]['SplittingArguments']
+            x += 1
 
     # Merged LFN
     if 'MergedLFNBase' not in result:
@@ -148,7 +204,7 @@ def modifySchema(helper, workflow, user, group, cache, events, firstLumi, backfi
     return result
 
 
-def cloneWorkflow(workflow, user, group, verbose=True, backfill=False, testbed=False, bwl=None):
+def cloneWorkflow(workflow, user, group, verbose=True, backfill=False, testbed=False, memory=None, bwl=None):
     """
     clones a workflow
     """
@@ -160,7 +216,7 @@ def cloneWorkflow(workflow, user, group, verbose=True, backfill=False, testbed=F
     except:
         cache = None
         
-    schema = modifySchema(helper, workflow, user, group, cache, None, None, backfill)
+    schema = modifySchema(helper, workflow, user, group, cache, None, None, backfill, memory)
 
     schema['OriginalRequestName'] = workflow
     if verbose:
@@ -266,7 +322,7 @@ url = 'cmsweb.cern.ch'
 url_tb = 'cmsweb-testbed.cern.ch'
 reqmgrCouchURL = "https://" + url + "/couchdb/reqmgr_workload_cache"
 
-
+ 
 def main():
 
     # Create option parser
@@ -282,6 +338,8 @@ def main():
                       help="Group to send the workflows.")
     parser.add_option("-b", "--backfill", action="store_true", dest="backfill", default=False,
                       help="Creates a clone for backfill test purposes.")
+    parser.add_option("-m", "--memory", dest="memory",
+                  help="Set max memory for the event. At assignment, this will be used to calculate maxRSS = memory*1024")
     parser.add_option("-v", "--verbose", action="store_true", dest="verbose", default=False,
                       help="Prints all query information.")
     parser.add_option('-f', '--file', help='Text file with a list of workflows', dest='file')
@@ -313,8 +371,13 @@ def main():
 
     if options.action == 'clone':
         for wf in wfs:
+            workflow = reqMgrClient.Workflow(wf)
+            if options.memory:
+                memory = options.memory
+            else:
+                memory = workflow.info["Memory"]
             cloneWorkflow(
-                wf, user, options.group, options.verbose, options.backfill, options.testbed, bwl=options.bwl)
+                wf, user, options.group, options.verbose, options.backfill, options.testbed, memory,bwl=options.bwl)
     elif options.action == 'extend':
         for wf in wfs:
             extendWorkflow(wf, user, options.group, options.verbose, options.events, options.firstlumi)

--- a/resubmit.py
+++ b/resubmit.py
@@ -41,7 +41,7 @@ DELTA_EVENTS = 1000
 DELTA_LUMIS = 200
 
 
-def modifySchema(helper, workflow, user, group, cache, events, firstLumi, backfill=False, memory=None):
+def modifySchema(helper, workflow, user, group, cache, events, firstLumi, backfill=False):
     """
     Adapts schema to right parameters.
     If the original workflow points to DBS2, DBS3 URL is fixed instead.
@@ -55,12 +55,6 @@ def modifySchema(helper, workflow, user, group, cache, events, firstLumi, backfi
             result['ConfigCacheID'] = value
         elif key == 'RequestSizeEvents':
             result['RequestSizeEvents'] = value
-        #Set memory
-        elif key == 'Memory':
-            if memory != None:
-                result['Memory'] = memory
-            else:
-                result['Memory'] = value
         #requestor info
         elif key == 'Requestor':
             result['Requestor'] = user
@@ -106,56 +100,6 @@ def modifySchema(helper, workflow, user, group, cache, events, firstLumi, backfi
         # Update the request priority
         if cache and 'RequestPriority' in cache:
             result['RequestPriority'] = cache['RequestPriority']
-    # check MonteCarlo
-    if result['RequestType'] == 'MonteCarlo':
-        # check assigning parameters
-        # seek for events per job on helper
-        try:
-            splitting = helper.listJobSplittingParametersByTask()
-        except AttributeError:
-            splitting = {}
-
-        eventsPerJob = 120000
-        eventsPerLumi = 100000
-        for k, v in splitting.items():
-            # print k,":",v
-            if k.endswith('/Production'):
-                if 'events_per_job' in v:
-                    eventsPerJob = v['events_per_job']
-                elif 'events_per_lumi' in v:
-                    eventsPerLumi = v['events_per_lumi']
-        # result['EventsPerJob'] = eventsPerJob
-        # result['EventsPerLumi'] = eventsPerLumi
-    # check MonteCarloFromGen
-    elif result['RequestType'] == 'MonteCarloFromGEN':
-        # seek for lumis per job on helper
-        splitting = helper.listJobSplittingParametersByTask()
-        lumisPerJob = 300
-        for k, v in splitting.items():
-            if k.endswith('/Production'):
-                if 'lumis_per_job' in v:
-                    lumisPerJob = v['lumis_per_job']
-        result['LumisPerJob'] = lumisPerJob
-        # Algorithm = lumi based?
-        result["SplittingAlgo"] = "LumiBased"
-    elif result['RequestType'] == "TaskChain":
-        # Now changing the parameters according to HG1309
-        x = 1
-        # on every task
-        while x <= result['TaskChain']:
-            task = 'Task' + str(x)
-            for (key, value) in result[task].iteritems():
-                if key == "SplittingAlgorithm":
-                    result[task]['SplittingAlgo'] = value
-                    del result[task]['SplittingAlgorithm']
-                elif key == "SplittingArguments":
-                    for (k2, v2) in result[task][key].iteritems():
-                        if k2 == "lumis_per_job":
-                            result[task]["LumisPerJob"] = v2
-                        elif k2 == "events_per_job":
-                            result[task]["EventsPerJob"] = v2
-                        del result[task]['SplittingArguments']
-            x += 1
 
     # Merged LFN
     if 'MergedLFNBase' not in result:
@@ -204,7 +148,7 @@ def modifySchema(helper, workflow, user, group, cache, events, firstLumi, backfi
     return result
 
 
-def cloneWorkflow(workflow, user, group, verbose=True, backfill=False, testbed=False, memory=None, bwl=None):
+def cloneWorkflow(workflow, user, group, verbose=True, backfill=False, testbed=False, bwl=None):
     """
     clones a workflow
     """
@@ -216,7 +160,7 @@ def cloneWorkflow(workflow, user, group, verbose=True, backfill=False, testbed=F
     except:
         cache = None
         
-    schema = modifySchema(helper, workflow, user, group, cache, None, None, backfill, memory)
+    schema = modifySchema(helper, workflow, user, group, cache, None, None, backfill)
 
     schema['OriginalRequestName'] = workflow
     if verbose:
@@ -322,7 +266,7 @@ url = 'cmsweb.cern.ch'
 url_tb = 'cmsweb-testbed.cern.ch'
 reqmgrCouchURL = "https://" + url + "/couchdb/reqmgr_workload_cache"
 
- 
+
 def main():
 
     # Create option parser
@@ -338,8 +282,6 @@ def main():
                       help="Group to send the workflows.")
     parser.add_option("-b", "--backfill", action="store_true", dest="backfill", default=False,
                       help="Creates a clone for backfill test purposes.")
-    parser.add_option("-m", "--memory", dest="memory",
-                  help="Set max memory for the event. At assignment, this will be used to calculate maxRSS = memory*1024")
     parser.add_option("-v", "--verbose", action="store_true", dest="verbose", default=False,
                       help="Prints all query information.")
     parser.add_option('-f', '--file', help='Text file with a list of workflows', dest='file')
@@ -371,13 +313,8 @@ def main():
 
     if options.action == 'clone':
         for wf in wfs:
-            workflow = reqMgrClient.Workflow(wf)
-            if options.memory:
-                memory = options.memory
-            else:
-                memory = workflow.info["Memory"]
             cloneWorkflow(
-                wf, user, options.group, options.verbose, options.backfill, options.testbed, memory,bwl=options.bwl)
+                wf, user, options.group, options.verbose, options.backfill, options.testbed, bwl=options.bwl)
     elif options.action == 'extend':
         for wf in wfs:
             extendWorkflow(wf, user, options.group, options.verbose, options.events, options.firstlumi)


### PR DESCRIPTION
Several changes to assign.py, including reverting back to the correct way to determine if we are dealing with a merge task when setting era and proc string. Other changes include setting sites using siteInfo class if --site "t1" or "t2" is given, and allowing the user to pass a comma-separated list of sites.

Added option to set max memory in reject.py and resubmit.py. These should be identical to the changes originally submitted in https://github.com/CMSCompOps/WmAgentScripts/pull/149