### PR TITLE
lock actor on failure

### DIFF
--- a/Unified/actor.py
+++ b/Unified/actor.py
@@ -15,6 +15,7 @@ import httplib
 import ssl
 import sys
 import random
+import glob
 from wtcClient import wtcClient
 from JIRAClient import JIRAClient
 
@@ -359,7 +360,11 @@ def singleClone(url, wfname, actions, comment, do=False):
 
 
 def actor(url,options=None):
-    
+
+    if glob.glob('%s/actor.failed-*.lock'%( base_eos_dir )):
+        sendLog('actor','module is locked because of past failures', level='critical')
+        return
+
     mlock = moduleLock(wait=False ,silent=True)
     if mlock(): return
     if userLock('actor'): return

--- a/Unified/actor.py
+++ b/Unified/actor.py
@@ -736,11 +736,11 @@ if __name__ == '__main__':
         print "No arguments accepted."
     else:
         if not options.do: options.ass=False
-        actor(url,options=options)
+        try:
+            actor(url,options=options)
+        except:
+            sendLog('actor','module has failed to operate, interlocking the module', level='critical')
+            os.system('touch %s/actor.failed-%s.lock'%( base_eos_dir, os.getpid() ))
+            sys.exit(-1)
 
-#    fdb = closeoutInfo()
-#    fdb.html()
-
-#    from showError import parse_all
- #   parse_all(url)
 


### PR DESCRIPTION
mentioned in #528.

there's something to be understood on what mechanism is locking based on /eos/cms/store/unified/actor*.lock ; I think it's a legacy not taken care of from 03caf9c12308a3f4a8a13cbdb60163eda2499bed

something needs to be changed then to use moduleLock

