### PR TITLE
Invalid rucio block lenght

### DIFF
--- a/RucioClient.py
+++ b/RucioClient.py
@@ -91,8 +91,10 @@ class RucioClient(Client):
             blocks = []
             for block in self.getBlockNamesDataset(dataset):
                 blocks.append((block, self.getFileCountBlock(block)))
+            if blocks is None:
+                raise Exception("number of file count per block is None")
         except Exception as e:
             print(str(e))
-            return []
+            return 0
         return blocks
 

--- a/RucioClient.py
+++ b/RucioClient.py
@@ -91,10 +91,8 @@ class RucioClient(Client):
             blocks = []
             for block in self.getBlockNamesDataset(dataset):
                 blocks.append((block, self.getFileCountBlock(block)))
-            if blocks is None:
-                raise Exception("number of file count per block is None")
         except Exception as e:
             print(str(e))
-            return 0
+            return []
         return blocks
 

--- a/RucioClient.py
+++ b/RucioClient.py
@@ -93,6 +93,6 @@ class RucioClient(Client):
                 blocks.append((block, self.getFileCountBlock(block)))
         except Exception as e:
             print(str(e))
-            return 0
+            return []
         return blocks
 

--- a/RucioClient.py
+++ b/RucioClient.py
@@ -75,6 +75,8 @@ class RucioClient(Client):
         """
         try:
             numFiles = self.get_metadata(self.scope, block)['length']
+            if numFiles is None:
+                raise Exception("block length in rucio is None")
         except Exception as e:
             print(str(e))
             return 0


### PR DESCRIPTION
"fixes" #588 

rucio returned 

> (u'/Wprimetotb_M2000W600_LH_TuneCP5_13TeV-madgraph-pythia8/RunIISummer16NanoAODv7-PUMoriond17_Nano02Apr2020_102X_mcRun2_asymptotic_v8-v1/NANOAODSIM#04ef69e5-9084-4649-89d7-8ce9552f786f', None)

for the block length.

BTW: rucio setup could be more integrated