### PR TITLE
Phedex2Rucio transition: Stop running stuckor module

### DIFF
--- a/acrontab.list
+++ b/acrontab.list
@@ -13,7 +13,7 @@
 */40 * * * * vocms0275 /data/unified/WmAgentScripts/cWrap.sh Unified/pushor.py &> /dev/null
 */5 * * * * vocms0275 source /data/unified/WmAgentScripts/whatjob.sh > /eos/cms/store/unified/www/info.txt 2> /dev/null
 ## single script that cycles through modules
-15 */4 * * * vocms0269 /data/unified/WmAgentScripts/cWrap.sh Unified/stuckor.py &> /dev/null
+#15 */4 * * * vocms0269 /data/unified/WmAgentScripts/cWrap.sh Unified/stuckor.py &> /dev/null
 20,50 * 1-31 * * vocms0269 /data/unified/WmAgentScripts/assigncycle.sh &> /dev/null
 #30 */4 1-31 * * vocms0269 /data/unified/WmAgentScripts/unlockingcycle.sh &> /dev/null
 10,40 * 1-31 * * vocms0273 /data/unified/WmAgentScripts/postcycle-strict.sh &> /dev/null


### PR DESCRIPTION
Fixes #662 

#### Status
ready

#### Description
As discussed in the tagged issue, the responsibility of the stuckor module is out of the scope of Unified anymore. This PR stops running the stuckor module. In the upcoming weeks/months, we should evaluate the need of such monitoring from the perspective of workflow management. If needed, developing a new solution should be discussed.

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
None

#### External dependencies / deployment changes
None

#### Mention people to look at PRs
@z4027163 FYI
