### PR TITLE
Adding  a check for ParentageResolved before announcement

### DIFF
--- a/Unified/closor.py
+++ b/Unified/closor.py
@@ -374,6 +374,7 @@ class CloseBuster(threading.Thread):
 
         jump_the_line = self.jump_the_line
         batch_goodness = self.batch_goodness
+        check_parentage_to_announce = UC.get('check_parentage_to_announce')
         check_fullcopy_to_announce = UC.get('check_fullcopy_to_announce')
 
         ## what is the expected #lumis 
@@ -584,6 +585,14 @@ class CloseBuster(threading.Thread):
                     else:
                         print wfo.name,"no stats for announcing",out
                         results.append('No Stats')
+
+                # adding check for PrentageResolved flag from ReqMgr:
+                if wfi.request['RequestType'] == 'StepChain' and check_parentage_to_announce:
+                    if wfi.request['ParentageResolved']:
+                        results.append(True)
+                    else:
+                        wfi.sendLog('closor',"Delayed announcement of %s due to unresolved Parentage dependencies" % wfi.request['RequestName'])
+                        results.append('No ParentageResolved')
 
                 if all(map(lambda result : result in ['None',None,True],results)):
                     if not jump_the_line:

--- a/unifiedConfiguration.json
+++ b/unifiedConfiguration.json
@@ -242,6 +242,10 @@
   "value" : false,
   "description": "Whether to check for a full copy being present prior to announcing a dataset"
  },
+ "check_parentage_to_announce": {
+  "value" : true,
+  "description": "Whether to check if all blocks are having their parentage dependencies resolved before announcing a dataset"
+ },
  "stagor_sends_back": {
    "value" : true,
    "description": "Whether the stagor module can send workflow back to considered"


### PR DESCRIPTION
Fixes #545 

#### Status
not-tested

#### Description
<Description of the changes proposed.>
Adding  a check for ParentageResolved before announcement

#### Is it backward compatible (if not, which system it affects?)
YES 

#### Related PRs
https://github.com/dmwm/WMCore/pull/9657

#### External dependencies / deployment changes
No

#### Mention people to look at PRs
@vlimant @sharad1126 @amaltaro 
