### PR TITLE
proper check on reqmgr

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -1082,13 +1082,8 @@ class componentCheck(threading.Thread):
         all_info = session.query(Workflow).filter(Workflow.name.contains('1')).all()
 
     def check_reqmgr(self):
-        if 'testbed' in reqmgr_url:
-            wfi = getWorkLoad(reqmgr_url,'sryu_B2G-Summer12DR53X-00743_v4_v2_150126_223017_1156')
-        else:
-            wfi = getWorkLoad(reqmgr_url,'pdmvserv_task_B2G-RunIIWinter15wmLHE-00067__v1_T_150505_082426_497')       
-        name = wfi['RequestName']
-        tests = getWorkflows(reqmgr_url, 'assignment-approved')
-
+        data = getReqmgrInfo(reqmgr_url)
+        
     def check_mcm(self):
         from McMClient import McMClient
         mcmC = McMClient(dev=False)
@@ -5189,7 +5184,13 @@ def getWorkLoad(url, wf ):
         except:
             print "failed twice to _getWorkLoad(url, wf )"
             return None
-
+def getReqmgrInfo(url):
+    conn = make_x509_conn(url)
+    r1= conn.request("GET",'/reqmgr2/data/info', headers={"Accept":"*/*"})
+    r2=conn.getresponse()
+    data = json.loads(r2.read())
+    return data['result']
+    
 def _getWorkLoad(url, wf ):
     conn = make_x509_conn(url)
     r1= conn.request("GET",'/reqmgr2/data/request/'+wf, headers={"Accept":"*/*"})


### PR DESCRIPTION
simple check on https://cmsweb.cern.ch/reqmgr2/data/info instead of adhoc workflows 