### PR TITLE
should send log to closor module in the workflow log

### DIFF
--- a/Unified/closor.py
+++ b/Unified/closor.py
@@ -545,7 +545,7 @@ class CloseBuster(threading.Thread):
 
                         ## by typical enabling
                         if tier in UC.get("tiers_to_rucio_nonrelval"):
-                            sendLog("Data Tier: %s is blacklisted, so skipping dataset placement for: %s" % (tier,out))
+                            wfi.sendLog('closor',"Data Tier: %s is blacklisted, so skipping dataset placement for: %s" % (tier,out))
                             continue
 
                         if tier in UC.get("tiers_to_DDM"):


### PR DESCRIPTION
Fixes #583 

#### Status
ready

#### Description
The sendLog function has two parameters and the log should go to the workflow logs instead of the normal closor logs. 

#### Is it backward compatible (if not, which system it affects?)
no

#### Related PRs
#584 

#### External dependencies / deployment changes
elastic-search

#### Mention people to look at PRs
@amaltaro @todor-ivanov @z4027163 