### PR TITLE
Cleanlog Script issue

### DIFF
--- a/acrontab.list
+++ b/acrontab.list
@@ -43,6 +43,6 @@
 10 00 * * 1 vocms0269 /data/unified/WmAgentScripts/cleanlog.sh 
 15 00 * * 1 vocms0272 /data/unified/WmAgentScripts/cleanlog.sh 
 20 00 * * 1 vocms0273 /data/unified/WmAgentScripts/cleanlog.sh 
-25 00 * * 1 vocms0274 /data/unified/WmAgentScripts/cleanlog.sh 
+#25 00 * * 1 vocms0274 /data/unified/WmAgentScripts/cleanlog.sh 
 30 00 * * 1 vocms0275 /data/unified/WmAgentScripts/cleanlog.sh 
 00 11 * * 1 vocms0275 /data/unified/WmAgentScripts/cleanBackfills.sh &> /dev/null


### PR DESCRIPTION
Fixes #497 

#### Status
ready

#### Description
There is no acron connection to vocms0274 as per puppet and therefore no acron job can ever run on the machine. 

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
n/a

#### External dependencies / deployment changes
acron 

#### Mention people to look at PRs
@vlimant @z4027163 @jenimal 