### PR TITLE
Correct events per lumi based on time per event

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -7630,7 +7630,7 @@ class workflowInfo:
                                                                                                                                                      time_per_input_lumi / (60.*60.),
                                                                                                                                                      job_timeout), level='critical')
                             this_max_events_per_lumi = int( job_target*60.*60. / timeperevent)
-                            max_events_per_lumi.append( this_max_events_per_lumi / efficiency_factor) # to be tested
+                            max_events_per_lumi.append( this_max_events_per_lumi ) 
 
                         else:
                             pass

--- a/utils.py
+++ b/utils.py
@@ -7613,7 +7613,9 @@ class workflowInfo:
                     #    #max_events_per_lumi.append( int(avg_events_per_job*0.75) ) ##reducing
                     #    max_events_per_lumi.append( int(avg_events_per_job*0.75) ) ##reducing
 
-
+		    # Time_per_event as input from PPD does not take into account of the filter efficiency. 
+		    # Therefore the time constraint must be number of actual events that the job needs to run on
+		    # ie, before the filter efficiency, not the number of output events (ie, after the filter efficiency).
                     if timeperevent:
                         job_timeout = 45. ## hours
                         job_target = 8. ## hours
@@ -7635,7 +7637,7 @@ class workflowInfo:
                         else:
                             pass
 
-
+                    # Size constraint only applies to the output; therefore it should take filter efficiency into account.
                     if sizeperevent:# and (avg_events_per_job * sizeperevent ) > (GB_space_limit*1024.**2):
                         size_per_input_lumi = events_per_lumi_at_this_task*sizeperevent*efficiency_factor
                         this_max_events_per_lumi = int( (GB_space_limit*1024.**2) / sizeperevent / efficiency_factor) # Take filter eff for size constraint of output

--- a/utils.py
+++ b/utils.py
@@ -7605,7 +7605,7 @@ class workflowInfo:
                         t = find_task_dict( t['InputTask'] )
                         if 'FilterEfficiency' in t:
                             efficiency_factor *= t['FilterEfficiency']
-                    events_per_lumi_at_this_task = events_per_lumi * efficiency_factor
+                    events_per_lumi_at_this_task = events_per_lumi 
                     all_filter_efficiency.append(efficiency_factor)
 			
                     #if (events_per_lumi_at_this_task > avg_events_per_job):
@@ -7637,7 +7637,7 @@ class workflowInfo:
 
 
                     if sizeperevent:# and (avg_events_per_job * sizeperevent ) > (GB_space_limit*1024.**2):
-                        size_per_input_lumi = events_per_lumi_at_this_task*sizeperevent
+                        size_per_input_lumi = events_per_lumi_at_this_task*sizeperevent*efficiency_factor
                         this_max_events_per_lumi = int( (GB_space_limit*1024.**2) / sizeperevent / efficiency_factor) # Take filter eff for size constraint of output
                         if (size_per_input_lumi > (GB_space_limit*1024.**2)):
                             ## derive a value for the lumisection

--- a/utils.py
+++ b/utils.py
@@ -7569,7 +7569,7 @@ class workflowInfo:
                         return copy.deepcopy( self.request[tname] )
                 return None
             
-            for step, spl in enumerate(splits):
+            for spl in splits:
                 #print spl
                 task = spl['splitParams']
                 tname = spl['taskName'].split('/')[-1]

--- a/utils.py
+++ b/utils.py
@@ -7581,9 +7581,6 @@ class workflowInfo:
                     #GB_space_limit = 10000 * ncores
                     print "the output is not kept, but keeping the output size to",GB_space_limit
 
-                print tname,ncores
-                print t
-                #print GB_space_limit
                 sizeperevent = t.get('SizePerEvent',None)
                 for keyword,factor in output_size_correction.items():
                     if keyword in spl['taskName']:
@@ -7613,7 +7610,6 @@ class workflowInfo:
                     efficiency_factor = 1.
                     while t and 'InputTask' in t:
                         t = find_task_dict( t['InputTask'] )
-                        print(t)
                         if 'FilterEfficiency' in t:
                             efficiency_factor *= t['FilterEfficiency']
                     
@@ -7710,9 +7706,6 @@ class workflowInfo:
                             modified_splits.append( root_split )
 
         ## the return list can easily be used to call the splitting api of reqmgr2
-        print "hold: ",hold
-        print "modified split ",modified_splits
-        sys.exit()
         return hold,modified_splits
 
 

--- a/utils.py
+++ b/utils.py
@@ -7557,7 +7557,6 @@ class workflowInfo:
             events_per_lumi=None
             events_per_lumi_inputs = None
             max_events_per_lumi=[]
-            all_filter_efficiency=[1.]
 
             def find_task_dict( name ):
                 i_task=1
@@ -7604,7 +7603,6 @@ class workflowInfo:
                     filter_efficiency_at_this_task = 1.
                     if 'FilterEfficiency' in t:
                         filter_efficiency_at_this_task *= t['FilterEfficiency']
-                    all_filter_efficiency.append(filter_efficiency_at_this_task)
                             
                     ## climb up all task to take the filter eff of the input tasks into account
                     efficiency_factor = 1.
@@ -7696,7 +7694,7 @@ class workflowInfo:
 		    
                     # Safeguard for small lumi:
                     if current_split:
-                        effective_output_lumi = min(current_split, min(max_events_per_lumi)) * min(all_filter_efficiency)
+                        effective_output_lumi = min(current_split, min(max_events_per_lumi)) * efficiency_factor
                         if effective_output_lumi < 50:
                             sendLog("assignor","{} will get {} events per lumi in output. Smaller than 50 is troublesome.".format(root_split['taskName'], effective_output_lumi), level='critical')
                             hold = True

--- a/utils.py
+++ b/utils.py
@@ -7607,7 +7607,8 @@ class workflowInfo:
                     filter_efficiency_at_this_task = 1.
                     if 'FilterEfficiency' in t:
                         filter_efficiency_at_this_task *= t['FilterEfficiency']
-                    
+                    all_filter_efficiency.append(filter_efficiency_at_this_task)
+                            
                     ## climb up all task to take the filter eff of the input tasks into account
                     efficiency_factor = 1.
                     while t and 'InputTask' in t:


### PR DESCRIPTION
Confirmation from PPD

> Imagine we want to generate 10 events (each has 5 s time/event) and the request has filter efficiency of 0.5. Sample will actually produce 20 events and the time/event has no correction (still 5s and not 5s / 0.5)

So if the target time limit is 100 sec, the `max_events_per_lumi` allowed is (time limit) / (time per event) = 100/5 = 20 events, which will give 10 events in the output lumi. (This is what the PR is proposing.)

If we allow `max_events_per_lumi` to be divided by `efficiency_factor` like it has been currently, we will let `max_events_per_lumi` to be 100/5/0.5 = 40 events, which will take 200 secs to finish, ie, double the limit.
