### PR TITLE
remove stagor checks

### DIFF
--- a/Unified/htmlor.py
+++ b/Unified/htmlor.py
@@ -219,7 +219,7 @@ def htmlor( caller = ""):
     view_not_a_module = ['agentInfo','componentInfo']
     view_modules = ['injector','batchor','transferor','cachor','stagor','assignor','completor','GQ','equalizor','checkor','recoveror','actor','closor']+view_not_a_module
 
-    all_modules = list(set(view_modules + ['actor','addHoc','assignor','batchor','cachor','checkor','closor','completor','efficiencor','equalizor','GQ','htmlor','injector','lockor','messagor','recoveror','remainor','showError','stagor','stuckor','subscribor','transferor']))
+    all_modules = list(set(view_modules + ['actor','addHoc','assignor','batchor','cachor','checkor','closor','completor','efficiencor','equalizor','GQ','htmlor','injector','lockor','messagor','recoveror','remainor','showError','stuckor','subscribor','transferor']))
 
     html_doc.write("""
 <html>

--- a/Unified/htmlor.py
+++ b/Unified/htmlor.py
@@ -217,7 +217,7 @@ def htmlor( caller = ""):
     summary_content = {}
 
     view_not_a_module = ['agentInfo','componentInfo']
-    view_modules = ['injector','batchor','transferor','cachor','stagor','assignor','completor','GQ','equalizor','checkor','recoveror','actor','closor']+view_not_a_module
+    view_modules = ['injector','batchor','transferor','cachor','assignor','completor','GQ','equalizor','checkor','recoveror','actor','closor']+view_not_a_module
 
     all_modules = list(set(view_modules + ['actor','addHoc','assignor','batchor','cachor','checkor','closor','completor','efficiencor','equalizor','GQ','htmlor','injector','lockor','messagor','recoveror','remainor','showError','stuckor','subscribor','transferor']))
 


### PR DESCRIPTION
Fixes #536 

#### Status
tested

#### Description
As we already stopped stagor module in #537 , htmlor shouldn't check the stagor module locks and if it is running or not and not throw any heartbeats like
```
The module stagor has not ran in 12 hours, now 1 [d]2 [h] 4 [m] 47 [s]
```

#### Is it backward compatible (if not, which system it affects?)
no

#### Related PRs
#537 

#### External dependencies / deployment changes
<Does it require deployment changes? Does it rely on third-party libraries?> 

#### Mention people to look at PRs
@z4027163 @amaltaro 