### PR TITLE
avoid sending stepchain workflows to transferor

### DIFF
--- a/Unified/injector.py
+++ b/Unified/injector.py
@@ -188,7 +188,7 @@ def injector(url, options, specific):
                 sendLog('injector',"putting %s as replacement of %s"%( member, wf.name))
                 status = 'away'
                 if fwl['RequestStatus'] in ['assignment-approved']:
-                    status = 'considered'
+                    status = 'staged'
                 new_wf = Workflow( name = member, status = status, wm_status = fwl['RequestStatus'])
                 wf.status = 'forget'
                 session.add( new_wf ) 


### PR DESCRIPTION
Fixes #535 

#### Status
tested

#### Description
changed the status of the workflow from considered to staged should stop making transferor pick up the requests which are step-chain converted.

#### Is it backward compatible (if not, which system it affects?)
no

#### Related PRs
<If it's a follow up work; or porting a fix from a different branch, please mention them here.>

#### External dependencies / deployment changes
transferor.py 

#### Mention people to look at PRs
@amaltaro @z4027163 