### PR TITLE
Remove sites from production

### DIFF
--- a/unifiedConfiguration.json
+++ b/unifiedConfiguration.json
@@ -80,7 +80,9 @@
 	      "T2_TH_CUNSTDA",
 	      "T2_EE_Estonia",
 	      "T2_UA_KIPT",
-	      "T0_CH_CERN"
+	      "T0_CH_CERN", 
+	      "T2_CH_CERN", 
+	      "T2_CH_CERN_HLT"
  	      ],
    "description" : "The sites that are banned from production"
  },		 


### PR DESCRIPTION
In case we need to remove T2_CERN and T2_CERN_HLT from specific campaign whitelists, this is easier to track than direct changes in the agent. 