### PR TITLE
Skip string for rucio testing

### DIFF
--- a/Unified/checkor.py
+++ b/Unified/checkor.py
@@ -236,7 +236,7 @@ def checkor(url, spec=None, options=None):
     for iwfo,wfo in enumerate(wfs):
         ## do the check other one workflow
         if spec and not (spec in wfo.name): continue
-        if not options.manual and 'rucio' in (wfo.name).lower(): continue
+        if not spec and 'rucio' in (wfo.name).lower(): continue
         checkers.append( CheckBuster(
             will_do_that_many = will_do_that_many,
             url = url,

--- a/Unified/checkor.py
+++ b/Unified/checkor.py
@@ -236,6 +236,7 @@ def checkor(url, spec=None, options=None):
     for iwfo,wfo in enumerate(wfs):
         ## do the check other one workflow
         if spec and not (spec in wfo.name): continue
+        if not options.manual and 'rucio' in (wfo.name).lower(): continue
         checkers.append( CheckBuster(
             will_do_that_many = will_do_that_many,
             url = url,

--- a/Unified/closor.py
+++ b/Unified/closor.py
@@ -151,7 +151,7 @@ def spawn_harvesting(url, wfi , in_full):
 def closor(url, specific=None, options=None):
     if userLock(): return
     mlock  = moduleLock()
-    if mlock(): return
+    if mlock() and not options.manual: return
     up = componentInfo(soft=['mcm','wtc'])
     if not up.check(): return
 
@@ -207,7 +207,7 @@ def closor(url, specific=None, options=None):
 
     for iwfo,wfo in enumerate(wfs):
         if specific and not specific in wfo.name: continue
-
+        if not options.manual and 'rucio' in (wfo.name).lower(): continue
         closers.append( CloseBuster(
             wfo = wfo,
             url = url,
@@ -655,6 +655,7 @@ if __name__ == "__main__":
     parser.add_option('--force', help="Force pushing the workflow through", default=False,action='store_true')
     parser.add_option('--announce', help="Announce the outputs that should be announced", default=False,action='store_true')
     parser.add_option('--threads',help='Number of threads for processing workflows',default=5, type=int)
+    parser.add_option('-m','--manual', help='Manual close, bypassing lock check',action='store_true',dest='manual',default=False)
     (options,args) = parser.parse_args()
 
     spec=None

--- a/Unified/equalizor.py
+++ b/Unified/equalizor.py
@@ -386,6 +386,7 @@ def equalizor(url , specific = None, options=None):
 
         if specific and not specific in wfo.name: 
             continue
+        if not options.manual and 'rucio' in (wfo.name).lower(): continue 
         if specific:
             wfi = workflowInfo(url, wfo.name)
         else:

--- a/Unified/injector.py
+++ b/Unified/injector.py
@@ -42,6 +42,8 @@ def injector(url, options, specific):
     for wf in workflows:
         if specific and not specific in wf: continue
 
+        if not options.manual and 'rucio' in wf.lower(): continue
+
         exists = session.query(Workflow).filter(Workflow.name == wf ).first()
         if not exists:
             wfi = workflowInfo(url, wf)
@@ -143,6 +145,7 @@ def injector(url, options, specific):
     for wf in session.query(Workflow).filter(Workflow.status == 'trouble').all():
         print wf.name
         if specific and not specific in wf.name: continue
+        if not options.manual and 'rucio' in wf.lower(): continue
         print wf.name
         wfi = workflowInfo(url, wf.name )
         wl = wfi.request #getWorkLoad(url, wf.name)

--- a/Unified/subscribor.py
+++ b/Unified/subscribor.py
@@ -48,7 +48,7 @@ for iw,wfn in enumerate(wfs):
         wl = getWorkLoad(url, wfn)
 
     print "%s/%s:"%(iw,len(wfs)),wfn
-
+    if 'rucio' in wfn.lower(): continue
     if not wl:
         continue
     outs= wl['OutputDatasets']


### PR DESCRIPTION
This change is for rucio testing WF. Ignore WFs that contain string 'rucio' in several modules unless those are run manully. 
Therefore we can create a separate branch where we can run those module manually on rucio testing WF.