### PR TITLE
Start overhaul of overflow routes.

### DIFF
--- a/Unified/go_condor.py
+++ b/Unified/go_condor.py
@@ -93,7 +93,7 @@ def makeOverflowAds(config):
     anAd["OverflowTasknames"] = map(str, needs_site[site])
     overflow_names_escaped = anAd.lookup('OverflowTasknames').__repr__()
     del anAd['OverflowTaskNames']
-    exp = classad.ExprTree('member(target.WMAgent_SubTaskName, %s) && (HasBeenRouter_Overflow isnt true)' % overflow_names_escaped)
+    exp = classad.ExprTree('member(target.WMAgent_SubTaskName, %s) && (HasBeenRouted_Overflow isnt true)' % overflow_names_escaped)
     anAd["Requirements"] = classad.ExprTree(str(exp))
     anAd["eval_set_DESIRED_Sites"] = classad.ExprTree('ifThenElse(siteMapping("", []) isnt error, siteMapping(DESIRED_CMSDataLocations, %s), DESIRED_CMSDataLocations)' % str(classad.ClassAd(source_to_dests)))
     anAd['set_Rank'] = classad.ExprTree("stringlistmember(GLIDEIN_CMSSite, ExtDESIRED_Sites)")

--- a/Unified/go_condor.py
+++ b/Unified/go_condor.py
@@ -75,7 +75,7 @@ def makeOverflowAds(config):
         anAd['set_HasBeenRouted'] = False
         for site in similar_sites:
             anAd['set_HasBeenRouted_%s' % site] = True
-        print anAd
+        #print anAd
 
     source_to_dests = {}
     for dest, sources in reversed_mapping.items():
@@ -85,8 +85,7 @@ def makeOverflowAds(config):
     tmp_source_to_dests = source_to_dests
     source_to_dests = {}
     for source, dests in tmp_source_to_dests.items():
-        source_to_dests[source] = list(dests)
-    serialized_map = json.dumps(source_to_dests)
+        source_to_dests[str(source)] = list(str(i) for i in dests)
     anAd = classad.ClassAd()
     anAd["GridResource"] = "condor localhost localhost"
     anAd["TargetUniverse"] = 5
@@ -96,11 +95,11 @@ def makeOverflowAds(config):
     del anAd['OverflowTaskNames']
     exp = classad.ExprTree('member(target.WMAgent_SubTaskName, %s) && (HasBeenRouter_Overflow isnt true)' % overflow_names_escaped)
     anAd["Requirements"] = classad.ExprTree(str(exp))
-    anAd["eval_set_DESIRED_Sites"] = classad.ExprTree('ifThenElse(siteMapping("", "{}") isnt error, siteMapping(ExtDESIRED_Sites, %s), ExtDESIRED_Sites)' % classad.quote(serialized_map))
+    anAd["eval_set_DESIRED_Sites"] = classad.ExprTree('ifThenElse(siteMapping("", []) isnt error, siteMapping(DESIRED_CMSDataLocations, %s), DESIRED_CMSDataLocations)' % str(classad.ClassAd(source_to_dests)))
     anAd['set_Rank'] = classad.ExprTree("stringlistmember(GLIDEIN_CMSSite, ExtDESIRED_Sites)")
     anAd['set_HasBeenRouted'] = False
     anAd['set_HasBeenRouted_Overflow'] = True
-    #print anAd
+    print anAd
 
 
 def makeSortAds():

--- a/Unified/go_condor.py
+++ b/Unified/go_condor.py
@@ -141,7 +141,6 @@ def makePrioCorrectionsAds():
     anAd["eval_set_JR_PostJobPrio2"] = classad.ExprTree("-MaxWallTimeMins - RequestDisk/1000000")
     anAd["set_PostJobPrio1"] = classad.Attribute("JR_PostJobPrio1")
     anAd["set_PostJobPrio2"] = classad.Attribute("JR_PostJobPrio2")
-    anAd["MaxJobs"] = 50
     print anAd
 
 def makePerformanceCorrectionsAds(configs):

--- a/Unified/go_condor.py
+++ b/Unified/go_condor.py
@@ -6,6 +6,7 @@ import json
 import socket
 import urllib
 import classad
+import hashlib
 import htcondor
 from collections import defaultdict
 

--- a/Unified/job_router_modules/unified_utils.py
+++ b/Unified/job_router_modules/unified_utils.py
@@ -1,5 +1,6 @@
 
 import re
+import json
 import classad
 
 _split_re = re.compile(",\s*")
@@ -13,5 +14,23 @@ def sortStringSet(in_list, state={}):
     split_list.sort()
     return ",".join(split_list)
 
+def siteMapping(in_list, in_mapping, state={}):
+    if isinstance(in_list, classad.ExprTree):
+        in_list = in_list.eval(state)
+    if isinstance(in_list, classad.Value):
+        return classad.Value.Undefined
+
+    source_to_dests = json.loads(in_mapping)
+
+    split_list = _split_re.split(in_list)
+    final_set = set()
+    for site in split_list:
+        final_set.add(site)
+        final_set.update(source_to_dests.setdefault(site, set()))
+    split_list = list(final_set)
+    split_list.sort()
+    return str(",".join(split_list))
+
 classad.register(sortStringSet)
+classad.register(siteMapping)
 

--- a/Unified/job_router_modules/unified_utils.py
+++ b/Unified/job_router_modules/unified_utils.py
@@ -1,6 +1,5 @@
 
 import re
-import json
 import classad
 
 _split_re = re.compile(",\s*")
@@ -14,13 +13,12 @@ def sortStringSet(in_list, state={}):
     split_list.sort()
     return ",".join(split_list)
 
-def siteMapping(in_list, in_mapping, state={}):
+_split_re = re.compile(",\s*")
+def siteMapping(in_list, source_to_dests, state={}):
     if isinstance(in_list, classad.ExprTree):
         in_list = in_list.eval(state)
     if isinstance(in_list, classad.Value):
         return classad.Value.Undefined
-
-    source_to_dests = json.loads(in_mapping)
 
     split_list = _split_re.split(in_list)
     final_set = set()


### PR DESCRIPTION
Includes code for a single route for all overflow jobs, but that isn't
enabled.  For now, just combine sufficiently similar routes.

Reduces the amount of work the JobRouter has to do by about 2-3x.  Once we get the 'master overflow rule' working, it'll be an additional 2-3x (about an order of magnitude combined).