### PR TITLE
Temporarily stop heavy wmstatsserver requests

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -6711,6 +6711,11 @@ class workflowInfo:
                         self.errors = d_cache['data']
                         return self.errors
 
+            # Alan Malta on 28/May/2020
+            ### FIXME TODO temporarily skipping this call
+            print "temporarily bypassing getWMErrors"
+            return {}
+            ### end of temporary hack code
             self.conn = make_x509_conn(self.url)
             r1=self.conn.request("GET",'/wmstatsserver/data/jobdetail/%s'%(self.request['RequestName']), headers={"Accept":"*/*"})
             r2=self.conn.getresponse()
@@ -6831,7 +6836,12 @@ class workflowInfo:
                     print "wmstats taken from cache",f_cache
                     self.wmstats = d_cache['data']
                     return self.wmstats
-        r1=self.conn.request("GET",'/wmstatsserver/data/request/%s'%self.request['RequestName'], headers={"Accept":"application/json"})
+        # Alan Malta on 28/may/2020
+        ### FIXME TODO temporarily query reqmgr2 instead of wmstats
+        print "temporarily querying reqmgr2 instead of wmstatsserver"
+        r1=self.conn.request("GET",'/reqmgr2/data/request/%s'%self.request['RequestName'], headers={"Accept":"application/json"})
+        ### end of hack, uncomment line below
+        #r1=self.conn.request("GET",'/wmstatsserver/data/request/%s'%self.request['RequestName'], headers={"Accept":"application/json"})
         r2=self.conn.getresponse()
         self.wmstats = json.loads(r2.read())['result'][0][self.request['RequestName']]
         try:


### PR DESCRIPTION
Fixes #

#### Status
not-tested

#### Description
Given that CouchDB and wmstatsserver were working properly during the oracle outage (aka. no or very few clients sending requests). I'd like to test a new theory: where OSDroid and Unified queries are contributing to the couchdb and wmstats saturation and eventually unresponsiveness.

None of the calls to wmstatsserver are going through anyways, so if we can test this patch in for a couple of hours, at least, it would be great. I can create a "Revert" PR once this gets merged

From one of the cmsweb frontends, I see that these nodes are making requests to wmstats:
vocms0269
vocms0272
vocms0268
vocms0273
#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
none

#### External dependencies / deployment changes
none

#### Mention people to look at PRs
@sharad1126 @z4027163 