### PR TITLE
remove Nebraska and Purdue from HighPU relval

### DIFF
--- a/unifiedConfiguration.json
+++ b/unifiedConfiguration.json
@@ -392,7 +392,7 @@
   },
   "relval_routing":{
    "description" : "Set of keywords and special settings for relvals",
-   "value" : { "highPU" : {"parameters" : { "SiteWhitelist" : ["T1_US_FNAL","T2_US_Nebraska","T2_US_Purdue"]}},
+   "value" : { "highPU" : {"parameters" : { "SiteWhitelist" : ["T1_US_FNAL"]}},
 	       "highIO" : {"parameters" : { "SiteWhitelist" : ["T2_US_Nebraska","T2_US_Purdue"]}},
 	       "pLHE" : {"parameters" : { "SiteWhitelist" : ["T2_CH_CERN"]}},
 	       "ALCA_" : { "primary_AAA" : true , 


### PR DESCRIPTION
As discussed in yesterday's compops meeting. 

#### Status
ready

#### Description
HighPU to be run only at FNAL. 

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
#620 

#### External dependencies / deployment changes
Purdue and Nebraska

#### Mention people to look at PRs
@z4027163 fyi