### PR TITLE
check agentjobinfo before searching in it

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -8222,12 +8222,13 @@ def getFailedJobs(taskname, caller='getFailedJobs'):
     failed_jobs = 0
 
     for info in reading['result']:
-        for agentName in info.get('AgentJobInfo', {}):
-            if taskname in info['AgentJobInfo'][agentName].get("tasks", {}):
-                taskInfo = info['AgentJobInfo'][agentName]["tasks"][taskname]
-                if "failure" in taskInfo.get("status", {}):
-                    for failureType, numFailures in taskInfo["status"]["failure"].items():
-                        failed_jobs += numFailures
-
+        if info.get('AgentJobInfo', {}) is not None:
+            for agentName in info.get('AgentJobInfo', {}):
+                if taskname in info['AgentJobInfo'][agentName].get("tasks", {}):
+                    taskInfo = info['AgentJobInfo'][agentName]["tasks"][taskname]
+                    if "failure" in taskInfo.get("status", {}):
+                        for failureType, numFailures in taskInfo["status"]["failure"].items():
+                            failed_jobs += numFailures
+    
     return failed_jobs
 


### PR DESCRIPTION
Fixes https://github.com/dmwm/WMCore/issues/9722

#### Status
ready

#### Description
check agentjobinfo is not null and let the function to check failed jobs fail gracefully 

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs

#### External dependencies / deployment changes
wmstats server

#### Mention people to look at PRs
@z4027163 @amaltaro @todor-ivanov this should fix the issue.