### PR TITLE
rm the tem file after the eos cp

### DIFF
--- a/Unified/showError.py
+++ b/Unified/showError.py
@@ -124,6 +124,7 @@ class LogBuster(threading.Thread):
                                         os.system('mkdir -p %s'%(tem_local))
                                         os.system('tar zxvf %s -C %s'%(local,tem_local))
                                         os.system('env EOS_MGM_URL=root://eoscms.cern.ch eos cp -r %s/* %s'%(tem_local, m_dir))
+                                        os.system('rm -rf %s'%(tem_local))          #avoid running out of space
                                         ## truncate the content ??
                                         actual_logs = os.popen('find %s -type f'%(m_dir)).read().split('\n')
                                         for fn in actual_logs:


### PR DESCRIPTION
Machine 0272 is out of space due to large /tmp file, which is caused by the PR #630. 
Now remove those temporary files after they are copied into eos. 

@sharad1126 @haozturk 
