### PR TITLE
add GEN-SIM-DIGI-RAW-MINIAOD data tier to_DDM

### DIFF
--- a/unifiedConfiguration.json
+++ b/unifiedConfiguration.json
@@ -227,7 +227,7 @@
    "description": "The data tiers that do not go to AnaOps"
  },
  "tiers_to_DDM": {
-   "value" : ["AODSIM","MINIAODSIM","GEN-SIM-RAW","GEN-SIM-RECO","GEN-SIM-RECODEBUG","AOD","RECO","MINIAOD","ALCARECO","USER","RAW-RECO","RAWAODSIM","NANOAOD","NANOAODSIM","FEVT","PREMIX"],
+   "value" : ["GEN-SIM-DIGI-RAW-MINIAOD","AODSIM","MINIAODSIM","GEN-SIM-RAW","GEN-SIM-RECO","GEN-SIM-RECODEBUG","AOD","RECO","MINIAOD","ALCARECO","USER","RAW-RECO","RAWAODSIM","NANOAOD","NANOAODSIM","FEVT","PREMIX"],
    "description": "The data tiers that go to AnaOps"
  },
  "tiers_to_rucio_relval": {


### PR DESCRIPTION
Adding GEN-SIM-DIGI-RAW-MINIAOD to unified configuration

#### Status
ready

#### Description
Phat and PdMv has requested to add a new data tier - GEN-SIM-DIGI-RAW-MINIAOD and as it would be an output dataset, the tier needs to go to DDM.

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
N/A

#### External dependencies / deployment changes
DBS

#### Mention people to look at PRs
@amaltaro @z4027163 @todor-ivanov fyi