### PR TITLE
force-complete and bypass directly from jira

### DIFF
--- a/JIRAClient.py
+++ b/JIRAClient.py
@@ -143,9 +143,13 @@ class JIRAClient:
             else:
                 query += ' AND status = %s'%(status)
 
-        if specifications.get('label'):
+        if specifications.get('label',None):
             label = specifications['label']
             query += ' AND labels = %s'%label
+
+        if specifications.get('text',None):
+            string = specifications['text']
+            query += ' AND text ~ "%s"'% string
 
         return self._find( query )
 

--- a/Unified/checkor.py
+++ b/Unified/checkor.py
@@ -158,7 +158,7 @@ def checkor(url, spec=None, options=None):
                     keyword = c.body[(c.body.find(force_complete_jira_string)+len(force_complete_jira_string)):].split()[0]
                     if keyword and user in actors:
                         print user,"is force-completing", keyword,"from JIRA"
-                        bypasses.update( keyword )
+                        bypasses.extend( keyword )
                         overrides[user].extend( keyword )
                     break
         bypass_jira_string = "cmsunified please do bypass"
@@ -172,7 +172,7 @@ def checkor(url, spec=None, options=None):
                     keyword = c.body[(c.body.find(bypass_jira_string)+len(bypass_jira_string)):].split()[0]
                     if keyword and user in actors:
                         print user,"is bypassing", keyword,"from JIRA"
-                        bypasses.update( keyword )
+                        bypasses.extend( keyword )
                     break
                     
     if use_mcm:

--- a/Unified/checkor.py
+++ b/Unified/checkor.py
@@ -155,8 +155,10 @@ def checkor(url, spec=None, options=None):
                 if force_complete_jira_string in c.body:
                     user = c.author.name
                     prepid = jira.fields.summary.split()[0]
-                    bypasses.update( prepid )
-                    overrides[user].extend( prepid )
+                    keyword = c.body[(c.body.find(force_complete_jira_string)+len(force_complete_jira_string)):].split()[0]
+                    if keyword and user in actors:
+                        bypasses.update( keyword )
+                        overrides[user].extend( keyword )
                     break
         bypass_jira_string = "cmsunified please do bypass"
         to_check = JC.find({'text' : bypass_jira_string, "status" : "!CLOSED"})
@@ -166,7 +168,10 @@ def checkor(url, spec=None, options=None):
                 if bypass_jira_string in c.body:
                     user = c.author.name
                     prepid = jira.fields.summary.split()[0]
-                    bypasses.update( prepid )
+                    keyword = c.body[(c.body.find(bypass_jira_string)+len(bypass_jira_string)):].split()[0]
+                    if keyword and user in actors:
+                        bypasses.update( keyword )
+                    break
                     
     if use_mcm:
         ## this is a list of prepids that are good to complete

--- a/Unified/checkor.py
+++ b/Unified/checkor.py
@@ -157,6 +157,7 @@ def checkor(url, spec=None, options=None):
                     prepid = jira.fields.summary.split()[0]
                     keyword = c.body[(c.body.find(force_complete_jira_string)+len(force_complete_jira_string)):].split()[0]
                     if keyword and user in actors:
+                        print user,"is force-completing", keyword,"from JIRA"
                         bypasses.update( keyword )
                         overrides[user].extend( keyword )
                     break
@@ -170,6 +171,7 @@ def checkor(url, spec=None, options=None):
                     prepid = jira.fields.summary.split()[0]
                     keyword = c.body[(c.body.find(bypass_jira_string)+len(bypass_jira_string)):].split()[0]
                     if keyword and user in actors:
+                        print user,"is bypassing", keyword,"from JIRA"
                         bypasses.update( keyword )
                     break
                     


### PR DESCRIPTION
with regards to https://its.cern.ch/jira/browse/CMSCOMPPR-11343 if one wants to avoid having to operate manually, see this PR.
adding a "cmsunified please do force-complete wfname" or "cmsunified please do bypass wfname" will result in the desired action