### PR TITLE
hook to hold sites

### DIFF
--- a/Unified/go_condor.py
+++ b/Unified/go_condor.py
@@ -10,6 +10,8 @@ import hashlib
 import htcondor
 from collections import defaultdict
 
+
+_site_re = re.compile("(T\d)_([A-Z]{2})_([A-Z]{1}[A-Z,a-z,_]+)$")
 def makeHighPrioAds(config):
     to_be_raised = config.get('highprio',[])
     if to_be_raised:
@@ -32,8 +34,10 @@ def makeHoldSiteAds(config):
     """
     Create a rule to hold jobs from matching a given site
     """
-    held_site = config.get('hold_site',['T0_CH_CERN'])
+    held_site = config.get('hold_site',[])
+
     for site in held_site:
+        if not _site_re.match( site ): continue
         anAd = classad.ClassAd()
         anAd["GridResource"] = "condor localhost localhost"
         anAd["TargetUniverse"] = 5
@@ -50,8 +54,9 @@ def makeReleaseSiteAds(config):
     """
     Create a rule to add a site back in site whitelist
     """
-    relase_site = config.get('release_site',['T0_CH_CERN'])
+    relase_site = config.get('release_site',[])
     for site in relase_site:
+        if not _site_re.match( site ): continue
         anAd = classad.ClassAd()
         anAd["GridResource"] = "condor localhost localhost"
         anAd["TargetUniverse"] = 5

--- a/Unified/go_condor.py
+++ b/Unified/go_condor.py
@@ -27,6 +27,44 @@ def makeHighPrioAds(config):
         anAd["set_HasBeenRouted"] = False
         print anAd
 
+
+def makeHoldSiteAds(config):
+    """
+    Create a rule to hold jobs from matching a given site
+    """
+    held_site = config.get('hold_site',['T0_CH_CERN'])
+    for site in held_site:
+        anAd = classad.ClassAd()
+        anAd["GridResource"] = "condor localhost localhost"
+        anAd["TargetUniverse"] = 5
+        anAd["Name"] = str("Holding jobs from %s"%site)
+        anAd["Requirements"] = classad.ExprTree('regexp("%s",DESIRED_Sites) && HasBeenHeldFrom%s isnt true'% (site, site))
+        anAd["copy_DESIRED_Sites"] = "Holding_DESIRED_Sites"
+        ## remove the site string from the sitewhitelist
+        anAd["eval_set_DESIRED_Sites"] = classad.ExprTree('removeSite("%s",Holding_DESIRED_Sites)'% site)
+        anAd["set_HasBeenHeldFrom%s"% site] = True
+        anAd["set_HasBeenRouted"] = False
+        print anAd
+
+def makeReleaseSiteAds(config):
+    """
+    Create a rule to add a site back in site whitelist
+    """
+    relase_site = config.get('release_site',['T0_CH_CERN'])
+    for site in relase_site:
+        anAd = classad.ClassAd()
+        anAd["GridResource"] = "condor localhost localhost"
+        anAd["TargetUniverse"] = 5
+        anAd["Name"] = str("Releasing jobs for %s"%site)
+        anAd["Requirements"] = classad.ExprTree('HasBeenHeldFrom%s is true'% site )
+        anAd["copy_DESIRED_Sites"] = "Editing_DESIRED_Sites"
+        anAd["eval_set_DESIRED_Sites"] = classad.ExprTree('strcat(Editing_DESIRED_Sites,",%s")'% site)
+        anAd["delete_Editing_DESIRED_Sites"] = True
+        anAd["set_HasBeenHeldFrom%s"% site] = False
+        anAd["set_HasBeenRouted"] = False
+        print anAd
+
+    
 def makeHoldAds(config):
     """
     Create a set of rules to hold a task from matching
@@ -315,6 +353,20 @@ def makeAdhocAds():
     anAd["set_HasBeenRouted"] = False
     print anAd
 
+    anAd = classad.ClassAd()
+    anAd["GridResource"] = "condor localhost localhost"
+    anAd["TargetUniverse"] = 5
+    anAd["Name"] = str("Draining T0 VMs")
+    anAd["Requirements"] = classad.ExprTree('regexp("T0_CH_CERN", DESIRED_Sites) && OutOfT0 isnt true')
+    anAd["copy_DESIRED_Sites"] = "T0Off_DESIRED_Sites"
+    with_sites = "T2_CH_CERN"
+    anAd["eval_set_DESIRED_Sites"] = classad.ExprTree('strcat(T0Off_DESIRED_Sites,",%s")'% with_sites)
+    anAd["set_OutOfT0"] = True
+    anAd["set_HasBeenRouted"] = False
+    print anAd
+
+
+
     ############################################################
     ## if you want to reset the routing of eveything in the pool
     reset_routing = []#'HasBeenRouted','HasBeenRouted_Overflow','HasBeenMemoryTuned','HasBeenSlopeTuned', 'HasBeenTimingTuned','WMCore_ResizeJob','HasBeenReplaced','HasBeenReadTuned','HasBeenRaisedHighPrio']
@@ -341,6 +393,8 @@ def makeAds(config):
     makeReadAds(config)
     makeHoldAds(config)
     makeReleaseAds(config)
+    makeHoldSiteAds(config)
+    makeReleaseSiteAds(config)
     makeHighPrioAds(config)
     makeAdhocAds()
     makeDrainAds()

--- a/Unified/go_condor.py
+++ b/Unified/go_condor.py
@@ -57,9 +57,9 @@ def makeReleaseSiteAds(config):
         anAd["TargetUniverse"] = 5
         anAd["Name"] = str("Releasing jobs for %s"%site)
         anAd["Requirements"] = classad.ExprTree('HasBeenHeldFrom%s is true'% site )
-        anAd["copy_DESIRED_Sites"] = "Editing_DESIRED_Sites"
-        anAd["eval_set_DESIRED_Sites"] = classad.ExprTree('strcat(Editing_DESIRED_Sites,",%s")'% site)
-        anAd["delete_Editing_DESIRED_Sites"] = True
+        anAd["copy_DESIRED_Sites"] = "Releasing_DESIRED_Sites"
+        anAd["eval_set_DESIRED_Sites"] = classad.ExprTree('strcat(Releasing_DESIRED_Sites,",%s")'% site)
+        anAd["delete_Releasing_DESIRED_Sites"] = True
         anAd["set_HasBeenHeldFrom%s"% site] = False
         anAd["set_HasBeenRouted"] = False
         print anAd

--- a/Unified/job_router_modules/unified_utils.py
+++ b/Unified/job_router_modules/unified_utils.py
@@ -31,6 +31,11 @@ def siteMapping(in_list, source_to_dests, state={}):
     split_list.sort()
     return str(",".join(split_list))
 
+def removeSite(those,from_sites):
+    to_remove = set(_split_re.split(those))
+    from_sites = set(_split_re.split(from_sites))
+    return str(",".join( sorted( from_sites - to_remove )))
+
 classad.register(sortStringSet)
 classad.register(siteMapping)
-
+classad.register(removeSite)


### PR DESCRIPTION
Somehow along the lines of what you suggested @bbockelm 
The agents are already removing the draining sites from site whitelist.
The purpose here is a dramatic increase in number of failures is observed for a give site to go and quickly edit it out from the whitelist, with the possibility of adding it back just as quickly.
FYI @thongonary @mcremone 