### PR TITLE
added rucio export path

### DIFF
--- a/postcycle-review-manual.sh
+++ b/postcycle-review-manual.sh
@@ -1,6 +1,9 @@
 BASE_DIR=/data/unified/WmAgentScripts/
 HTML_DIR=/var/www/html/unified/
 
+## export RUCIO_HOME
+export RUCIO_HOME=~/.local/
+
 lock_name=`echo $BASH_SOURCE | cut -f 1 -d "."`.lock
 source $BASE_DIR/cycle_common.sh $lock_name
 

--- a/postcycle-review-recovering.sh
+++ b/postcycle-review-recovering.sh
@@ -1,6 +1,9 @@
 BASE_DIR=/data/unified/WmAgentScripts/
 HTML_DIR=/var/www/html/unified/
 
+## export RUCIO_HOME
+export RUCIO_HOME=~/.local/
+
 lock_name=`echo $BASH_SOURCE | cut -f 1 -d "."`.lock
 source $BASE_DIR/cycle_common.sh $lock_name
 

--- a/postcycle-strict.sh
+++ b/postcycle-strict.sh
@@ -1,6 +1,9 @@
 BASE_DIR=/data/unified/WmAgentScripts/
 HTML_DIR=/var/www/html/unified/
 
+## export RUCIO_HOME
+export RUCIO_HOME=~/.local/
+
 lock_name=`echo $BASH_SOURCE | cut -f 1 -d "."`.lock
 source $BASE_DIR/cycle_common.sh $lock_name
 

--- a/postcycle-update.sh
+++ b/postcycle-update.sh
@@ -1,6 +1,9 @@
 BASE_DIR=/data/unified/WmAgentScripts/
 HTML_DIR=/var/www/html/unified/
 
+## export RUCIO_HOME
+export RUCIO_HOME=~/.local/
+
 lock_name=`echo $BASH_SOURCE | cut -f 1 -d "."`.lock
 source $BASE_DIR/cycle_common.sh $lock_name
 


### PR DESCRIPTION
Fixes #560 

#### Status
ready

#### Description
`export RUCIO_HOME=~/.local/` is required to get the rucio.cfg file in-order to run the rucio client

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
#561 

#### External dependencies / deployment changes
~/.local/etc/rucio.cfg

Content:
```
~/.local/etc/rucio.cfg
[common]
[client]
rucio_host = http://cms-rucio.cern.ch
auth_host = https://cms-rucio-auth.cern.ch
auth_type = x509
ca_cert = /etc/grid-security/certificates/
client_cert = $X509_USER_CERT
client_key = $X509_USER_KEY
client_x509_proxy = $X509_USER_PROXY
request_retries = 3
```
#### Mention people to look at PRs
@amaltaro @ericvaandering @todor-ivanov