### PR TITLE
Change console link from seeworkflow->seeworkflow2 and comment other consoles.

### DIFF
--- a/Unified/showError.py
+++ b/Unified/showError.py
@@ -338,9 +338,9 @@ def parse_one(url, wfn, options=None):
     if r_type in ['ReReco']:
         html += '<a href=../datalumi/lumi.%s.html>Lumisection Summary</a>, '% wfi.request['PrepID']
     html += '<a href="https://its.cern.ch/jira/issues/?jql=text~%s AND project = CMSCOMPPR" target="_blank">jira</a>, '% (wfi.request['PrepID'])
-    html += '<a href="https://vocms0113.cern.ch/seeworkflow/?workflow=%s">console</a>,'% wfn
-    html += '<a href="http://vocms0276.cern.ch/tasks?page=1&filter=%s">new console</a>,'% wfn
-    html += '<a href="http://wc-dev.cern.ch/tasks?page=1&filter=%s">dev console</a>'% wfn
+    html += '<a href="https://vocms0113.cern.ch/seeworkflow2/?workflow=%s">console</a>,'% wfn
+    #html += '<a href="http://vocms0276.cern.ch/tasks?page=1&filter=%s">new console</a>,'% wfn
+    #html += '<a href="http://wc-dev.cern.ch/tasks?page=1&filter=%s">dev console</a>'% wfn
     html+='<hr>'
     html += '<a href=#IO>I/O</a>, <a href=#ERROR>Errors</a>, <a href=#BLOCK>blocks</a>, <a href=#FILE>files</a>, <a href=#CODES>Error codes</a><br>'
     html+='<hr>'


### PR DESCRIPTION
Fixes the issue for manually adding 2 after the seeworkflow on opening the console.

#### Status
ready

#### Description
The console has two sub urls: seeworkflow and seeworkflow2. seeworkflow2 was made inorder to see that the deadlock doesn't occur and we don't get the 404 error page that we often get with seeworkflow. The other console links are never used as the new console never got ready to be used till now, so we can comment out those for now.

#### Is it backward compatible (if not, which system it affects?)
yes

#### Mention people to look at PRs
@thongonary can you please have a look?