### PR TITLE
stop sending NANOAOD to tape from unified

### DIFF
--- a/unifiedConfiguration.json
+++ b/unifiedConfiguration.json
@@ -207,7 +207,7 @@
    "description" : "overide of the completion fraction of dataset with keyword"
  },
  "tiers_with_no_custodial": {
-   "value" : ["DQM","DQMIO","RECO","RAWAODSIM"],
+   "value" : ["DQM","DQMIO","RECO","RAWAODSIM","NANOAOD","NANOAODSIM"],
    "description": "The data tiers that do not go to tape. Can be overidden by custodial overide at campaign level"
  },
  "use_parent_custodial": {


### PR DESCRIPTION
Fixes #589 

#### Status
ready

#### Description
Added NANOAOD and NANOAODSIM to tiers_with_no_custodial so that unified stops sending nanoaod to tape.

#### Is it backward compatible (if not, which system it affects?)
no

#### Related PRs
#562 #561 

#### External dependencies / deployment changes
n/a

#### Mention people to look at PRs
@amaltaro @vlimant @nsmith- @todor-ivanov 