### PR TITLE
temparorily take out PIC from the distribution for tape storage

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -2243,7 +2243,11 @@ class siteInfo:
 
             if mss in sites_space_override:
                 self.storage[mss] = sites_space_override[mss]
-
+            
+            ## disbale PIC tape temparorily
+            if mss == 'T1_ES_PIC_MSS':
+                self.storage[mss] = 0
+                print "disable T1_ES_PIC_MSS temparorily" 
 
         self.fetch_queue_info()
         ## and detox info


### PR DESCRIPTION
As requested by L2, PIC needs to be taken out of tape writing, temparorily set "usable" of PIC tape to be 0.