### PR TITLE
Temporarily stop completed to closed out transition

### DIFF
--- a/acrontab.list
+++ b/acrontab.list
@@ -16,10 +16,10 @@
 15 */4 * * * vocms0269 /data/unified/WmAgentScripts/cWrap.sh Unified/stuckor.py &> /dev/null
 20,50 * 1-31 * * vocms0269 /data/unified/WmAgentScripts/assigncycle.sh &> /dev/null
 #30 */4 1-31 * * vocms0269 /data/unified/WmAgentScripts/unlockingcycle.sh &> /dev/null
-10,40 * 1-31 * * vocms0273 /data/unified/WmAgentScripts/postcycle-strict.sh &> /dev/null
-15,45 * 1-31 * * vocms0273 /data/unified/WmAgentScripts/postcycle-update.sh &> /dev/null
-20,50 * 1-31 * * vocms0268 /data/unified/WmAgentScripts/postcycle-review-recovering.sh &> /dev/null
-25,55 * 1-31 * * vocms0269 /data/unified/WmAgentScripts/postcycle-review-manual.sh &> /dev/null
+#10,40 * 1-31 * * vocms0273 /data/unified/WmAgentScripts/postcycle-strict.sh &> /dev/null
+#15,45 * 1-31 * * vocms0273 /data/unified/WmAgentScripts/postcycle-update.sh &> /dev/null
+#20,50 * 1-31 * * vocms0268 /data/unified/WmAgentScripts/postcycle-review-recovering.sh &> /dev/null
+#25,55 * 1-31 * * vocms0269 /data/unified/WmAgentScripts/postcycle-review-manual.sh &> /dev/null
 */5 * 1-31 * * vocms0269 /data/unified/WmAgentScripts/actcycle.sh &> /dev/null
 30,50 * 1-31 * * vocms0272 /data/unified/WmAgentScripts/clearcycle.sh  &> /dev/null
 25,55 * 1-31 * * vocms0268 /data/unified/WmAgentScripts/shortcycle.sh &> /dev/null


### PR DESCRIPTION
#### Status
not-tested

#### Description
This is the first step of disabling output data placement in Unified and enabling it WMCore:
1. stop unified moving workflows from "completed" to "closed-out".
2. run Unified closor module until all workflows in "closed-out" are moved to "announced" (here, Unified making the necessary placement)
3. CHECK: Unified must have moved all workflows from closed-out to announced
4. CHECK: MSOutput must have processed the same workflows in DRY-RUN (thus, no actual data placement. Workflows get marked as "done")
5. if the two checks above are satisfied, merge this Unified PR: https://github.com/CMSCompOps/WmAgentScripts/pull/653
6. re-enable all modules in Unified
7. fully enable MSOutput in production - thus, output data placement now go through MSOutput

#### Is it backward compatible (if not, which system it affects?)
YES 

#### Mention people to look at PRs
@z4027163 FYI
