### PR TITLE
only pick requests for dataops and anaops

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -3866,7 +3866,7 @@ def getBetterDatasetDestinations( url, dataset, only_blocks=None, group=None, ve
         try:
             conn = make_x509_conn(url)
             #conn  =  httplib.HTTPSConnection(url, cert_file = os.getenv('X509_USER_PROXY'), key_file = os.getenv('X509_USER_PROXY'))
-            url = '/phedex/datasvc/json/prod/requestlist?dataset=%s'%dataset
+            url = '/phedex/datasvc/json/prod/requestlist?dataset=%s&group=AnalysisOps&group=DataOps'%dataset
             if group:
                 url+='group=%s'%group
             r1=conn.request("GET",url)


### PR DESCRIPTION
with regards to 
https://hypernews.cern.ch/HyperNews/CMS/get/comp-ops/4856.html 
https://its.cern.ch/jira/browse/CMSCOMPPR-11171 

https://cms-unified.web.cern.ch/cms-unified/showlog/?search=ReReco-Run2018A-SingleMuon-12Nov2019_UL2018-0001&module=transferor&limit=500&size=10000

> The input is either fully in place or getting in full somewhere with [2000338]
> latches on existing transfers, and nothing else, settin staging
> setting pgunnell_Run2018A-v1-SingleMuon-12Nov2019_UL2018_1064p1_191114_160444_8742 status to staging

only request for AnalysisOps and DataOps should be considered as good source for production