### PR TITLE
Change touch and tar command on eos to avoid IO issue

### DIFF
--- a/Unified/actor.py
+++ b/Unified/actor.py
@@ -700,7 +700,7 @@ def actor(url,options=None):
             r = WC.remove_action(wfname)
             if not r:
                 sendLog('actor','not able to remove the action, interlocking the module', level='critical')
-                os.system('touch %s/actor.failed-%s.lock'%( base_eos_dir, os.getpid() ))
+                os.system('env EOS_MGM_URL=root://eoscms.cern.ch eos touch %s/actor.failed-%s.lock'%( base_eos_dir, os.getpid() ))
                 sys.exit(-1)
 
         ## update the status with recovering removing manual

--- a/Unified/showError.py
+++ b/Unified/showError.py
@@ -117,7 +117,12 @@ class LogBuster(threading.Thread):
 
                                     if os.system('ls %s'% local)==0:
                                         os.system('env EOS_MGM_URL=root://eoscms.cern.ch eos mkdir -p %s'%(m_dir))
-                                        os.system('tar zxvf %s -C %s'%(local,m_dir))
+                                        tem_local = '/tmp/%s/%s/%s/%s'%(self.wfn, 
+                                                                      self.errorcode_s,
+                                                                      self.task_short,
+                                                                      label)
+                                        os.system('tar zxvf %s -C %s'%(local,tem_local))
+                                        os.system('env EOS_MGM_URL=root://eoscms.cern.ch eos cp -r %s/* %s'%(tem_local, m_dir))
                                         ## truncate the content ??
                                         actual_logs = os.popen('find %s -type f'%(m_dir)).read().split('\n')
                                         for fn in actual_logs:

--- a/Unified/showError.py
+++ b/Unified/showError.py
@@ -121,6 +121,7 @@ class LogBuster(threading.Thread):
                                                                       self.errorcode_s,
                                                                       self.task_short,
                                                                       label)
+                                        os.system('mkdir -p %s'%(tem_local))
                                         os.system('tar zxvf %s -C %s'%(local,tem_local))
                                         os.system('env EOS_MGM_URL=root://eoscms.cern.ch eos cp -r %s/* %s'%(tem_local, m_dir))
                                         ## truncate the content ??

--- a/utils.py
+++ b/utils.py
@@ -3035,7 +3035,7 @@ class closeoutInfo:
 
         ## lock everyone else from collecting info
         my_file = '%s/closedout.%s.lock'%(base_eos_dir,self.owner)
-        os.system('touch %s'%my_file)
+        os.system('env EOS_MGM_URL=root://eoscms.cern.ch eos touch %s'%my_file)
         #out = open(my_file, 'w')
         #out.write( json.dumps( self.record , indent=2 ) )
         #out.write( my_file )


### PR DESCRIPTION
Add eos command for touch and tar.

For tar command, tar the file at /tmp and then use "eos cp" command to move to eos. Since "eos mv" command doesn't support overwrite option (-T). 

@sharad1126 @haozturk 
