### PR TITLE
script to remove campign and put in archive

### DIFF
--- a/remove_campaign.py
+++ b/remove_campaign.py
@@ -11,28 +11,28 @@ parser.add_option('-n','--name',help='campaign name to be removed')
 (options,args) = parser.parse_args()
 
 if not options.name:
-	print "enter a campaign name as parameter -n <campaign name>"
-	sys.exit(1)
+    print "enter a campaign name as parameter -n <campaign name>"
+    sys.exit(1)
 p=0
 with open('campaigns.json','r') as campaigns:
-	campaign_db = json.load(campaigns)
-        for key,value in campaign_db.items():
-		if key == options.name:
-                        # remove the campaign from the mongoDB
-	            	remove_from_campaign_config = 'python campaignsConfiguration.py --name ' + options.name	+ ' --remove'
-	            	os.system(remove_from_campaign_config)
-			with open('archive_campaigns.json','r') as outfile:
-				destination = json.load(outfile)	
-                        	destination.update({key : value})
-                        	with open('archive_campaigns.json', 'w') as out:
-                            		json.dump(destination, out, indent=2) #putting the campaign into archive_campaigns.json file
-                            		with open('campaigns.json','w') as Origin:
-                                		del campaign_db[key] #deleting the campaign from campaigns.json file
-			        		Origin.write(json.dumps(campaign_db, indent=2))
-                                                sys.exit(1)
-                else:
-			p=1
+    campaign_db = json.load(campaigns)
+for key,value in campaign_db.items():
+    if key == options.name:
+        # remove the campaign from the mongoDB
+	remove_from_campaign_config = 'python campaignsConfiguration.py --name ' + options.name	+ ' --remove'
+	os.system(remove_from_campaign_config)
+	with open('archive_campaigns.json','r') as outfile:
+	    destination = json.load(outfile)	
+            destination.update({key : value})
+        with open('archive_campaigns.json', 'w') as out:
+            json.dump(destination, out, indent=2) #putting the campaign into archive_campaigns.json file
+        with open('campaigns.json','w') as Origin:
+            del campaign_db[key] #deleting the campaign from campaigns.json file
+	    Origin.write(json.dumps(campaign_db, indent=2))
+        sys.exit(1)
+    else:
+	p=1
 
 if p is 1:
-	print "campaign name doesn't exists."
+    print "campaign name doesn't exists."
 

--- a/remove_campaign.py
+++ b/remove_campaign.py
@@ -10,24 +10,29 @@ parser = optparse.OptionParser()
 parser.add_option('-n','--name',help='campaign name to be removed')
 (options,args) = parser.parse_args()
 
-if options.name:
-	with open('campaigns.json','r') as campaigns:
-		campaign_db = json.load(campaigns)
-                for key,value in campaign_db.items():
-                	if key == options.name:
-                                # remove the campaign from the mongoDB
-	                        remove_from_campaign_config = 'python campaignsConfiguration.py --name ' + options.name	+ ' --remove'
-	                        os.system(remove_from_campaign_config)
-                        	with open('archive_campaigns.json','r') as outfile:   
-                                	destination = json.load(outfile)	
-                                	destination.update({key : value})
-					with open('archive_campaigns.json', 'w') as out:
-                                        	json.dump(destination, out, indent=2) #putting the campaign into archive_campaigns.json file
-                                                with open('campaigns.json','w') as Origin:
-							del campaign_db[key] #deleting the campaign from campaigns.json file
-							Origin.write(json.dumps(campaign_db, indent=2)) 
-                        else:
-				print "campaign name not found"
-else:
-	print "enter a campaign name with -n <campaign name>"
+if not options.name:
+	print "enter a campaign name as parameter -n <campaign name>"
+	sys.exit(1)
+p=0
+with open('campaigns.json','r') as campaigns:
+	campaign_db = json.load(campaigns)
+        for key,value in campaign_db.items():
+		if key == options.name:
+                        # remove the campaign from the mongoDB
+	            	remove_from_campaign_config = 'python campaignsConfiguration.py --name ' + options.name	+ ' --remove'
+	            	os.system(remove_from_campaign_config)
+			with open('archive_campaigns.json','r') as outfile:
+				destination = json.load(outfile)	
+                        	destination.update({key : value})
+                        	with open('archive_campaigns.json', 'w') as out:
+                            		json.dump(destination, out, indent=2) #putting the campaign into archive_campaigns.json file
+                            		with open('campaigns.json','w') as Origin:
+                                		del campaign_db[key] #deleting the campaign from campaigns.json file
+			        		Origin.write(json.dumps(campaign_db, indent=2))
+                                                sys.exit(1)
+                else:
+			p=1
+
+if p is 1:
+	print "campaign name doesn't exists."
 

--- a/remove_campaign.py
+++ b/remove_campaign.py
@@ -1,0 +1,33 @@
+import sys
+import os
+import socket
+import json
+import optparse
+from json import JSONEncoder
+
+
+parser = optparse.OptionParser()
+parser.add_option('-n','--name',help='campaign name to be removed')
+(options,args) = parser.parse_args()
+
+if options.name:
+	with open('campaigns.json','r') as campaigns:
+		campaign_db = json.load(campaigns)
+                for key,value in campaign_db.items():
+                	if key == options.name:
+                                # remove the campaign from the mongoDB
+	                        remove_from_campaign_config = 'python campaignsConfiguration.py --name ' + options.name	+ ' --remove'
+	                        os.system(remove_from_campaign_config)
+                        	with open('archive_campaigns.json','r') as outfile:   
+                                	destination = json.load(outfile)	
+                                	destination.update({key : value})
+					with open('archive_campaigns.json', 'w') as out:
+                                        	json.dump(destination, out, indent=2) #putting the campaign into archive_campaigns.json file
+                                                with open('campaigns.json','w') as Origin:
+							del campaign_db[key] #deleting the campaign from campaigns.json file
+							Origin.write(json.dumps(campaign_db, indent=2)) 
+                        else:
+				print "campaign name not found"
+else:
+	print "enter a campaign name with -n <campaign name>"
+


### PR DESCRIPTION
Feature to remove campaign from mongodb, and campaigns.json and copy to archive_campaigns.json

#### Status
tested and ready 

#### Description
The script helps to remove the unwanted campaign from the mongodb,campaigns.json and copy it to archive_campaigns.json.

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
https://github.com/CMSCompOps/WmAgentScripts/pull/430

#### External dependencies / deployment changes
needs campaigns.json, archive_campaigns.json and campaignsConfiguration.py 

#### Mention people to look at PRs
@thongonary @optimisticcynic can you please have a look?
