### PR TITLE
Accept list with a single campaign config in the createCampaignConfig method

### DIFF
--- a/campaignAPI.py
+++ b/campaignAPI.py
@@ -27,6 +27,11 @@ def createCampaignConfig(docContent, url=reqmgr_url):
     :param docContent: dictionary with the campaign content
     :return: a boolean whether it succeeded (True) or not (False)
     """
+    if isinstance(docContent, list) and len(docContent) > 1:
+        print("ERROR: createCampaignConfig expects a single campaign configuration, not a list of them!")
+        return False
+    elif isinstance(docContent, list):
+        docContent = docContent[0]
     outcome = True
     headers = {"Content-type": "application/json", "Accept": "application/json"}
     conn = make_x509_conn(url)


### PR DESCRIPTION
Fixes #466 and #468

#### Status
not-tested

#### Description
There is still a problem in the code, sorry!
Problem is that when we parse the MongoDB campaign and create a WMCore one, the `parse` method returns a list of dictionaries. We were then passing it over to the `createCampaignConfig` method that was dealing with it as a dictionary (but it was a list of one dict).

This should fix that problem. If a list of multiple campaigns (multiple dicts) is passed in, the createCampaignConffig will report an error.

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
Said in the first line, it's a bug fix for #466 and #468

#### External dependencies / deployment changes
none

#### Mention people to look at PRs
@sharad1126 hoping it to be the last PR now.
