### PR TITLE
checking event splitting in lumibased

### DIFF
--- a/Unified/actor.py
+++ b/Unified/actor.py
@@ -197,7 +197,7 @@ def singleRecovery(url, task, initial, actions, do=False):
                         if split['splitAlgo'] in ['EventBased']:
                             sendLog('actor',"Changing the splitting on %s for %s is not permitted. Not changing."%(split['splitAlgo'],initial["RequestName"]), level='critical')
                             continue
-                        if split['splitAlgo'] in ['LumiBased'] and 'events' in split_par:
+                        if split['splitAlgo'] in ['LumiBased'] and (any("events" in x for x in split_par)):
                             sendLog('actor',"Changing the splitting on %s with events parameter for %s is not permitted. Not changing."%(split['splitAlgo'], initial["RequestName"]), level='critical')
                             continue
                         for act in ['avg_events_per_job','events_per_job','lumis_per_job']:

--- a/Unified/actor.py
+++ b/Unified/actor.py
@@ -197,6 +197,9 @@ def singleRecovery(url, task, initial, actions, do=False):
                         if split['splitAlgo'] in ['EventBased']:
                             sendLog('actor',"Changing the splitting on %s for %s is not permitted. Not changing."%(split['splitAlgo'],initial["RequestName"]), level='critical')
                             continue
+                        if split['splitAlgo'] in ['LumiBased'] and 'events' in split_par:
+                            sendLog('actor',"Changing the splitting on %s for %s is not permitted. Not changing."%(split['splitAlgo'],initial["RequestName"]), level='critical')
+                            continue
                         for act in ['avg_events_per_job','events_per_job','lumis_per_job']:
                             if act in split_par:
                                 print "Changing %s (%d) by a factor %d"%( act, split_par[act], factor),

--- a/Unified/actor.py
+++ b/Unified/actor.py
@@ -198,7 +198,7 @@ def singleRecovery(url, task, initial, actions, do=False):
                             sendLog('actor',"Changing the splitting on %s for %s is not permitted. Not changing."%(split['splitAlgo'],initial["RequestName"]), level='critical')
                             continue
                         if split['splitAlgo'] in ['LumiBased'] and 'events' in split_par:
-                            sendLog('actor',"Changing the splitting on %s with %s for %s is not permitted. Not changing."%(split['splitAlgo'], split_par, initial["RequestName"]), level='critical')
+                            sendLog('actor',"Changing the splitting on %s with events parameter for %s is not permitted. Not changing."%(split['splitAlgo'], initial["RequestName"]), level='critical')
                             continue
                         for act in ['avg_events_per_job','events_per_job','lumis_per_job']:
                             if act in split_par:

--- a/Unified/actor.py
+++ b/Unified/actor.py
@@ -198,7 +198,7 @@ def singleRecovery(url, task, initial, actions, do=False):
                             sendLog('actor',"Changing the splitting on %s for %s is not permitted. Not changing."%(split['splitAlgo'],initial["RequestName"]), level='critical')
                             continue
                         if split['splitAlgo'] in ['LumiBased'] and 'events' in split_par:
-                            sendLog('actor',"Changing the splitting on %s for %s is not permitted. Not changing."%(split['splitAlgo'],initial["RequestName"]), level='critical')
+                            sendLog('actor',"Changing the splitting on %s with %s for %s is not permitted. Not changing."%(split['splitAlgo'], split_par, initial["RequestName"]), level='critical')
                             continue
                         for act in ['avg_events_per_job','events_per_job','lumis_per_job']:
                             if act in split_par:


### PR DESCRIPTION
Fixes job splitting issue for lumibased

#### Status
ready

#### Description
checks and sends critical log message if job splitting in LumiBased.

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
N/A

#### External dependencies / deployment changes
no

#### Mention people to look at PRs
@thongonary 