### PR TITLE
showError tar is causing I/O issues as it uses eos

### DIFF
--- a/Unified/showError.py
+++ b/Unified/showError.py
@@ -117,7 +117,7 @@ class LogBuster(threading.Thread):
 
                                     if os.system('ls %s'% local)==0:
                                         os.system('env EOS_MGM_URL=root://eoscms.cern.ch eos mkdir -p %s'%(m_dir))
-                                        os.system('tar zxvf %s -C %s'%(local,m_dir))
+                                        os.system('env EOS_MGM_URL=root://eoscms.cern.ch eos tar zxvf %s -C %s'%(local,m_dir))
                                         ## truncate the content ??
                                         actual_logs = os.popen('find %s -type f'%(m_dir)).read().split('\n')
                                         for fn in actual_logs:


### PR DESCRIPTION
Fixes #611 

#### Status
not-tested

#### Description
I saw today some machines were having D state for the tar processes as it also communicates with eos. We might want to cross check again all scripts using eos.

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
#579 

#### External dependencies / deployment changes
eos

#### Mention people to look at PRs
@z4027163 @haozturk fyi