### PR TITLE
check primary dataset before assigning primary_aaa

### DIFF
--- a/Unified/assignor.py
+++ b/Unified/assignor.py
@@ -204,7 +204,7 @@ def assignor(url ,specific = None, talk=True, options=None):
         if 'Campaign' in wfh.request and wfh.request['Campaign'] in CI.campaigns:
             assign_parameters.update( CI.campaigns[wfh.request['Campaign']] )
 
-        if 'primary_AAA' in assign_parameters:
+        if 'primary_AAA' in assign_parameters and primary:
             primary_aaa = primary_aaa or assign_parameters['primary_AAA']
         if 'secondary_AAA' in assign_parameters:
             secondary_aaa = secondary_aaa or assign_parameters['secondary_AAA']


### PR DESCRIPTION
Fixes #601 

#### Status
ready

#### Description
check the primary and then assign primary_aaa even if primary_aaa is in the campaign config.

#### Is it backward compatible (if not, which system it affects?)
no

#### Related PRs
N/A

#### External dependencies / deployment changes
N/A

#### Mention people to look at PRs
@amaltaro this should fix what you asked us. @z4027163 fyi