### PR TITLE
Allow auto-approve for tape requests against JINR MSS storage

### DIFF
--- a/unifiedConfiguration.json
+++ b/unifiedConfiguration.json
@@ -88,7 +88,7 @@
    "description" : "The sites that are banned from production"
  },		 
  "sites_auto_approve": {
-   "value" : ["T0_CH_CERN_MSS","T1_FR_CCIN2P3_MSS","T1_IT_CNAF_MSS"],
+   "value" : ["T0_CH_CERN_MSS","T1_FR_CCIN2P3_MSS","T1_IT_CNAF_MSS", "T1_RU_JINR_MSS"],
    "description" : "The sites we can autoapprove tape request to"
  },
  "sites_space_override": {	


### PR DESCRIPTION
No issue created

#### Status
ready

#### Description
I just confirmed with the site admin (Valery) and he gave us the green light to make auto-approved transfer requests against their MSS endpoint.

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
none

#### External dependencies / deployment changes
none

#### Mention people to look at PRs
@haozturk feel free to merge it at any time, preferable before we enable MSOutput.
