### PR TITLE
Exclude NANOAOD from Unified output dataplacement for standard workfl…

### DIFF
--- a/Unified/closor.py
+++ b/Unified/closor.py
@@ -499,6 +499,9 @@ class CloseBuster(threading.Thread):
                         ## make the specific relval rules and the replicas
                         ## figure the destination(s) out
                         destinations = set()
+                        if tier in UC.get("tiers_to_rucio_relval"):
+                            sendLog("Data Tier: %s is blacklisted, so skipping dataset placement for: %s" % (tier,out))
+                            continue
                         if tier != "RECO" and tier != "ALCARECO":
                             destinations.add('T2_CH_CERN')
                         if tier == "GEN-SIM":
@@ -540,6 +543,10 @@ class CloseBuster(threading.Thread):
                             to_DDM = True
 
                         ## by typical enabling
+                        if tier in UC.get("tiers_to_rucio_nonrelval"):
+                            sendLog("Data Tier: %s is blacklisted, so skipping dataset placement for: %s" % (tier,out))
+                            continue
+
                         if tier in UC.get("tiers_to_DDM"):
                             to_DDM = True
                         ## check for unitarity

--- a/unifiedConfiguration.json
+++ b/unifiedConfiguration.json
@@ -230,6 +230,14 @@
    "value" : ["AODSIM","MINIAODSIM","GEN-SIM-RAW","GEN-SIM-RECO","GEN-SIM-RECODEBUG","AOD","RECO","MINIAOD","ALCARECO","USER","RAW-RECO","RAWAODSIM","NANOAOD","NANOAODSIM","FEVT","PREMIX"],
    "description": "The data tiers that go to AnaOps"
  },
+ "tiers_to_rucio_relval": {
+   "value" : ["NANOAOD", "NANOAODSIM"],
+   "description": "The data tiers not to be considered for output data placement - RelVal workflows."
+ },
+ "tiers_to_rucio_nonrelval": {
+   "value" : [],
+   "description": "The data tiers not to be considered for output data placement - NonRelVal workflows."
+ },
  "secondary_lock_timeout": {
    "value" : 30,
    "description": "The number of days to keep a secondary input locked"


### PR DESCRIPTION
Fixes #530
Status
Description

As part of the Rucio migration there have been a plan put into action to initially adapt the NANOAOD data tier. Which means that Unified should not subscribe data transfers when it comes to those datasets.

After our previous investigation of the code we concluded that Unified is doing output data placement through DDM for standard Workflows and through Phedex for RelVal. It seems we can benefit from the already existing parameter 'tier_to_DDM' here. And we can hard code the exclusion of NANOD for Relval in a similar way as it is done for the rest of the data tiers here: [1]

[1] https://github.com/CMSCompOps/WmAgentScripts/blob/master/Unified/closor.py#L502-L518

Is it backward compatible (if not, which system it affects?)
Related PRs

NO
External dependencies / deployment changes

We may want to make it configurable for RelVal workflows too.
Mention people to look at PRs

@sharad1126 @amaltaro @vlimant