### PR TITLE
add nanoaod to nonrelval for rucio too

### DIFF
--- a/unifiedConfiguration.json
+++ b/unifiedConfiguration.json
@@ -235,7 +235,7 @@
    "description": "The data tiers not to be considered for output data placement - RelVal workflows."
  },
  "tiers_to_rucio_nonrelval": {
-   "value" : [],
+   "value" : ["NANOAOD", "NANOAODSIM"],
    "description": "The data tiers not to be considered for output data placement - NonRelVal workflows."
  },
  "secondary_lock_timeout": {


### PR DESCRIPTION
Fixes #560 

#### Status
ready

#### Description
As per @amaltaro 's  request, I have added the NANOAOD tiers to non relval config too. 

#### Is it backward compatible (if not, which system it affects?)
no

#### Related PRs
#562 #561 

#### External dependencies / deployment changes
wmagents and rucio

#### Mention people to look at PRs
@z4027163 @amaltaro @todor-ivanov 