### PR TITLE
Make single query for relval users workflows; then fetch workflows by…

### DIFF
--- a/Unified/batchor.py
+++ b/Unified/batchor.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 from assignSession import *
-from utils import getWorkflows, sendEmail, sendLog, monitor_pub_dir, unifiedConfiguration, deep_update, global_SI, getWorkflowByCampaign, base_eos_dir, monitor_dir, eosRead, eosFile, campaignInfo, batchInfo
+from utils import getWorkflows, sendEmail, sendLog, monitor_pub_dir, unifiedConfiguration, deep_update, global_SI, getWorkflowByCampaign, base_eos_dir, monitor_dir, eosRead, eosFile, campaignInfo, batchInfo, getWorkflowsByName
 from collections import defaultdict
 import copy
 import json
@@ -14,8 +14,12 @@ def batchor( url ):
     BI = batchInfo()
     ## get all workflows in assignment-approved with SubRequestType = relval
     all_wfs = []
-    for user in UC.get("user_relval"):
-        all_wfs.extend( getWorkflows(url, 'assignment-approved', details=True, user=user, rtype='TaskChain') )
+    if UC.get("user_relval"):
+        users = ','.join(UC.get("user_relval"))
+        wfs = getWorkflows(url, 'assignment-approved', details=False, user=users, rtype='TaskChain')
+        if wfs:
+            # then there is likely work to be done
+            all_wfs = getWorkflowsByName(url, wfs, details=True)
 
     wfs = filter( lambda r :r['SubRequestType'] == 'RelVal' if 'SubRequestType' in r else False, all_wfs)
     ## need a special treatment for those

--- a/utils.py
+++ b/utils.py
@@ -6202,6 +6202,29 @@ def getAllAgents(url):
         teams[r['agent_team']].append( r )
     return teams
 
+def getWorkflowsByName(url, names, details=False):
+    conn = make_x509_conn(url)
+
+    go_to = '/reqmgr2/data/request?'
+    if isinstance(names, basestring):
+        names = [names]
+    for wfName in names:
+        go_to += '&name=%s' % wfName
+    go_to += '&detail=%s'%('true' if details else 'false')
+
+    conn.request("GET",go_to, headers={"Accept":"application/json"})
+    r2=conn.getresponse()
+    data = json.loads(r2.read())
+    items = data['result']
+
+    print "%d retrieved for %d workflow names with details: %s" % (len(items), len(names), details)
+    if details and items:
+        workflows = items[0].values()
+    else:
+        workflows = items
+
+    return workflows
+
 def getWorkflows(url,status,user=None,details=False,rtype=None, priority=None):
     retries=10000
     wait=2


### PR DESCRIPTION
… name

#### Status
not-tested

#### Description
In short:
* make a single call - with all the relval users in the query string - to reqmgr2, without details
* if there are workflows matching those constraints, make a second call retrieving details of every workflow returned from the previous call.

It doesn't really fix https://github.com/dmwm/WMCore/issues/9419, but it will properly use those APIs (by reducing the amount of calls and the memory footprint on the backend).

Still, we need to come back to this in the next month, when we should have a new CouchDB view to efficiently provide this information that we're querying.

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
none

#### External dependencies / deployment changes
none

#### Mention people to look at PRs
@sharad1126 @thongonary could you please review and get it tested? Thanks
