### PR TITLE
size_worth_checking can't have unicode characters 

### DIFF
--- a/Unified/checkor.py
+++ b/Unified/checkor.py
@@ -1277,8 +1277,8 @@ class CheckBuster(threading.Thread):
 
             if custodial:
                 for output in out_worth_checking:
-                    if size_worth_checking[output] > tape_size_limit:
-                        wfi.sendLog('checkor',"%s output size (%s TB) is too large for the limit set (%s TB)"%( output, size_worth_checking[output], tape_size_limit))
+                    if getDatasetSize(output)/1023 > tape_size_limit:
+                        wfi.sendLog('checkor',"%s output size (%s TB) is too large for the limit set (%s TB)"%( output, getDatasetSize(output)/1023, tape_size_limit))
                         assistance_tags.add('bigoutput')
                         custodial = None
 

--- a/Unified/checkor.py
+++ b/Unified/checkor.py
@@ -1278,7 +1278,7 @@ class CheckBuster(threading.Thread):
             if custodial:
                 for output in out_worth_checking:
                     if getDatasetSize(output)/1023 > tape_size_limit:
-                        wfi.sendLog('checkor',"%s output size (%s TB) is too large for the limit set (%s TB)"%( output, getDatasetSize(output)/1023, tape_size_limit))
+                        wfi.sendLog('checkor',"%s output size (%s TB) is too large for the limit set (%s TB)"%( output, out_worth_checking[output], tape_size_limit))
                         assistance_tags.add('bigoutput')
                         custodial = None
 


### PR DESCRIPTION
Fixes checkor as the last PR #616 

#### Status
ready

#### Description
The PR #616 changes the size_worth_checking to a list of integers and the if condition changed in this PR was trying to give it a unicode. 

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
#616 

#### External dependencies / deployment changes
n/a

#### Mention people to look at PRs
@z4027163 @haozturk fyi