### PR TITLE
remove T1 only contraints for output placement.

### DIFF
--- a/Unified/assignor.py
+++ b/Unified/assignor.py
@@ -295,13 +295,12 @@ def assignor(url ,specific = None, talk=True, options=None):
             continue
 
  
-        t1_only = [ce for ce in sites_allowed if ce.startswith('T1')]
-        if t1_only:
+#        t1_only = [ce for ce in sites_allowed if ce.startswith('T1')]
+#        if t1_only:
             # try to pick from T1 only first
-            sites_out = [SI.pick_dSE([SI.CE_to_SE(ce) for ce in t1_only])]
-        else:
+#            sites_out = [SI.pick_dSE([SI.CE_to_SE(ce) for ce in t1_only])]
             # then pick any otherwise
-            sites_out = [SI.pick_dSE([SI.CE_to_SE(ce) for ce in sites_allowed])]
+        sites_out = [SI.pick_dSE([SI.CE_to_SE(ce) for ce in sites_allowed])]
             
         print "available=",SI.disk[sites_out[0]]    
         wfh.sendLog('assignor',"Placing the output on %s"%sites_out)

--- a/Unified/assignor.py
+++ b/Unified/assignor.py
@@ -295,12 +295,13 @@ def assignor(url ,specific = None, talk=True, options=None):
             continue
 
  
-#        t1_only = [ce for ce in sites_allowed if ce.startswith('T1')]
-#        if t1_only:
-            # try to pick from T1 only first
-#            sites_out = [SI.pick_dSE([SI.CE_to_SE(ce) for ce in t1_only])]
+        t1t2_only = [ce for ce in sites_allowed if [ce.startswith('T1') or ce.startswith('T2')]]
+        if t1t2_only:
+            # try to pick from T1T2 only first
+            sites_out = [SI.pick_dSE([SI.CE_to_SE(ce) for ce in t1t2_only])]
             # then pick any otherwise
-        sites_out = [SI.pick_dSE([SI.CE_to_SE(ce) for ce in sites_allowed])]
+        else:
+            sites_out = [SI.pick_dSE([SI.CE_to_SE(ce) for ce in sites_allowed])]
             
         print "available=",SI.disk[sites_out[0]]    
         wfh.sendLog('assignor',"Placing the output on %s"%sites_out)


### PR DESCRIPTION
For the output data placement noncustodial site selection, T1 only constraint is no longer needed. As discussed with L2, the site for output data placement is selected among T1+T2 sites based on their status and size. 

@sharad1126 @haozturk 


