### PR TITLE
Quick fix for JIRA import failures

### DIFF
--- a/JIRAClient.py
+++ b/JIRAClient.py
@@ -1,6 +1,25 @@
+from subprocess import PIPE,Popen
 import sys,os,json
-import jira
 import time
+
+# JIRA requires a peculiar combination of package versions sometimes
+try:
+    import jira
+except ImportError as e:
+    try:
+        cmd1 = 'sudo yum remove python-requests python-urllib3 -y' 
+        cmd2 = 'sudo pip uninstall urllib3 requests chardet -y'
+        cmd3 = 'echo yes | sudo pip install urllib3==1.25.6 requests==2.22.0 chardet==3.0.2'
+
+        Popen(cmd1, shell=True, stderr=PIPE, stdout=PIPE)
+        Popen(cmd2, shell=True, stderr=PIPE, stdout=PIPE)
+        Popen(cmd3, shell=True, stderr=PIPE, stdout=PIPE)
+
+        import jira
+    except ImportError as e:
+        print(e)
+        raise ImportError
+
 
 class JIRAClient:
     def __init__(self, debug=False,cookie=None):

--- a/JIRAClient.py
+++ b/JIRAClient.py
@@ -3,6 +3,7 @@ import sys,os,json
 import time
 
 # JIRA requires a peculiar combination of package versions sometimes
+# Github issue: https://github.com/CMSCompOps/WmAgentScripts/issues/454
 try:
     import jira
 except ImportError as e:


### PR DESCRIPTION
Fixes #<GH_Issue_Number>
https://github.com/CMSCompOps/WmAgentScripts/issues/454

#### Status
ready

#### Description
Reinstalling the packages whenever `import jira` failed. This might be a dangerous practice, but a quick and dirty solution for now -- unless we have a more elegant way to handle this.

#### Is it backward compatible (if not, which system it affects?)
YES

#### Related PRs

#### External dependencies / deployment changes
What it does is essentially
```
sudo yum remove python-requests python-urllib3
sudo pip uninstall urllib3 requests
sudo pip install urllib3==1.25.6 requests==2.22.0 chardet==3.0.2
```

#### Mention people to look at PRs
@amaltaro @drkovalskyi @sharad1126 
