### PR TITLE
Remove ban of T2_EE_Estonia from production jobs

### DIFF
--- a/unifiedConfiguration.json
+++ b/unifiedConfiguration.json
@@ -82,7 +82,6 @@
  "sites_banned": {
    "value" : ["T2_CH_CERN_AI",
 	      "T2_TH_CUNSTDA",
-	      "T2_EE_Estonia",
 	      "T0_CH_CERN",
 	      "T0_CH_CSCS_HPC"
  	      ],


### PR DESCRIPTION
Since T2_EE_Estonia site is banned from production for 4 years, it's decided to remove this restriction and monitor the site's status in the upcoming days. The site performed well in the test workflow that we have assigned in the past weeks: 
https://dmytro.web.cern.ch/dmytro/cmsprodmon/workflows.php?prep_id=TEST-task_TOP-RunIISummer19UL17wmLHEGEN-00126

@z4027163 FYI