### PR TITLE
Disable hep cloud assignments

### DIFF
--- a/Unified/assignor.py
+++ b/Unified/assignor.py
@@ -414,16 +414,14 @@ def assignor(url ,specific = None, talk=True, options=None):
                         sendLog('assignor',"leaving splitting untouched for %s, please check on %s"%( pstring, wfo.name), level='critical')
                         wfh.sendLog('assignor',"leaving splitting untouched for PU_RD*, please check.")
 
-        """
-        if isHEPCloudReady(url) and wfh.isGoodForNERSC():
-            parameters['Team'] = 'hepcloud'
-            parameters['SiteWhitelist'] = ['T3_US_NERSC']
-            if primary:
-                parameters['TrustSitelists'] = True
-            if secondary:
-                parameters['TrustPUSitelists'] = True
-            sendEmail("sending work to hepcloud","pleasse check on %s"% wfh.request['RequestName'], destination=['hufnagel@fnal.gov'])
-        """
+        #if isHEPCloudReady(url) and wfh.isGoodForNERSC():
+        #    parameters['Team'] = 'hepcloud'
+        #    parameters['SiteWhitelist'] = ['T3_US_NERSC']
+        #    if primary:
+        #        parameters['TrustSitelists'] = True
+        #    if secondary:
+        #        parameters['TrustPUSitelists'] = True
+        #    sendEmail("sending work to hepcloud","pleasse check on %s"% wfh.request['RequestName'], destination=['hufnagel@fnal.gov'])
 
         ## make sure to autoapprove all NonCustodialSites
         parameters['AutoApproveSubscriptionSites'] = list(set(parameters['NonCustodialSites'] + parameters.get('AutoApproveSubscriptionSites',[])))

--- a/Unified/assignor.py
+++ b/Unified/assignor.py
@@ -414,6 +414,7 @@ def assignor(url ,specific = None, talk=True, options=None):
                         sendLog('assignor',"leaving splitting untouched for %s, please check on %s"%( pstring, wfo.name), level='critical')
                         wfh.sendLog('assignor',"leaving splitting untouched for PU_RD*, please check.")
 
+        """
         if isHEPCloudReady(url) and wfh.isGoodForNERSC():
             parameters['Team'] = 'hepcloud'
             parameters['SiteWhitelist'] = ['T3_US_NERSC']
@@ -422,7 +423,8 @@ def assignor(url ,specific = None, talk=True, options=None):
             if secondary:
                 parameters['TrustPUSitelists'] = True
             sendEmail("sending work to hepcloud","pleasse check on %s"% wfh.request['RequestName'], destination=['hufnagel@fnal.gov'])
-        
+        """
+
         ## make sure to autoapprove all NonCustodialSites
         parameters['AutoApproveSubscriptionSites'] = list(set(parameters['NonCustodialSites'] + parameters.get('AutoApproveSubscriptionSites',[])))
         result = reqMgrClient.assignWorkflow(url, wfo.name, None, parameters) ## team is not relevant anymore here


### PR DESCRIPTION
Fixes #637

#### Status
not-tested

#### Description
The issue was explained at #637 . In this PR, we disable hep cloud assignments for now due to the lack of hep cloud agents running them. After this PR is merged, we will kill&clone the stuck workflows.

#### Is it backward compatible (if not, which system it affects?)
YES

#### Mention people to look at PRs
@sharad1126 @z4027163 @amaltaro @todor-ivanov FYI
