### PR TITLE
Fix KeyError exception while fetching failures from wmstatsserver

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -8188,10 +8188,12 @@ def getFailedJobs(taskname, caller='getFailedJobs'):
     failed_jobs = 0
 
     for info in reading['result']:
-        for f,taskinfo in info['AgentJobInfo'].iteritems():
-            if taskname in taskinfo['tasks'] and 'failure' in taskinfo['tasks'][taskname]['status']:
-                for ff,njobs in taskinfo['tasks'][taskname]['status']['failure'].iteritems():
-                    failed_jobs += njobs
+        for agentName in info.get('AgentJobInfo', {}):
+            if taskname in info['AgentJobInfo'][agentName].get("tasks", {}):
+                taskInfo = info['AgentJobInfo'][agentName]["tasks"][taskname]
+                if "failure" in taskInfo.get("status", {}):
+                    for failureType, numFailures in taskInfo["status"]["failure"].items():
+                        failed_jobs += numFailures
 
     return failed_jobs
 


### PR DESCRIPTION
Fixes  (is there any issue for this?)

#### Status
not-tested

#### Description
Handle cases where one of those keys (e.g. `status`) is missing.

Just a note, if we have many tasks to be recovered within the same workflow, it appears to me that we would make that wmstatsserver call many times. That query is heavy and it should be avoided as much as we can (thus, single query for the workflow and handle multiple tasks on the client side).

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
none

#### External dependencies / deployment changes
none

#### Mention people to look at PRs
@sharad1126 