### PR TITLE
Remove more legacy code from closor

### DIFF
--- a/Unified/closor.py
+++ b/Unified/closor.py
@@ -552,23 +552,23 @@ class CloseBuster(threading.Thread):
 
                         n_copies = 1
                         destinations=[]
-                        if to_DDM and campaign and campaign in CI.campaigns and 'DDMcopies' in CI.campaigns[campaign]:
-                            ddm_instructions = CI.campaigns[campaign]['DDMcopies']
-                            if type(ddm_instructions) == int:
-                                n_copies = CI.campaigns[campaign]['DDMcopies']
-                            elif type(ddm_instructions) == dict:
-                                ## a more fancy configuration
-                                for ddmtier,indication in ddm_instructions.items():
-                                    if ddmtier==tier or ddmtier in ['*','all']:
-                                        ## this is for us
-                                        if 'N' in indication:
-                                            n_copies = indication['N']
-                                        if 'host' in indication:
-                                            destinations = indication['host']
+                        #if to_DDM and campaign and campaign in CI.campaigns and 'DDMcopies' in CI.campaigns[campaign]:
+                        #    ddm_instructions = CI.campaigns[campaign]['DDMcopies']
+                        #    if type(ddm_instructions) == int:
+                        #        n_copies = CI.campaigns[campaign]['DDMcopies']
+                        #    elif type(ddm_instructions) == dict:
+                        #        ## a more fancy configuration
+                        #        for ddmtier,indication in ddm_instructions.items():
+                        #            if ddmtier==tier or ddmtier in ['*','all']:
+                        #                ## this is for us
+                        #                if 'N' in indication:
+                        #                    n_copies = indication['N']
+                        #                if 'host' in indication:
+                        #                    destinations = indication['host']
                                             
-                        destination_spec = ""
-                        if destinations:
-                            destination_spec = "--destination="+",".join( destinations )
+                        #destination_spec = ""
+                        #if destinations:
+                        #    destination_spec = "--destination="+",".join( destinations )
                         group_spec = "" ## not used yet 
                         ### should make this a campaign configuration
                         ## inject to DDM when necessary

--- a/Unified/closor.py
+++ b/Unified/closor.py
@@ -569,12 +569,12 @@ class CloseBuster(threading.Thread):
                         #destination_spec = ""
                         #if destinations:
                         #    destination_spec = "--destination="+",".join( destinations )
-                        group_spec = "" ## not used yet 
+                        #group_spec = "" ## not used yet 
                         ### should make this a campaign configuration
                         ## inject to DDM when necessary
                         if to_DDM:
                             print "Sending",out," to DDM"
-                            status = pass_to_dynamo( [out], N = n_copies, sites=destinations if destinations else None, group = group_spec if group_spec else None)
+                            status = pass_to_dynamo( [out], N = n_copies, sites=destinations if destinations else None, None)
                             results.append( status )
                             if status == True:
                                 wfi.sendLog('closor','%s is send to dynamo in %s copies %s %s'%( out, n_copies, sorted(destinations), group_spec))

--- a/Unified/closor.py
+++ b/Unified/closor.py
@@ -551,7 +551,7 @@ class CloseBuster(threading.Thread):
                             continue
 
                         n_copies = 1
-                        destinations=[]
+                        #destinations=[]
                         #if to_DDM and campaign and campaign in CI.campaigns and 'DDMcopies' in CI.campaigns[campaign]:
                         #    ddm_instructions = CI.campaigns[campaign]['DDMcopies']
                         #    if type(ddm_instructions) == int:


### PR DESCRIPTION
Removed old code from closor

#### Status
not tested

#### Description
```DDMcopies``` is not used anymore in campaigns and therefore shouldn't be used in the code as well. 

#### Is it backward compatible (if not, which system it affects?)
no

#### Related PRs
<If it's a follow up work; or porting a fix from a different branch, please mention them here.>

#### External dependencies / deployment changes
campaigns.json and unifiedconfigurations.json

#### Mention people to look at PRs
@z4027163 @vlimant @amaltaro fyi