### PR TITLE
Parse correct campaign config in batchor, for wmcore format

### DIFF
--- a/Unified/batchor.py
+++ b/Unified/batchor.py
@@ -82,7 +82,9 @@ def batchor( url ):
         add_on[campaign] = setup
         sendLog('batchor','Adding the relval campaigns %s with parameters \n%s'%( campaign, json.dumps( setup, indent=2)),level='critical')
         BI.update( campaign, by_campaign[campaign])
-        wmcoreCamp = parseMongoCampaigns(campaign)
+        # now update it in central CouchDB
+        setup['name'] = campaign
+        wmcoreCamp = parseMongoCampaigns(setup)
         res = createCampaignConfig(wmcoreCamp)
         print "Campaign %s correctly created in ReqMgr2: %s" % (wmcoreCamp['CampaignName'], res)
 
@@ -98,7 +100,9 @@ def batchor( url ):
         add_on[campaign] = setup
         sendLog('batchor','Adding the HI relval campaigns %s with parameters \n%s'%( campaign, json.dumps( setup, indent=2)),level='critical')
         BI.update( campaign, by_hi_campaign[campaign])
-        wmcoreCamp = parseMongoCampaigns(campaign)
+        # now update it in central CouchDB
+        setup['name'] = campaign
+        wmcoreCamp = parseMongoCampaigns(setup)
         res = createCampaignConfig(wmcoreCamp)
         print "Campaign %s correctly created in ReqMgr2: %s" % (wmcoreCamp['CampaignName'], res)
 


### PR DESCRIPTION
Complement to #466 (read a bug fix for)

#### Status
not-tested

#### Description
Sharad reported this batchor crash over slack
```
File "Unified/batchor.py", line 154, in <module>
    batchor(url)
  File "Unified/batchor.py", line 85, in batchor
    wmcoreCamp = parseMongoCampaigns(campaign)
  File "/data/unified/WmAgentScripts/campaignAPI.py", line 132, in parseMongoCampaigns
    conf[wmKey] = rec.get(uniKey, conf[wmKey])
AttributeError: 'unicode' object has no attribute 'get'
```

The previous PR was passing a plain string (campaign name) to the function to parse a unified campaign dictionary to a wmcore dictionary.
So this PR should be passing the correct data structure (with the `name` key/value pair), which will then be converted to a WMCore campaign schema.

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
Bugfix for #466 

#### External dependencies / deployment changes
none

#### Mention people to look at PRs
@sharad1126 @thongonary could one of you please review it and if possible push it in in order to fix the batchor bug? Thanks
