### PR TITLE
change the siteWhiteList for premix WF

### DIFF
--- a/Unified/equalizor.py
+++ b/Unified/equalizor.py
@@ -815,7 +815,7 @@ def equalizor(url , specific = None, options=None):
                 extend_to = set( LHE_overflow[campaign]) & neighboring_ces ## at the intersection
                 
 
-                if wfi.heavyRead():
+                if wfi.heavyRead(sec):
                     needs = False
                     needs_overide = False
 

--- a/unifiedConfiguration.json
+++ b/unifiedConfiguration.json
@@ -102,7 +102,7 @@
     "description" : "The sites identified as having good storage bandwidth"
  },
  "sites_with_goodAAA": {
-    "value" : ["T2_CH_CSCS","T2_UA_KIPT","T2_US_Purdue","T2_TW_NCHC","T2_UK_SGrid_RALPP","T2_BE_UCL","T2_ES_IFCA","T2_DE_RWTH","T2_UK_SGrid_Bristol","T2_FR_IPHC","T2_DE_DESY","T2_IT_Legnaro","T2_US_Caltech","T2_UK_London_Brunel","T2_RU_JINR","T2_US_Vanderbilt","T2_EE_Estonia","T2_IT_Rome","T2_US_Florida","T2_UK_London_IC","T2_IT_Bari","T2_US_Nebraska","T2_FR_CCIN2P3","T2_US_UCSD","T2_CH_CERN_HLT","T2_ES_CIEMAT","T2_US_Wisconsin","T2_HU_Budapest","T2_CN_Beijing","T2_US_MIT","T2_BE_IIHE","T2_KR_KISTI","T2_RU_ITEP","T2_CH_CERN","T2_PT_NCG_Lisbon","T2_BR_SPRACE"],
+    "value" : ["T2_CH_CSCS","T2_DE_DESY","T2_DE_RWTH","T2_ES_CIEMAT","T2_FR_GRIF_LLR", "T2_FR_GRIF_IRFU", "T2_FR_IPHC","T2_FR_CCIN2P3","T2_IT_Bari", "T2_IT_Legnaro", "T2_IT_Pisa", "T2_IT_Rome","T2_UK_London_Brunel", "T2_UK_London_IC","T2_US_Caltech","T2_US_MIT","T2_US_Nebraska","T2_US_Purdue","T2_US_UCSD","T2_US_Wisconsin","T2_US_Florida","T2_BE_IIHE","T2_EE_Estonia","T2_PL_Swierk","T2_CH_CERN","T2_CH_CERN_HLT","T2_TW_NCHC","T2_IN_TIFR","T2_HU_Budapest","T2_KR_KISTI","T2_BR_SPRACE","T2_RU_JINR","T2_UK_SGrid_RALPP","T2_US_Vanderbilt"],
     "description" : "The sites identified as having good AAA bandwidth"
  },
  "blow_up_limits" : {

--- a/unifiedConfiguration.json
+++ b/unifiedConfiguration.json
@@ -99,7 +99,11 @@
  },
  "sites_with_goodIO": {
     "value" : ["T2_CH_CSCS","T2_DE_DESY","T2_DE_RWTH","T2_ES_CIEMAT","T2_FR_GRIF_LLR", "T2_FR_GRIF_IRFU", "T2_FR_IPHC","T2_FR_CCIN2P3","T2_IT_Bari", "T2_IT_Legnaro", "T2_IT_Pisa", "T2_IT_Rome","T2_UK_London_Brunel", "T2_UK_London_IC","T2_US_Caltech","T2_US_MIT","T2_US_Nebraska","T2_US_Purdue","T2_US_UCSD","T2_US_Wisconsin","T2_US_Florida","T2_BE_IIHE","T2_EE_Estonia","T2_PL_Swierk","T2_CH_CERN","T2_CH_CERN_HLT"],
-    "description" : "The sites identified as having good storage badnwidth"
+    "description" : "The sites identified as having good storage bandwidth"
+ },
+ "sites_with_goodAAA": {
+    "value" : ["T2_CH_CSCS","T2_UA_KIPT","T2_US_Purdue","T2_TW_NCHC","T2_UK_SGrid_RALPP","T2_BE_UCL","T2_ES_IFCA","T2_DE_RWTH","T2_UK_SGrid_Bristol","T2_FR_IPHC","T2_DE_DESY","T2_IT_Legnaro","T2_US_Caltech","T2_UK_London_Brunel","T2_RU_JINR","T2_US_Vanderbilt","T2_EE_Estonia","T2_IT_Rome","T2_US_Florida","T2_UK_London_IC","T2_IT_Bari","T2_US_Nebraska","T2_FR_CCIN2P3","T2_US_UCSD","T2_CH_CERN_HLT","T2_ES_CIEMAT","T2_US_Wisconsin","T2_HU_Budapest","T2_CN_Beijing","T2_US_MIT","T2_BE_IIHE","T2_KR_KISTI","T2_RU_ITEP","T2_CH_CERN","T2_PT_NCG_Lisbon","T2_BR_SPRACE"],
+    "description" : "The sites identified as having good AAA bandwidth"
  },
  "blow_up_limits" : {
    "value" : [5,10],

--- a/utils.py
+++ b/utils.py
@@ -7353,8 +7353,10 @@ class workflowInfo:
         elif secondary:
             if self.heavyRead(secondary):
                 sites_allowed = sorted(set(SI.sites_T0s + SI.sites_T1s + SI.sites_with_goodIO))
+                print "Reading minbias"
             else:
                 sites_allowed = sorted(set(SI.sites_T0s + SI.sites_T1s + SI.sites_with_goodAAA))
+                print "Reading premix"
         elif primary:
             sites_allowed =sorted(set(SI.sites_T0s + SI.sites_T1s + SI.sites_T2s))# + SI.sites_T3s))
         else:

--- a/utils.py
+++ b/utils.py
@@ -2173,7 +2173,7 @@ class siteInfo:
         self.sites_veto_transfer = []  ## do not prevent any transfer by default
 
         ## new site lists for better matching
-        self.sites_with_goodAAA = self.sites_with_goodIO + add_on_good_aaa
+        self.sites_with_goodAAA = add_on_good_aaa
         self.sites_with_goodAAA = list(set([ s for s in self.sites_with_goodAAA if s in self.sites_ready]))
 
 
@@ -7355,7 +7355,7 @@ class workflowInfo:
             if self.heavyRead():
                 sites_allowed = sorted(set(SI.sites_T0s + SI.sites_T1s + SI.sites_with_goodIO))
             else:
-                sites_allowed = sorted(set(SI.sites_T0s + SI.sites_T1s + SI.sites_with_goodAAA))
+                sites_allowed = sorted(set(SI.sites_T0s + SI.sites_T1s + SI.sites_T2s + SI.sites_with_goodAAA))
         elif primary:
             sites_allowed =sorted(set(SI.sites_T0s + SI.sites_T1s + SI.sites_T2s))# + SI.sites_T3s))
         else:

--- a/utils.py
+++ b/utils.py
@@ -6549,7 +6549,7 @@ class workflowInfo:
         nersc_archs=set(['slc6_amd64_gcc530','slc6_amd64_gcc630'])
         good = (self.request['RequestType'] == 'StepChain' or no_step)  and self.request['RequestPriority'] <= 85000 and len(set(self.request['ScramArch'])&nersc_archs)>=1
         io = _,prim,_,sec = self.getIO()
-        if self.heavyRead(): good=False
+        if self.heavyRead(sec): good=False
         if prim: good = False
         #if sec: good = False
         ## should be of significant size. how do we check that ???
@@ -7330,13 +7330,11 @@ class workflowInfo:
                         max_blow_up = blow_up
             return (min_child_job_per_event, root_job_per_event, max_blow_up)
         return (1.,1.,1.)
-    def heavyRead(self):
-        ## this is an add-hoc way of doing this. True by default. False if "premix" appears in the output datasets or in the campaigns
-        response = True
-        if any(['premix' in c.lower() for c in self.getCampaigns()]):
-            response = False
-        if any(['premix' in o.lower() for o in self.request['OutputDatasets']]):
-            response = False
+    def heavyRead(self,secondary):
+        ## Fasle by default. True if "minbias" appears in the secondary
+        response = False
+        if any(['minbias' in c.lower() for c in secondary]):
+            response = True
         return response
     
     def producePremix(self):
@@ -7352,7 +7350,7 @@ class workflowInfo:
         if lheinput:
             sites_allowed = sorted(SI.sites_eos) #['T2_CH_CERN'] ## and that's it
         elif secondary:
-            if self.heavyRead():
+            if self.heavyRead(secondary):
                 sites_allowed = sorted(set(SI.sites_T0s + SI.sites_T1s + SI.sites_with_goodIO))
             else:
                 sites_allowed = sorted(set(SI.sites_T0s + SI.sites_T1s + SI.sites_T2s + SI.sites_with_goodAAA))

--- a/utils.py
+++ b/utils.py
@@ -2173,7 +2173,8 @@ class siteInfo:
         self.sites_veto_transfer = []  ## do not prevent any transfer by default
 
         ## new site lists for better matching
-        self.sites_with_goodAAA = add_on_good_aaa
+        self.sites_with_goodAAA = UC.get('sites_with_goodAAA')
+        self.sites_with_goodAAA = self.sites_with_goodAAA + add_on_good_aaa
         self.sites_with_goodAAA = list(set([ s for s in self.sites_with_goodAAA if s in self.sites_ready]))
 
 
@@ -7353,7 +7354,7 @@ class workflowInfo:
             if self.heavyRead(secondary):
                 sites_allowed = sorted(set(SI.sites_T0s + SI.sites_T1s + SI.sites_with_goodIO))
             else:
-                sites_allowed = sorted(set(SI.sites_T0s + SI.sites_T1s + SI.sites_T2s + SI.sites_with_goodAAA))
+                sites_allowed = sorted(set(SI.sites_T0s + SI.sites_T1s + SI.sites_with_goodAAA))
         elif primary:
             sites_allowed =sorted(set(SI.sites_T0s + SI.sites_T1s + SI.sites_T2s))# + SI.sites_T3s))
         else:


### PR DESCRIPTION
As discussed in the P&R meeting, we no longer require goodIO (T2 sites) for premix WFs, instead we choose all the T2 sites.

@haozturk @sharad1126 

