### PR TITLE
Push one more campaign parameter - toDDM - to central Couch

### DIFF
--- a/campaignAPI.py
+++ b/campaignAPI.py
@@ -111,6 +111,7 @@ def parseMongoCampaigns(campaigns, verbose=False):
         'SecondaryLocation': 'SecondaryLocation',
         'secondaries': 'Secondaries',
         'partial_copy': 'PartialCopy',
+        'toDDM': 'TiersToDM',
         'maxcopies': 'MaxCopies'}
     # campaign schema dict
     confRec = {
@@ -122,6 +123,7 @@ def parseMongoCampaigns(campaigns, verbose=False):
         'SecondaryLocation': [],
         'Secondaries': {},
         'PartialCopy': 1,
+        'TiersToDM': [],
         'MaxCopies': 1}
 
     if not isinstance(campaigns, list):


### PR DESCRIPTION
Fixes https://github.com/dmwm/WMCore/issues/9756

#### Status
not-tested

#### Description
As we have recently learned, campaign configurations can have a specific parameter `toDDM` which can be used to make sure that a given datatier gets a nonCustodial output data placement, even if that same datatier is blacklisted in the Unified campaign.

That means, Unified needs to start publishing this parameter to the campaigns uploaded to central CouchDB. This schema change should parse the Unified campaign configuration and convert that value into `TiersToDM`, which will then get posted to central CouchDB campaign.

Once this PR gets merged, I'll update all the campaigns already available in central CouchDB.

#### Is it backward compatible (if not, which system it affects?)
No, in the sense that there is a campaign schema change in WMCore.

#### Related PRs
WMCore: https://github.com/dmwm/WMCore/pull/9906

#### External dependencies / deployment changes
none

#### Mention people to look at PRs
@haozturk @z4027163 I really don't want to rush you with this, but this needs to be tested and merged before the CMSWEB production upgrade is finished on the coming Tuesday morning :-D