### PR TITLE
Add alternative pilot from SubRequestType

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -8086,7 +8086,10 @@ class workflowInfo:
 		else:
 		    print(msg)
 		return True
-	
+        # If there is 'pilot' in SubRequestType (an alternative pilot)
+        if 'SubRequestType' in self.request and 'pilot' in self.request['SubRequestType']:
+            return True        
+ 	
         for campaign,label in pas:
             if not CI.go( campaign, label):
                 if log:

--- a/utils.py
+++ b/utils.py
@@ -8088,6 +8088,7 @@ class workflowInfo:
 		return True
         # If there is 'pilot' in SubRequestType (an alternative pilot)
         if 'SubRequestType' in self.request and 'pilot' in self.request['SubRequestType']:
+            print "Alternative pilot"
             return True        
  	
         for campaign,label in pas:


### PR DESCRIPTION
Fixes #585 

#### Description
An alternative way to tag pilot workflows besides "pilot" processing string, in order to have the normal output dataset name.

#### Mention people to look at PRs
@sharad1126 @amaltaro 
