### PR TITLE
updating the recovermissinglumi script as per wmagent updates

### DIFF
--- a/campaigns.json
+++ b/campaigns.json
@@ -412,6 +412,13 @@
     "maxcopies": 1, 
     "tune": true
   }, 
+  "Run3Winter20CosmicGS": {
+    "fractionpass": 0.95, 
+    "go": false, 
+    "lumisize": -1, 
+    "maxcopies": 1, 
+    "tune": true
+  }, 
   "Run3Winter20DR": {
     "fractionpass": 0.95, 
     "go": false, 

--- a/recoverMissingLumis.py
+++ b/recoverMissingLumis.py
@@ -306,7 +306,7 @@ def getFiles(datasetName, runBlacklist, runWhitelist, blockBlacklist,
             if len(replicaInfo["phedex"]["block"]) > 0:
                 for replica in replicaInfo["phedex"]["block"][0]["replica"]:
                     PNN = replica["node"]
-                    PSNs = CRIC.PNNstoPSNs(PNN)
+                    PSNs = CRICsite.PNNstoPSNs(PNN)
                     blockLocations.add(PNN)
                     #logging.debug("PhEDEx Node Name: %s\tPSNs: %s", PNN, PSNs)
 

--- a/recoverMissingLumis.py
+++ b/recoverMissingLumis.py
@@ -6,7 +6,7 @@ from WMCore.Database.CMSCouch import Database
 from WMCore.Services.DBS.DBSReader import DBSReader
 from WMCore.Services.PhEDEx.PhEDEx import PhEDEx
 from WMCore.Services.RequestDB.RequestDBReader import RequestDBReader
-from WMCore.Services.SiteDB.SiteDB import SiteDBJSON
+from WMCore.Services.CRIC.CRIC import CRIC
 from WMCore.WMSpec.WMWorkload import WMWorkloadHelper
 from pprint import pprint
 
@@ -261,7 +261,7 @@ def getFiles(datasetName, runBlacklist, runWhitelist, blockBlacklist,
     """
     dbsReader = DBSReader(endpoint=dbsUrl)
     phedexReader = PhEDEx()
-    siteDB = SiteDBJSON()
+    CRICsite = CRIC()
 
 
     class BlockBuster(threading.Thread):
@@ -287,7 +287,7 @@ def getFiles(datasetName, runBlacklist, runWhitelist, blockBlacklist,
                 return
 
             phedexReader = PhEDEx()
-            siteDB = SiteDBJSON()
+            CRICsite = CRIC()
             dbsReader = DBSReader(endpoint=self.dbs)
             replicaInfo = phedexReader.getReplicaInfoForBlocks(block=blockName,
                                                                     subscribed='y')
@@ -306,7 +306,7 @@ def getFiles(datasetName, runBlacklist, runWhitelist, blockBlacklist,
             if len(replicaInfo["phedex"]["block"]) > 0:
                 for replica in replicaInfo["phedex"]["block"][0]["replica"]:
                     PNN = replica["node"]
-                    PSNs = siteDB.PNNtoPSN(PNN)
+                    PSNs = CRIC.PNNstoPSNs(PNN)
                     blockLocations.add(PNN)
                     #logging.debug("PhEDEx Node Name: %s\tPSNs: %s", PNN, PSNs)
 


### PR DESCRIPTION
Fixes #509 

#### Status
tested

#### Description
WmAgent now depends on CRIC instead of siteDB. The dependency in the script now depends on CRIC too. 

#### Is it backward compatible (if not, which system it affects?)
no

#### Related PRs
<If it's a follow up work; or porting a fix from a different branch, please mention them here.>

#### External dependencies / deployment changes
CRIC, sitedb

#### Mention people to look at PRs
@amaltaro fyi