### PR TITLE
APIs to campaign configuration in ReqMgr2; updated Ops campaign script

### DIFF
--- a/Unified/batchor.py
+++ b/Unified/batchor.py
@@ -6,6 +6,8 @@ import copy
 import json
 import os, sys
 import random
+from campaignAPI import parseMongoCampaigns, createCampaignConfig, deleteCampaignConfig
+
 
 def batchor( url ):
     UC = unifiedConfiguration()
@@ -80,6 +82,9 @@ def batchor( url ):
         add_on[campaign] = setup
         sendLog('batchor','Adding the relval campaigns %s with parameters \n%s'%( campaign, json.dumps( setup, indent=2)),level='critical')
         BI.update( campaign, by_campaign[campaign])
+        wmcoreCamp = parseMongoCampaigns(campaign)
+        res = createCampaignConfig(wmcoreCamp)
+        print "Campaign %s correctly created in ReqMgr2: %s" % (wmcoreCamp['CampaignName'], res)
 
     for campaign in by_hi_campaign:
         if campaign in batches: continue
@@ -93,8 +98,9 @@ def batchor( url ):
         add_on[campaign] = setup
         sendLog('batchor','Adding the HI relval campaigns %s with parameters \n%s'%( campaign, json.dumps( setup, indent=2)),level='critical')
         BI.update( campaign, by_hi_campaign[campaign])
-        
-    
+        wmcoreCamp = parseMongoCampaigns(campaign)
+        res = createCampaignConfig(wmcoreCamp)
+        print "Campaign %s correctly created in ReqMgr2: %s" % (wmcoreCamp['CampaignName'], res)
 
     ## only new campaigns in announcement
     for new_campaign in list(set(add_on.keys())-set(CI.all(c_type='relval'))):
