### PR TITLE
Remove more legacy

### DIFF
--- a/Unified/closor.py
+++ b/Unified/closor.py
@@ -551,24 +551,24 @@ class CloseBuster(threading.Thread):
                             continue
 
                         n_copies = 1
-                        destinations=[]
-                        if to_DDM and campaign and campaign in CI.campaigns and 'DDMcopies' in CI.campaigns[campaign]:
-                            ddm_instructions = CI.campaigns[campaign]['DDMcopies']
-                            if type(ddm_instructions) == int:
-                                n_copies = CI.campaigns[campaign]['DDMcopies']
-                            elif type(ddm_instructions) == dict:
-                                ## a more fancy configuration
-                                for ddmtier,indication in ddm_instructions.items():
-                                    if ddmtier==tier or ddmtier in ['*','all']:
-                                        ## this is for us
-                                        if 'N' in indication:
-                                            n_copies = indication['N']
-                                        if 'host' in indication:
-                                            destinations = indication['host']
+                        #destinations=[]
+                        #if to_DDM and campaign and campaign in CI.campaigns and 'DDMcopies' in CI.campaigns[campaign]:
+                        #    ddm_instructions = CI.campaigns[campaign]['DDMcopies']
+                        #    if type(ddm_instructions) == int:
+                        #        n_copies = CI.campaigns[campaign]['DDMcopies']
+                        #    elif type(ddm_instructions) == dict:
+                        #        ## a more fancy configuration
+                        #        for ddmtier,indication in ddm_instructions.items():
+                        #            if ddmtier==tier or ddmtier in ['*','all']:
+                        #                ## this is for us
+                        #                if 'N' in indication:
+                        #                    n_copies = indication['N']
+                        #                if 'host' in indication:
+                        #                    destinations = indication['host']
                                             
-                        destination_spec = ""
-                        if destinations:
-                            destination_spec = "--destination="+",".join( destinations )
+                        #destination_spec = ""
+                        #if destinations:
+                        #    destination_spec = "--destination="+",".join( destinations )
                         group_spec = "" ## not used yet 
                         ### should make this a campaign configuration
                         ## inject to DDM when necessary

--- a/campaigns.json
+++ b/campaigns.json
@@ -412,6 +412,13 @@
     "maxcopies": 1, 
     "tune": true
   }, 
+  "Run3Winter20CosmicGS": {
+    "fractionpass": 0.95, 
+    "go": false, 
+    "lumisize": -1, 
+    "maxcopies": 1, 
+    "tune": true
+  }, 
   "Run3Winter20DR": {
     "fractionpass": 0.95, 
     "go": false, 

--- a/utils.py
+++ b/utils.py
@@ -1546,6 +1546,9 @@ def getWMStats(url):
     return json.loads(r2.read())['result'][0]
 
 def get_dashbssb(path_name, ssb_metric):
+    return runWithRetries(_get_dashbssb, [path_name, ssb_metric], {})
+
+def _get_dashbssb(path_name, ssb_metric):
     with open('Unified/monit_secret.json') as monit:
         conf = json.load(monit)
     query = """'{"search_type":"query_then_fetch","ignore_unavailable":true,"index":["monit_prod_cmssst_*","monit_prod_cmssst_*"]}


### PR DESCRIPTION
Removed old legacy code from closor

#### Status
not tested

#### Description
```DDMCopies``` parameter is not used in campaigns at all. So we should remove this from production. 

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
<If it's a follow up work; or porting a fix from a different branch, please mention them here.>

#### External dependencies / deployment changes
campaigns.json 

#### Mention people to look at PRs
@z4027163 