### PR TITLE
Allow resizing of jobs down to one core.

### DIFF
--- a/Unified/go_condor.py
+++ b/Unified/go_condor.py
@@ -135,7 +135,7 @@ def makeResizeAd():
     anAd["GridResource"] = "condor localhost localhost"
     anAd["TargetUniverse"] = 5
     anAd['Name'] = "Enable job resizing"
-    anAd['Requirements'] = classad.ExprTree("target.MaxCores > 1 && !target.WMACore_ResizeJob")
+    anAd['Requirements'] = classad.ExprTree("target.MaxCores > 1 && !target.WMCore_ResizeJob")
     anAd['set_HasBeenRouted'] = False
     anAd['set_WMCore_ResizeJob'] = True
     anAd['set_RequestMemory'] = classad.ExprTree("ifThenElse(WMCore_ResizeJob && (RequestCpus == 1), 2300, OriginalMemory + 500 * ( WMCore_ResizeJob ? ( RequestCpus - OriginalCpus ) : 0 ))")

--- a/Unified/go_condor.py
+++ b/Unified/go_condor.py
@@ -129,12 +129,25 @@ def makePerformanceCorrectionsAds(configs):
         anAd['set_HasBeenRouted'] = False
         anAd['set_MaxWallTimeMins'] = int(timing)
         print anAd
-        
+
+def makeResizeAd():
+    anAd = classad.ClassAd()
+    anAd["GridResource"] = "condor localhost localhost"
+    anAd["TargetUniverse"] = 5
+    anAd['Name'] = "Enable job resizing"
+    anAd['Requirements'] = classad.ExprTree("target.MaxCores > 1 && !target.WMACore_ResizeJob")
+    anAd['set_HasBeenRouted'] = False
+    anAd['set_WMCore_ResizeJob'] = True
+    anAd['set_RequestMemory'] = classad.ExprTree("ifThenElse(WMCore_ResizeJob && (RequestCpus == 1), 2300, OriginalMemory + 500 * ( WMCore_ResizeJob ? ( RequestCpus - OriginalCpus ) : 0 ))")
+    anAd['set_MinCores'] = 1
+    print anAd
+
 def makeAds(config):
     makeOverflowAds(config)
     makeSortAds()
     makePrioCorrectionsAds()
     makePerformanceCorrectionsAds(config)    
+    makeResizeAd()
 
 if __name__ == "__main__":
 


### PR DESCRIPTION
This allows any multi-core job to be resized down to a single-core one.  GlideinWMS will automatically determine if the single-core version of this job fits in the remaining pilot lifetime.

@vlimant - note that, with this, you cannot do performance tuning as the performance is a function of the number of cores.