### PR TITLE
Allow LHE datatier to be subscribed to Disk

### DIFF
--- a/unifiedConfiguration.json
+++ b/unifiedConfiguration.json
@@ -223,11 +223,11 @@
    "description": "The data tiers that do not pass closeout checks. Can be overidden by custodial overide at campaign level"
  },
  "tiers_no_DDM": {
-   "value" : ["GEN-SIM","LHE","GEN","SIM","DQM","DQMIO","GEN-SIM-DIGI-RAW","RAW","GEN-SIM-DIGI"],
+   "value" : ["GEN-SIM","GEN","SIM","DQM","DQMIO","GEN-SIM-DIGI-RAW","RAW","GEN-SIM-DIGI"],
    "description": "The data tiers that do not go to AnaOps"
  },
  "tiers_to_DDM": {
-   "value" : ["GEN-SIM-DIGI-RAW-MINIAOD","AODSIM","MINIAODSIM","GEN-SIM-RAW","GEN-SIM-RECO","GEN-SIM-RECODEBUG","AOD","RECO","MINIAOD","ALCARECO","USER","RAW-RECO","RAWAODSIM","NANOAOD","NANOAODSIM","FEVT","PREMIX"],
+   "value" : ["LHE", "GEN-SIM-DIGI-RAW-MINIAOD","AODSIM","MINIAODSIM","GEN-SIM-RAW","GEN-SIM-RECO","GEN-SIM-RECODEBUG","AOD","RECO","MINIAOD","ALCARECO","USER","RAW-RECO","RAWAODSIM","NANOAOD","NANOAODSIM","FEVT","PREMIX"],
    "description": "The data tiers that go to AnaOps"
  },
  "tiers_to_rucio_relval": {


### PR DESCRIPTION
No issue created

#### Status
ready

#### Description
It looks like Unified was relying on the unified parameter `tiers_keep_on_disk` to keep the LHE output datasets on disk (without any disk subscription?).
We overlooked that parameter when implementing MSOutput, so I suggest we actually allow this datatier to be subscribed to Disk. It will anyways be used as input dataset for other workflow(s). So we must have it on disk.

E.g. from MSOutput:
```
2020-09-24 08:49:17,143:WARNING:MSOutput: Output dataset configured to 0 copies, so skipping it. Details:
        Workflow name: pdmvserv_task_HIG-RunIIFall17pLHE-00040__v1_T_200813_142709_4652
        Dataset name: /SUSYGluGluToBBHToTauTau_M2900_TuneCP5_13TeV-powheg-pythia8/RunIIFall17pLHE-93X_mc2017_realistic_v3-v1/LHE
        Campaign name: RunIIFall17pLHE
```

we will have to chase those workflows that didn't create an LHE subscription and make standalone DDM requests :(

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
none

#### External dependencies / deployment changes
none

#### Mention people to look at PRs
@haozturk @z4027163 the sooner we merge it the better.