### PR TITLE
htmlor code with legacy mistakes

### DIFF
--- a/Unified/htmlor.py
+++ b/Unified/htmlor.py
@@ -844,7 +844,7 @@ Worflow through (%d) <a href=logs/closor/last.log target=_blank>log</a> <a href=
 %s
 </pre>
 """%(os.getenv('USER'),
-     os.popen('acrontab -l | grep -i unified | grep -v \#  |sort -f 6').read()))
+     os.popen('acrontab -l | grep -i unified | grep -v \#  |sort -f ').read()))
 
 
     per_module = defaultdict(list)

--- a/Unified/htmlor.py
+++ b/Unified/htmlor.py
@@ -844,7 +844,7 @@ Worflow through (%d) <a href=logs/closor/last.log target=_blank>log</a> <a href=
 %s
 </pre>
 """%(os.getenv('USER'),
-     os.popen('acrontab -l | grep -i unified | grep -v \#  |sort -f ').read()))
+     os.popen('acrontab -l | grep -i unified | grep -v \#  |sort -k 6').read()))
 
 
     per_module = defaultdict(list)


### PR DESCRIPTION
Fixes errors in htmlor logs:
```
sort: cannot read: 6: No such file or directory
grep: write error: Broken pipe
```

#### Status
tested

#### Description
htmlor module logs shows errors due to some mistakes in code. 

#### Is it backward compatible (if not, which system it affects?)
NO

#### Related PRs
#489 

#### External dependencies / deployment changes
sort -f

#### Mention people to look at PRs
@z4027163 