### PR TITLE
remove transferor checks from htmlor

### DIFF
--- a/Unified/htmlor.py
+++ b/Unified/htmlor.py
@@ -217,9 +217,9 @@ def htmlor( caller = ""):
     summary_content = {}
 
     view_not_a_module = ['agentInfo','componentInfo']
-    view_modules = ['injector','batchor','transferor','cachor','assignor','completor','GQ','equalizor','checkor','recoveror','actor','closor']+view_not_a_module
+    view_modules = ['injector','batchor','cachor','assignor','completor','GQ','equalizor','checkor','recoveror','actor','closor']+view_not_a_module
 
-    all_modules = list(set(view_modules + ['actor','addHoc','assignor','batchor','cachor','checkor','closor','completor','efficiencor','equalizor','GQ','htmlor','injector','lockor','messagor','recoveror','remainor','showError','stuckor','subscribor','transferor']))
+    all_modules = list(set(view_modules + ['actor','addHoc','assignor','batchor','cachor','checkor','closor','completor','efficiencor','equalizor','GQ','htmlor','injector','lockor','messagor','recoveror','remainor','showError','stuckor','subscribor']))
 
     html_doc.write("""
 <html>


### PR DESCRIPTION
Fixes #550 

#### Status
tested

#### Description
Remove the module check from htmlor so it doesn't complains about the module not able to run. 

#### Is it backward compatible (if not, which system it affects?)
no

#### Related PRs
#551 

#### External dependencies / deployment changes
htmlor, transferor

#### Mention people to look at PRs
@amaltaro @z4027163 