### PR TITLE
checkTransferLag fetch collapse=n when dataset sub is available

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -3514,14 +3514,13 @@ def try_checkTransferLag( url, xfer_id , datasets=None):
 
     for item in  result['phedex']['dataset']:
         if 'subscription' in item:
-             add_collapse=True
-             break
+            add_collapse=True
+            break
     if add_collapse:
         subs_url+='&collapse=n'
         r1=conn.request("GET",subs_url)
         r2=conn.getresponse()
         result = json.loads(r2.read())
-
 
     now = time.mktime( time.gmtime() )
     #print result

--- a/utils.py
+++ b/utils.py
@@ -3512,7 +3512,7 @@ def try_checkTransferLag( url, xfer_id , datasets=None):
     #only check '&collapse=n' when there is dataset level subscription
     add_collapse=False
 
-    for item in  result['phedex']['dataset']:
+    for item in result['phedex']['dataset']:
         if 'subscription' in item:
             add_collapse=True
             break
@@ -3539,7 +3539,7 @@ def try_checkTransferLag( url, xfer_id , datasets=None):
                 result = json.loads(r2.read())
                 break
 
-    for item in  result['phedex']['dataset']:
+    for item in result['phedex']['dataset']:
         if 'subscription' not in item:
             #print "sub"
             loop_on = list(itertools.chain.from_iterable([[(subitem['name'],i) for i in subitem['subscription']] for subitem in item['block']]))


### PR DESCRIPTION
Fixes #450

#### Status
Tested for stuckor module

#### Description
checkTransferLag looks into 'collapse=n' for block substription only when dataset subscription is available in 'collapse=y'.

#### Is it backward compatible (if not, which system it affects?)
Yes

#### Related PRs
N/A

#### External dependencies / deployment changes
NO

#### Mention people to look at PRs
@sharad1126 @drkovalskyi 
