### PR TITLE
Added clone API; fixed some wf submission code

### DIFF
--- a/issues/getdataTaskChains.py
+++ b/issues/getdataTaskChains.py
@@ -105,6 +105,7 @@ def getWorkloadParameters(workflow):
     batch = workflow.split('_')[2] #TODO fix this
     processingstring = workflow.split('_')[4] #TODO fix this
 
+    # FIXME: broken code!
     list = reqMgr.getWorkflowWorkload('cmsweb.cern.ch', workflow)
 
     primaryds = ''
@@ -237,7 +238,7 @@ def getWorkloadParameters(workflow):
     return wlinfo
 
 def getAssignmentDate(workflow):
-    data = reqMgr.getWorkloadCache('cmsweb.cern.ch', workflow)
+    data = reqMgr.getWorkflowInfo('cmsweb.cern.ch', workflow)
     ls = data['RequestTransition']
     date = None
     for status in ls:

--- a/reject.py
+++ b/reject.py
@@ -80,7 +80,8 @@ def main():
             else:
                 mem = workflowInfo.info["Memory"]
             cloned = resubmit.cloneWorkflow(workflow, user, options.group, memory=mem)
-    sys.exit(0);
+    sys.exit(0)
+
 
 if __name__ == "__main__":
     main()

--- a/resubmit.py
+++ b/resubmit.py
@@ -54,7 +54,9 @@ def modifySchema(cache, workflow, user, group, events, firstLumi, backfill=False
                       'OutputDatasets', 'ReqMgr2Only', 'RequestDate' 'RequestorDN', 'RequestName', 'RequestStatus',
                       'RequestTransition', 'RequestWorkflow', 'SiteWhitelist', 'SoftTimeout', 'SoftwareVersions',
                       'SubscriptionPriority', 'Team', 'timeStamp', 'TrustSitelists', 'TrustPUSitelists',
-                      'TotalEstimatedJobs', 'TotalInputEvents', 'TotalInputLumis', 'TotalInputFiles']
+                      'TotalEstimatedJobs', 'TotalInputEvents', 'TotalInputLumis', 'TotalInputFiles', 'DN',
+                      'AutoApproveSubscriptionSites', 'NonCustodialSites', 'CustodialSites', 'Teams',
+                      'OutputModulesLFNBases', 'AllowOpportunistic', 'InputDatasets', 'DeleteFromSource', '_id']
 
     result = {}
     for k, v in cache.iteritems():
@@ -124,6 +126,15 @@ def modifySchema(cache, workflow, user, group, events, firstLumi, backfill=False
                     result[taskName]['ProcessingString'] = "BACKFILL"
                 if 'AcquisitionEra' in result[taskName]:
                     result[taskName]['AcquisitionEra'] += "Backfill"
+
+    # DataProcessing requests don't support RequestNumEvents argument anymore
+    if 'InputDataset' in result and result['InputDataset']:
+        result.pop('RequestNumEvents', None)
+    # Dirty check in TaskChain and StepChains
+    if 'Task1' in result and 'InputDataset' in result['Task1'] and result['Task1']['InputDataset']:
+        result['Task1'].pop('RequestNumEvents', None)
+    if 'Step1' in result and 'InputDataset' in result['Step1'] and result['Step1']['InputDataset']:
+        result['Step1'].pop('RequestNumEvents', None)
 
     return result
 

--- a/test/test_reqMgrClient.py
+++ b/test/test_reqMgrClient.py
@@ -83,11 +83,6 @@ class TestReqMgrClient(unittest.TestCase):
             self.fail("None lumis")
         il = float(il)
 
-    def testGetWorkloadCache(self):
-        # getWorkloadCache
-        ca = reqMgr.getWorkloadCache(url, testwf)
-        if ca is None:
-            self.fail("None output")
 
 
 # Creation of request


### PR DESCRIPTION
This PR is about adding the clone API, here:
https://github.com/CMSCompOps/WmAgentScripts/compare/master...amaltaro:clone-api?expand=1#diff-3fc98fbeeaadf6df0cfbc50d59551ffeR1120

one can simply provide the request name in the URI and that workflow gets cloned. Or one can provide a encoded python dictionary to be used to override arguments. This also works for overriding only one or two arguments inside a task/step.

Additional changes are:
* use reqmgr2 request api to retrieve the request json
* dropped access to the couchdb workfload_cache data (the same data as above)
* dropped the WMWorkload helper object from some places (need to be well tested). Can someone please clarify why it has to get the workload instance instead of just using the json request?

We still need to distinguish plain clones (no override) from real workflow retry (overriding args, at least ProcVersion). This way we can better use resources. This needs to be addressed ASAP to avoid issues with the upcoming cmsweb upgrade.

Things to follow up/fix (not me :)):
* fix this code I marked as broken (getdataTaskChains.py)
* fix extendWorkflow.py and resubmitUnprocessedBlocks.py for two reasons, that I could see. First, it calls reqmgr several times when it can make a single call. Second, it uses the wmworkload helper as well.

FYI @ticoann 
@prozober can you please test these changes? If you prefer, let me know how to run these tests and on which workflows and I can try it myself.