@@ -135,6 +141,9 @@ This is an automated message"""%( new_campaign,
             CI.pop( old_campaign ) ## or just drop it all together ?
             BI.pop( old_campaign )
             print "batch",old_campaign," configuration was removed"
+            res = deleteCampaignConfig(old_campaign)
+            print "Campaign %s correctly deleted in ReqMgr2: %s" % (old_campaign, res)
+
 
     ## merge all anyways
     CI.update( add_on , c_type = 'relval')

--- a/Unified/closor.py
+++ b/Unified/closor.py
@@ -18,6 +18,8 @@ import random
 import optparse
 import sqlalchemy 
 from JIRAClient import JIRAClient
+from campaignAPI import deleteCampaignConfig
+
 
 def spawn_harvesting(url, wfi , in_full):
     SI = global_SI()
@@ -326,6 +328,7 @@ def closor(url, specific=None, options=None):
             sendEmail(subject, text, destination=to )
             ## just announced ; take it out now.
             BI.pop( bname )
+            deleteCampaignConfig(bname)
 
 
     if os.path.isfile('.closor_stop'):

--- a/campaignAPI.py
+++ b/campaignAPI.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python
+import json
+
+from utils import make_x509_conn, reqmgr_url
+
+
+def getCampaignConfig(docName, url=reqmgr_url):
+    """
+    Retrieve campaign documents from central CouchDB
+    :param url: API URL
+    :param docName: string with the doc name (use "ALL_DOCS" to retrieve all docs)
+    :return: a list of dictionaries
+    """
+    headers = {"Content-type": "application/json", "Accept": "application/json"}
+    conn = make_x509_conn(url)
+    url = '/reqmgr2/data/campaignconfig/%s' % docName
+    conn.request("GET", url, headers=headers)
+    r2 = conn.getresponse()
+    data = json.loads(r2.read())
+    return data['result']
+
+
+def createCampaignConfig(docContent, url=reqmgr_url):
+    """
+    Create a new campaign document in central CouchDB
+    :param url: API URL
+    :param docContent: dictionary with the campaign content
+    :return: a boolean whether it succeeded (True) or not (False)
+    """
+    outcome = True
+    headers = {"Content-type": "application/json", "Accept": "application/json"}
+    conn = make_x509_conn(url)
+    url = '/reqmgr2/data/campaignconfig/%s' % docContent['CampaignName']
+    json_args = json.dumps(docContent)
+    conn.request("POST", url, json_args, headers=headers)
+    resp = conn.getresponse()
+    if resp.status >= 400:
+        print("FAILED to create campaign: %s. Response status: %s, response reason: %s"
+              % (docContent['CampaignName'], resp.status, resp.reason))
+        outcome = False
+    conn.close()
+    return outcome
+
+
+def updateCampaignConfig(docContent, url=reqmgr_url):
+    """
+    Update an existent campaign document in central CouchDB
+    :param url: API URL
+    :param docContent: full dictionary with the campaign content
+    :return: a boolean whether it succeeded (True) or not (False)
+    """
+    outcome = True
+    headers = {"Content-type": "application/json", "Accept": "application/json"}
+    conn = make_x509_conn(url)
+    url = '/reqmgr2/data/campaignconfig/%s' % docContent['CampaignName']
+    json_args = json.dumps(docContent)
+    conn.request("PUT", url, json_args, headers=headers)
+    resp = conn.getresponse()
+    if resp.status >= 400:
+        print("FAILED to update campaign: %s. Response status: %s, response reason: %s"
+              % (docContent['CampaignName'], resp.status, resp.reason))
+        outcome = False
+    conn.close()
+    return outcome
+
+
+def deleteCampaignConfig(docName, url=reqmgr_url):
+    """
+    Delete an existent campaign document in central CouchDB
+    :param url: API URL
+    :param docName: string with the document name
+    :return: a boolean whether it succeeded (True) or not (False)
+    """
+    outcome = True
+    headers = {"Content-type": "application/json", "Accept": "application/json",
+               "Content-Length": 0}  # this is required for DELETE calls
+    conn = make_x509_conn(url)
+    url = '/reqmgr2/data/campaignconfig/%s' % docName
+    conn.request("DELETE", url, headers=headers)
+    resp = conn.getresponse()
+    if resp.status >= 400:
+        print("FAILED to delete campaign: %s. Response status: %s, response reason: %s"
+              % (docName, resp.status, resp.reason))
+        outcome = False
+    conn.close()
+    return outcome
+
+
+def parseMongoCampaigns(campaigns, verbose=False):
+    """
+    Given a set of campaign records, parse it and convert them
+    to a WMCore supported format
+    :param campaigns: list of campaign configurations
+    :param verbose: flag to enable verbosity or not
+    :return: a list of dictionaries, each dict corresponds to a campaign config
+    """
+    wmCampaigns = []
+
+    # re-map Unified keys into campaign schema ones
+    remap = {
+        'name': 'CampaignName',
+        'SiteWhitelist': 'SiteWhiteList',
+        'SiteBlacklist': 'SiteBlackList',
+        'primary_AAA': 'PrimaryAAA',
+        'secondary_AAA': 'SecondaryAAA',
+        'SecondaryLocation': 'SecondaryLocation',
+        'secondaries': 'Secondaries',
+        'partial_copy': 'PartialCopy',
+        'maxcopies': 'MaxCopies'}
+    # campaign schema dict
+    confRec = {
+        'CampaignName': None,
+        'SiteWhiteList': [],
+        'SiteBlackList': [],
+        'PrimaryAAA': False,
+        'SecondaryAAA': False,
+        'SecondaryLocation': [],
+        'Secondaries': {},
+        'PartialCopy': 1,
+        'MaxCopies': 1}
+
+    if not isinstance(campaigns, list):
+        campaigns = [campaigns]
+    for rec in campaigns:
+        if verbose:
+            print("read record: %s (type=%s)" % (rec, type(rec)))
+
+        conf = dict(confRec)
+        # Set default value from top level campaign configuration
+        # or use the default values defined above
+        for uniKey, wmKey in remap.items():
+            conf[wmKey] = rec.get(uniKey, conf[wmKey])
+
+        conf['SiteWhiteList'] = _getSiteList("SiteWhitelist", conf['SiteWhiteList'], rec)
+        conf['SiteBlackList'] = _getSiteList("SiteBlacklist", conf['SiteBlackList'], rec)
+        conf['SecondaryAAA'] = _getSecondaryAAA(conf['SecondaryAAA'], rec)
+        conf['SecondaryLocation'] = _getSecondaryLocation(conf['SecondaryLocation'], rec)
+        conf['Secondaries'] = _getSecondaries(conf['Secondaries'], rec)
+        if verbose:
+            print("Final WMCore Campaign configuration: %s" % conf)
+        wmCampaigns.append(conf)
+    return wmCampaigns
+
+
+def _intersect(slist1, slist2):
+    "Helper function to intersect values from two non-empty lists"
+    if slist1 and slist2:
+        return list(set(slist1) & set(slist2))
+    if slist1 and not slist2:
+        return slist1
+    if not slist1 and slist2:
+        return slist2
+    return []
+
+
+def _getSiteList(keyName, initialValue, uniRecord):
+    """
+    Parse information related to the SiteWhiteList and SiteBlackList, which corresponds
+    to a list of sites where the workflow gets (or doesn't) assigned to and where the
+    primary and secondary CLASSIC MIX dataset is placed (likely in chunks of data);
+    mapped from the SiteWhitelist/SiteBlacklist key which can be AFAIK in multiple places, like:
+      * top level dict,
+      * under the parameters key and
+      * under the secondaries dictionary.
+    If it appears multiple times, we make an intersection of the values
+    """
+    if keyName in uniRecord.get("parameters", {}):
+        print("Found internal %s for campaign: %s" % (keyName, uniRecord['name']))
+        initialValue = _intersect(initialValue, uniRecord["parameters"][keyName])
+
+    for _, innerDict in uniRecord.get("secondaries", {}).items():
+        if keyName in innerDict:
+            print("Found internal %s for campaign: %s" % (keyName, uniRecord['name']))
+            initialValue = _intersect(initialValue, innerDict[keyName])
+    return initialValue
+
+
+def _getSecondaryAAA(initialValue, uniRecord):
+    """
+    SecondaryAAA: boolean to flag whether to use AAA for the secondary dataset;
+    mapped from the secondary_AAA key, which can be either:
+      * at top level or
+      * under the secondaries dictionary.
+    If it appears multiple times, we make an OR of the values.
+    """
+    for _, innerDict in uniRecord.get("secondaries", {}).items():
+        if "secondary_AAA" in innerDict:
+            print("Found internal secondary_AAA for campaign: %s" % uniRecord['name'])
+            initialValue = initialValue or innerDict["secondary_AAA"]
+    return initialValue
+
+
+def _getSecondaryLocation(initialValue, uniRecord):
+    """
+    SecondaryLocation: list of sites where the secondary PREMIX dataset has to be placed
+    as a whole (not necessarily also assigned to those).
+    mapped from the SecondaryLocation key, which can be either:
+      * at top level or
+      * under the secondaries dictionary.
+    If it appears multiple times, we make an intersection of the values.
+    """
+    for _, innerDict in uniRecord.get("secondaries", {}).items():
+        if "SecondaryLocation" in innerDict:
+            print("Found internal SecondaryLocation for campaign: %s" % uniRecord['name'])
+            initialValue = _intersect(initialValue, innerDict["SecondaryLocation"])
+    return initialValue
+
+
+def _getSecondaries(initialValue, uniRecord):
+    """
+    Secondaries: dictionary with a map of allowed secondary datasets and where they are
+    supposed to be placed (in conjunction with the top level location parameters;
+    mapped from the secondaries top level key
+
+    Each dataset will have a list value type, and the content is either:
+      * taken from the SiteWhitelist key or
+      * taken from the SecondaryLocation one
+    """
+    for dset, innerDict in uniRecord.get("secondaries", {}).items():
+        print("Found secondaries for campaign: %s" % uniRecord['name'])
+        initialValue[dset] = _intersect(innerDict.get("SiteWhitelist", []),
+                                        innerDict.get("SecondaryLocation", []))
+
+    return initialValue

--- a/campaignsConfiguration.py
+++ b/campaignsConfiguration.py
@@ -1,123 +1,186 @@
 #!/usr/bin/env python
 from utils import mongo_client
-import optparse
+import argparse
 import ssl,pymongo
 import json
 import sys
-
-parser = optparse.OptionParser()
-parser.add_option('--dump',help="dump the whole content in this file",default=None)
-parser.add_option('--load',help="synchronize the db with the content of this file", default=None)
-parser.add_option('-n','--name', help='a campaign name to be viewed/added/updated')
-parser.add_option('--remove', help="remove the specified campaign", default=False, action='store_true')
-parser.add_option('-c','--configuration', help='either a json doc or a json string for the campaign to be add/updated')
-parser.add_option('-p','--parameter', help='a single parameter to be updated of the form key:value or a.b.key:value for nested')
-parser.add_option('--type', default=None, help='set only to relval for adding a relval campaign', choices = ['relval'])
-(options,args) = parser.parse_args()
+from copy import deepcopy
+from campaignAPI import updateCampaignConfig, deleteCampaignConfig, parseMongoCampaigns
 
 
-client = mongo_client()
-db = client.unified.campaignsConfiguration
+def parseArgs():
+    """
+    Parse command line arguments
+    """
+    parser = argparse.ArgumentParser(description="Script to manage Campaign configurations")
+    parser.add_argument('-d', '--dump', default=None, help="dump the whole content in this file")
+    parser.add_argument('-l', '--load', default=None, help="synchronize the db with the content of this file")
+    parser.add_argument('-n', '--name', help="a campaign name to be viewed/added/updated")
+    parser.add_argument('-r', '--remove', default=False, action='store_true', help="remove the specified campaign")
+    parser.add_argument('-c','--configuration',
+                        help='either a json doc or a json string for the campaign to be add/updated')
+    parser.add_argument('-p','--parameter',
+                        help='a single parameter to be updated of the form key:value or a.b.key:value for nested')
+    parser.add_argument('-t', '--type', default=None, choices=['relval'],
+                        help='set only to relval for adding a relval campaign')
+    args = parser.parse_args()
+    return args
 
-if options.load:
-    content = json.loads( open(options.load).read())
-    for k,v in content.items():
-        up = {'name' : k}
-        #s = {"$set": v}
-        #db.update( up, s )
-        ## replace the db content
-        v['name'] = k
-        if options.type: v['type'] = options.type
-        db.replace_one( up, v)
 
-        print k,v
-    sys.exit(0)
+def main():
+    """
+    Execute the whole logic for campaign configuration management
+    """
+    options = parseArgs()
 
-if options.dump:
-    uc = {}
-    for content in db.find():
-        i=content.pop("_id")
-        if content.get('type',None) != options.type: continue ## no relval
-        if 'name' not in content:
-            db.delete_one({'_id': i})
-            print "dropping",i,content,"because it is malformated"
-            continue
-        uc[content.pop("name")] = content
-    print len(uc.keys()),"campaigns damp"
-    open(options.dump,'w').write(json.dumps( uc, indent =2, sort_keys=True))
-    sys.exit(0)
+    client = mongo_client()
+    db = client.unified.campaignsConfiguration
 
-if options.remove:
-    if options.name:
-        db.delete_one({'name' : options.name})
-    else:
-        pass
-    sys.exit(0)
+    if options.load:
+        campaigns = []
+        content = json.loads( open(options.load).read())
+        for k,v in content.items():
+            up = {'name' : k}
+            #s = {"$set": v}
+            #db.update( up, s )
+            ## replace the db content
+            v['name'] = k
+            if options.type: v['type'] = options.type
+            db.replace_one( up, v)
+            campaigns.append(v)
+            print k,v
+        replaceCampaigns(campaigns)
+        sys.exit(0)
 
-post = {}
-if options.configuration:
-    try:
-        post.update(json.loads(options.configuration))
-    except:
-        post.update(json.loads(open(options.configuration).read()))
-    post['name'] = options.name
-update = {}
-if options.parameter:
-    name,value = options.parameter.split(':',1)
-    ## convert to int or float or object
-    try:
-        value = int(value)
-    except:
+    if options.dump:
+        uc = {}
+        for content in db.find():
+            i=content.pop("_id")
+            if content.get('type',None) != options.type: continue ## no relval
+            if 'name' not in content:
+                db.delete_one({'_id': i})
+                print "dropping",i,content,"because it is malformated"
+                continue
+            uc[content.pop("name")] = content
+        print len(uc.keys()),"campaigns damp"
+        open(options.dump,'w').write(json.dumps( uc, indent =2, sort_keys=True))
+        sys.exit(0)
+
+    if options.remove:
+        if options.name:
+            db.delete_one({'name' : options.name})
+            # and delete it in central couch too
+            deleteCampaignConfig(options.name)
+        else:
+            pass
+        sys.exit(0)
+
+    post = {}
+    if options.configuration:
         try:
-            value = float(value)
+            post.update(json.loads(options.configuration))
+        except:
+            post.update(json.loads(open(options.configuration).read()))
+        post['name'] = options.name
+    update = {}
+    if options.parameter:
+        name,value = options.parameter.split(':',1)
+        ## convert to int or float or object
+        try:
+            value = int(value)
         except:
             try:
-                value = json.loads(value)
+                value = float(value)
             except:
-                # as string
-                pass
+                try:
+                    value = json.loads(value)
+                except:
+                    # as string
+                    pass
 
 
-    if '.' in name:
-        path = list(name.split('.'))
-        w = update
-        for p in path[:-1]:
-            w[p] = {}
-            w = w[p]
-        w[path[-1]] = value
-    else:
-        update[name] = value
+        if '.' in name:
+            path = list(name.split('.'))
+            w = update
+            for p in path[:-1]:
+                w[p] = {}
+                w = w[p]
+            w[path[-1]] = value
+        else:
+            update[name] = value
         
 
-found = db.find_one({"name":options.name})
-if found:
-    up = {'_id':found['_id']}
-    if post:
-        print "replacing",options.name,"with values",post
-        if options.type: post['type'] = options.type
-        db.replace_one(up, post)
-    elif update:
-        ## need to update a value
-        if options.type: update['type'] = options.type
-        print "updating",options.name,"with values",update
-        db.update( up, {"$set": update} )
+    found = db.find_one({"name":options.name})
+    if found:
+        up = {'_id':found['_id']}
+        if post:
+            print "replacing",options.name,"with values",post
+            if options.type: post['type'] = options.type
+            db.replace_one(up, post)
+            ### Alan: can I assume options.name and options.configuration
+            # contain the same campaign configuration?!?!
+            replaceCampaigns(post)
+        elif update:
+            ## need to update a value
+            if options.type: update['type'] = options.type
+            print "updating",options.name,"with values",update
+            db.update( up, {"$set": update} )
+            ### And update it in central CouchDB as well
+            thisDoc = deepcopy(found)
+            thisDoc.update(update)
+            replaceCampaigns(thisDoc)
+        else:
+            ## use that to show the value in the database
+            # not other headers in the output, so that it can be json loadable
+            found.pop('name')
+            found.pop('_id')
+            print json.dumps(found, indent=2, sort_keys=True)
     else:
-        ## use that to show the value in the database
-        # not other headers in the output, so that it can be json loadable
-        found.pop('name')
-        found.pop('_id')
-        print json.dumps(found, indent=2, sort_keys=True)
-else:
-    if post:
-        ## entering a new value
-        if options.type: post['type'] = options.type
-        post.update( {"name":options.name})
-        db.insert_one( post )
-    elif update:
-        if options.type: update['type'] = options.type
-        update.update( {"name":options.name})
-        db.insert_one( update )        
-    else:
-        availables = [o["name"] for o in db.find()]
-        print options.name," Not found. ",len(availables),"available campaigns \n","\n\t".join( sorted( availables))
+        if post:
+            ## entering a new value
+            if options.type: post['type'] = options.type
+            post.update( {"name":options.name})
+            db.insert_one( post )
+            createCampaign(post)
+        elif update:
+            if options.type: update['type'] = options.type
+            update.update( {"name":options.name})
+            db.insert_one( update )
+            createCampaign(post)
+        else:
+            availables = [o["name"] for o in db.find()]
+            print options.name," Not found. ",len(availables),"available campaigns \n","\n\t".join( sorted( availables))
 
+
+def replaceCampaigns(campaigns):
+    """
+    If we replaced (updated) all the campaign records in MongoDB,
+    let's do the same with CouchDB campaigns
+    :param campaigns: list of campaign dictionaries
+    """
+    data = parseMongoCampaigns(campaigns, verbose=False)
+    for rec in data:
+        campName = rec['CampaignName']
+        if not updateCampaignConfig(rec):
+            print("FAILED to update campaign: %s. Full content was: %s" % (campName, rec))
+        else:
+            print("Campaign '%s' successfully updated in central CouchDB" % campName)
+
+
+def createCampaign(content):
+    """
+    Parse the Unified campaign configuration and create a new
+    campaign in central Couch
+    :param content: the campaign content
+    """
+    data = parseMongoCampaigns(content, verbose=False)
+    for rec in data:
+        campName = rec['CampaignName']
+        if not updateCampaignConfig(rec):
+            print("FAILED to create campaign: %s. Full content was: %s" % (campName, rec))
+        else:
+            print("Campaign '%s' successfully created in central CouchDB" % campName)
+
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
Fixes https://github.com/dmwm/WMCore/issues/9310

#### Status
not-tested

#### Description
Summary of changes is:
* migrate from optparse to argparse (the former is not supported in python3)
* client APIs to interact with ReqMgr2 `campaignconfig` API.
* function to parse MongoDB campaign records and return WMCore formatted campaigns
* minor reorganization of the current campaignsConfiguration.py script
* then added a few extra methods such that we can reproduce MongoDB actions against CouchDB (ReqMgr2)
* updated `batchor` module to create (and delete) the same campaigns it updates in MongoDB.
* updated `closor` to delete campaigns in CouchDB as well

The usage of that script remains the same, same options and so on. The only difference is that it will try to make the same changes on two different backends, first MongoDB and then central CouchDB (production CMSWEB).

It uses the same logic - to convert unified campaign to wmcore campaign - as implemented in this script:
https://github.com/dmwm/WMCore/blob/master/bin/adhoc-scripts/parseUnifiedCampaigns.py

#### Is it backward compatible (if not, which system it affects?)
Sort of, shouldn't change anything in the unified ecosystem.

#### Related PRs
none

#### External dependencies / deployment changes
none

#### Mention people to look at PRs
none yet