### PR TITLE
run HIN relvals only at CERN

### DIFF
--- a/Unified/batchor.py
+++ b/Unified/batchor.py
@@ -92,8 +92,9 @@ def batchor( url ):
         if campaign in batches: continue
         ## get a bunch of information
         setup  = copy.deepcopy( default_hi_setup )
-        possible_sites = set(["T1_DE_KIT","T1_FR_CCIN2P3"])
-        hi_site = random.choice(list(possible_sites))
+        ##possible_sites = set(["T1_DE_KIT","T1_FR_CCIN2P3"])
+        ##hi_site = random.choice(list(possible_sites))
+        hi_site = "T2_CH_CERN"
         setup["parameters"]["SiteWhitelist"]=[ hi_site ]
 
         pick_one_site( setup )


### PR DESCRIPTION
Fixes #564 

#### Status
ready

#### Description
Changes site whitelist for HIN relvals from KIT and N2P3 to only CERN.

#### Is it backward compatible (if not, which system it affects?)
no, because all input data for HIN Relvals will now be available only at CERN disk. Request made to PdMv and DM team.

#### Related PRs
N/A

#### External dependencies / deployment changes
Input data required by relvals

#### Mention people to look at PRs
@z4027163 @amaltaro fyi