### PR TITLE
added FNAL to high PU relval

### DIFF
--- a/unifiedConfiguration.json
+++ b/unifiedConfiguration.json
@@ -392,7 +392,7 @@
   },
   "relval_routing":{
    "description" : "Set of keywords and special settings for relvals",
-   "value" : { "highPU" : {"parameters" : { "SiteWhitelist" : ["T2_US_Nebraska","T2_US_Purdue"]}},
+   "value" : { "highPU" : {"parameters" : { "SiteWhitelist" : ["T1_US_FNAL","T2_US_Nebraska","T2_US_Purdue"]}},
 	       "highIO" : {"parameters" : { "SiteWhitelist" : ["T2_US_Nebraska","T2_US_Purdue"]}},
 	       "pLHE" : {"parameters" : { "SiteWhitelist" : ["T2_CH_CERN"]}},
 	       "ALCA_" : { "primary_AAA" : true , 


### PR DESCRIPTION
Adds FNAL back to High PU relvals

#### Status
ready

#### Description
As discussed in the comp-ops meeting today, we are adding FNAL back to the site whitelist here. 

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
n/a

#### External dependencies / deployment changes
FNAL

#### Mention people to look at PRs
@z4027163 fyi