### PR TITLE
Stop running subcribor module

### DIFF
--- a/acrontab.list
+++ b/acrontab.list
@@ -24,7 +24,7 @@
 30,50 * 1-31 * * vocms0272 /data/unified/WmAgentScripts/clearcycle.sh  &> /dev/null
 25,55 * 1-31 * * vocms0268 /data/unified/WmAgentScripts/shortcycle.sh &> /dev/null
 5,35 * 1-31 * * vocms0269 /data/unified/WmAgentScripts/gqcycle.sh &> /dev/null
-45,15 * 1-31 * * vocms0268 /data/unified/WmAgentScripts/subscribecycle.sh &> /dev/null
+#45,15 * 1-31 * * vocms0268 /data/unified/WmAgentScripts/subscribecycle.sh &> /dev/null
 */10 * 1-31 * * vocms0268 /data/unified/WmAgentScripts/viewcycle.sh &> /dev/null
 45 */4 1-31 * * vocms0268 /data/unified/WmAgentScripts/remainingcycle.sh  &> /dev/null
 */15 * 1-31 * * vocms0272 /data/unified/WmAgentScripts/errorcycle.sh &> /dev/null


### PR DESCRIPTION

#### Status
ready

#### Description
This PR stops running subscribor module.

The subscription ability of the subscribor module has been removed with this PR #653 . The remaining code currently does nothing and since Unified does not do any output data placement anymore, this module could stop running.

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
#653 

#### External dependencies / deployment changes
none

#### Mention people to look at PRs
@z4027163  FYI
