### PR TITLE
cern can read from Swierk

### DIFF
--- a/Unified/equalizor.py
+++ b/Unified/equalizor.py
@@ -139,6 +139,7 @@ def equalizor(url , specific = None, options=None):
     mapping['T2_CH_CERN'].append('T3_CH_CERN_HelixNebula')
     mapping['T2_CH_CERN'].append('T3_CH_CERN_HelixNebula_REHA')
     
+    mapping['T2_PL_Swierk'].append('T2_CH_CERN')
 
     for site in sites_to_consider:
         if '_US_' in site:


### PR DESCRIPTION
@drkovalskyi another way to get cern to read from swierk ; that might be a bit distructive overall, as it would apply to anything running at swierk, likely ending up overloading the local storage