### PR TITLE
Adding Rucio to DBS-Phedex consistency check

### DIFF
--- a/RucioClient.py
+++ b/RucioClient.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python
+"""
+Encapsulates requests to Rucio API
+Requieres:
+    rucio-client
+Environment:
+    export X509_USER_PROXY=/tmp/x509up_$UID
+    export RUCIO_HOME=~/.local/
+    ${RUCIO_HOME}/rucio.cfg
+"""
+
+from rucio.client import Client
+
+class RucioClient(Client):
+    """
+    A wrapper class for the Rucio client.
+    """
+    def __init__(self, **kwargs):
+        """
+        Default configuration provided directly into the constructor to avoid
+        the need of an external configuration file.
+        All arguments passed to the constructor supersede the defaults.
+        """
+
+        defaultConfig = {
+            'rucio_host': 'http://cms-rucio.cern.ch',
+            'auth_host': 'https://cms-rucio-auth.cern.ch',
+            'auth_type': 'x509_proxy',
+            'ca_cert': '/etc/grid-security/certificates/',
+            'account': 'unified'
+        }
+
+        defaultConfig.update(kwargs)
+
+        super(RucioClient, self).__init__(**defaultConfig)
+        self.scope = 'cms'
+
+    def getFileCountDataset(self, dataset):
+        """
+        Returns the number of files registered in Rucio
+        """
+        try:
+            files = list(self.list_files(self.scope, dataset))
+        except Exception as e:
+            print(str(e))
+            return 0
+        return len(files)
+
+    def getFileNamesDataset(self, dataset):
+        """
+        Returns a set of file names in a dataset registered in Rucio
+        """
+        try:
+            files = list(self.list_files(self.scope, dataset))
+        except Exception as e:
+            print(str(e))
+            return []
+        fileNames = [_file['name'] for _file in files]
+        return fileNames
+
+    def getBlockNamesDataset(self, dataset):
+        """
+        Returns a set of block names in a dataset registerd in Rucio
+        """
+        try:
+            blockNames = [block['name'] for block in self.list_content(self.scope, dataset)]
+        except Exception as e:
+            print(str(e))
+            return []
+        return blockNames
+
+    def getFileCountBlock(self, block):
+        """
+        Returns the number of files in a block registered in Rucio
+        """
+        try:
+            numFiles = self.get_metadata(self.scope, block)['length']
+        except Exception as e:
+            print(str(e))
+            return 0
+        return numFiles
+
+    def getFileCountPerBlock(self, dataset):
+        """
+        Returns the number of files per block in a dataset registered in Rucio
+        """
+        # we need blocks to be a list of tuples so we can create a set out of this
+        try:
+            blocks = []
+            for block in self.getBlockNamesDataset(dataset):
+                blocks.append((block, self.getFileCountBlock(block)))
+        except Exception as e:
+            print(str(e))
+            return 0
+        return blocks
+

--- a/Unified/RucioClient.py
+++ b/Unified/RucioClient.py
@@ -1,0 +1,1 @@
+../RucioClient.py

--- a/phedexClient.py
+++ b/phedexClient.py
@@ -141,6 +141,43 @@ def getFileCountDataset(url, dataset):
     for block in result['phedex']['block']:
         files += block['files']
     return files
+
+def getFileCountPerBlock(url, dataset):
+    """
+    Returns the number of files per block in a dataset registered in phedex
+    """
+    result = phedexGet(url, '/phedex/datasvc/json/prod/blockreplicas?dataset='+dataset, auth=False)
+    if 'block' not in result['phedex']:
+        return {}
+    elif not result['phedex']['block']:
+        return {}
+    # we need blocks to be a list of tuples so we can create a set out of this
+    blocks = []
+    #check all blocks
+    for block in result['phedex']['block']:
+        # blocks.append({'name':block['name'],
+        #                'files':block['files']})
+        blocks.append((block['name'],block['files']))
+
+    return blocks
+
+
+def getFileNamesDataset(url, dataset):
+    """
+    Returns a set of file names in a dataset registered in phedex
+    """
+    result = phedexGet(url, '/phedex/datasvc/json/prod/filereplicas?dataset='+dataset, auth=False)
+    if 'block' not in result['phedex']:
+        return set()
+    elif not result['phedex']['block']:
+        return set()
+    files = []
+    # check all blocks
+    for block in result['phedex']['block']:
+        for _file in block['file']:
+            files.append(_file['name'])
+    return set(files)
+
         
 def getTransferPercentage(url, dataset, site):
     """


### PR DESCRIPTION
Fixes #560 

#### Status
tested

#### Description
Adding a simple wrapper class of the Rucio Client so that we can safely replicate the set of checks done through Phedex and create a default fallback mechanism to Rucio, when it comes to NANOAOD data tiers. 

#### Is it backward compatible (if not, which system it affects?)
YES 

#### Related PRs
N/A

#### External dependencies / deployment changes
Requires:                                                                                                                  
> rucio-client          

Configuration file:
```
~/.local/etc/rucio.cfg
[common]
[client]
rucio_host = http://cms-rucio.cern.ch
auth_host = https://cms-rucio-auth.cern.ch
auth_type = x509
ca_cert = /etc/grid-security/certificates/
client_cert = $X509_USER_CERT
client_key = $X509_USER_KEY
client_x509_proxy = $X509_USER_PROXY
request_retries = 3
```
                                                                                                
Environment:                                                                                                                   
> export X509_USER_PROXY=/tmp/x509up_$UID 
> export RUCIO_HOME=~/.local/
 
#### Mention people to look at PRs
@sharad1126 @vlimant @amaltaro 
