### PR TITLE
assign only 10 wfs per cycle for debugging

### DIFF
--- a/assigncycle.sh
+++ b/assigncycle.sh
@@ -18,13 +18,13 @@ $BASE_DIR/cWrap.sh Unified/assignor.py --early --limit 10
 $BASE_DIR/cWrap.sh Unified/injector.py
 
 ## assigned those that could have passed through directly
-$BASE_DIR/cWrap.sh Unified/assignor.py --from_status staged
+$BASE_DIR/cWrap.sh Unified/assignor.py --from_status staged --limit 10
 
-$BASE_DIR/cWrap.sh Unified/assignor.py _PR_newco
-$BASE_DIR/cWrap.sh Unified/assignor.py _PR_ref
+$BASE_DIR/cWrap.sh Unified/assignor.py _PR_newco --limit 10
+$BASE_DIR/cWrap.sh Unified/assignor.py _PR_ref --limit 10
 
 ## assign the workflow to sites
-$BASE_DIR/cWrap.sh Unified/assignor.py
+$BASE_DIR/cWrap.sh Unified/assignor.py --limit 10
 
 rm -f $lock_name
 


### PR DESCRIPTION
Fixes 
nothing

#### Status
Ready 

#### Description
Limit to O(10) workflows per cycle so Alan can watch and debug.

#### Is it backward compatible (if not, which system it affects?)
Yes

#### Related PRs
https://github.com/CMSCompOps/WmAgentScripts/pull/473

#### Mention people to look at PRs
@amaltaro @jenimal 