### PR TITLE
Fix eoscp syntax

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -1219,6 +1219,7 @@ class eosFile(object):
             sys.exit(2)
         self.opt = opt
         self.eos_filename = filename.replace('//','/')
+        self.eos_filename = 'root://eoscms.cern.ch/'+self.eos_filename
         self.cache_filename = (cache_dir+'/'+filename.replace('/','_')).replace('//','/')
         self.cache = open(self.cache_filename, self.opt)
         self.trials = trials
@@ -3026,7 +3027,8 @@ class closeoutInfo:
         #out.close()
 
         ## write the information out to disk
-        os.system('eoscp %s/closedout.json %s/closedout.json.last'%(base_eos_dir, base_eos_dir))
+        new_base_eos_dir = 'root://eoscms.cern.ch/'+base_eos_dir
+        os.system('eoscp %s/closedout.json %s/closedout.json.last'%(new_base_eos_dir, new_base_eos_dir))
 
         ## merge the content
         try:


### PR DESCRIPTION
Fixes #578 

#### Status
ready

#### Description
changes the syntax of eoscp to the one as suggested by eos team. 

#### Is it backward compatible (if not, which system it affects?)
no

#### Related PRs
#312 

#### External dependencies / deployment changes
eos

#### Mention people to look at PRs
@z4027163 