### PR TITLE
mappor added to run before equalizor

### DIFF
--- a/shortcycle.sh
+++ b/shortcycle.sh
@@ -4,6 +4,9 @@ HTML_DIR=/var/www/html/unified/
 lock_name=`echo $BASH_SOURCE | cut -f 1 -d "."`.lock
 source $BASE_DIR/cycle_common.sh $lock_name
 
+##mapping the sites
+$BASE_DIR/cWrap.sh Unified/mappor.py
+
 ## equalize site white list at the condor level                                                                                      
 $BASE_DIR/cWrap.sh Unified/equalizor.py
 


### PR DESCRIPTION
Addition to #495 

#### Status
tested

#### Description
adding mappor module to acron jobs before equalizor

#### Is it backward compatible (if not, which system it affects?)
no

#### Related PRs
#495 

#### External dependencies / deployment changes
acron, shortcycle.sh

#### Mention people to look at PRs
@vlimant @z4027163 fyi