### PR TITLE
Clear Redundant Phedex Dependencies

### DIFF
--- a/Unified/checkor.py
+++ b/Unified/checkor.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 from assignSession import *
-from utils import getWorkflows, workflowInfo, getDatasetEventsAndLumis, getDatasetEventsPerLumi, siteInfo, getDatasetPresence, campaignInfo, getWorkflowById, forceComplete, getDatasetSize, getDatasetFiles, sendLog, reqmgr_url, dbs_url, dbs_url_writer, display_time, checkMemory, ThreadHandler, wtcInfo
+from utils import getWorkflows, workflowInfo, getDatasetEventsAndLumis, getDatasetEventsPerLumi, siteInfo, campaignInfo, getWorkflowById, forceComplete, getDatasetSize, getDatasetFiles, sendLog, reqmgr_url, dbs_url, dbs_url_writer, display_time, checkMemory, ThreadHandler, wtcInfo
 from utils import componentInfo, unifiedConfiguration, userLock, moduleLock, dataCache, unified_url, getDatasetLumisAndFiles, getDatasetRuns, duplicateAnalyzer, invalidateFiles, findParent, do_html_in_each_module, phedex_url
 import phedexClient
 import dbs3Client
@@ -983,9 +983,9 @@ class CheckBuster(threading.Thread):
             is_closing = False 
 
 
-        any_presence = {}
-        for output in wfi.request['OutputDatasets']:
-            any_presence[output] = getDatasetPresence(url, output, vetoes=[])
+        #any_presence = {}
+        #for output in wfi.request['OutputDatasets']:
+        #    any_presence[output] = getDatasetPresence(url, output, vetoes=[])
 
         time_point("checked dataset presence", sub_lap=True)
 
@@ -1294,13 +1294,13 @@ class CheckBuster(threading.Thread):
         time_point("determined tape location", sub_lap=True)
 
         ## disk copy 
-        disk_copies = {}
-        for output in wfi.request['OutputDatasets']:
-            disk_copies[output] = [s for s in any_presence[output] if (not 'MSS' in s) and (not 'Buffer' in s)]
+        #disk_copies = {}
+        #for output in wfi.request['OutputDatasets']:
+        #    disk_copies[output] = [s for s in any_presence[output] if (not 'MSS' in s) and (not 'Buffer' in s)]
 
-        if not all(map( lambda sites : len(sites)!=0, disk_copies.values())):
-            print wfo.name,"has not all output on disk"
-            print json.dumps(disk_copies, indent=2)
+        #if not all(map( lambda sites : len(sites)!=0, disk_copies.values())):
+        #    print wfo.name,"has not all output on disk"
+        #    print json.dumps(disk_copies, indent=2)
 
 
 
@@ -1341,7 +1341,7 @@ class CheckBuster(threading.Thread):
             rec['fractionpass'] = math.floor(fractions_pass.get(output,0)*10000)/100.
             rec['duplicate'] = duplications[output] if output in duplications else 'N/A'
             rec['closeOutDataset'] = is_closing
-            rec['transPerc'] = float('%.2f'%any_presence[output][ disk_copies[output][0]][1]) if len(disk_copies[output])!=0 else 'N/A'
+            #rec['transPerc'] = float('%.2f'%any_presence[output][ disk_copies[output][0]][1]) if len(disk_copies[output])!=0 else 'N/A'
             rec['correctLumis'] = int(events_per_lumi[output]) if (events_per_lumi[output] > lumi_upper_limit[output]) else True
             rec['dbsFiles'] = dbs_presence[output]
             rec['dbsInvFiles'] = dbs_invalid[output]

--- a/Unified/checkor.py
+++ b/Unified/checkor.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 from assignSession import *
-from utils import getWorkflows, workflowInfo, getDatasetEventsAndLumis, findCustodialLocation, getDatasetEventsPerLumi, siteInfo, getDatasetPresence, campaignInfo, getWorkflowById, forceComplete, getDatasetSize, getDatasetFiles, sendLog, reqmgr_url, dbs_url, dbs_url_writer, display_time, checkMemory, ThreadHandler, wtcInfo
+from utils import getWorkflows, workflowInfo, getDatasetEventsAndLumis, getDatasetEventsPerLumi, siteInfo, getDatasetPresence, campaignInfo, getWorkflowById, forceComplete, getDatasetSize, getDatasetFiles, sendLog, reqmgr_url, dbs_url, dbs_url_writer, display_time, checkMemory, ThreadHandler, wtcInfo
 from utils import componentInfo, unifiedConfiguration, userLock, moduleLock, dataCache, unified_url, getDatasetLumisAndFiles, getDatasetRuns, duplicateAnalyzer, invalidateFiles, findParent, do_html_in_each_module, phedex_url
 import phedexClient
 import dbs3Client
@@ -55,13 +55,6 @@ def checkor(url, spec=None, options=None):
     use_mcm = True
     up = componentInfo(soft=['mcm','wtc'])
     if not up.check(): return
-    #phedex check    
-    try:
-        print "checking on phedex"
-        cust = findCustodialLocation(phedex_url,'/TTJets_mtop1695_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIIWinter15GS-MCRUN2_71_V1-v1/GEN-SIM')
-    except Exception as e:
-        print "fail phedex fail"
-        return   
 
     use_mcm = up.status['mcm']
 

--- a/Unified/closor.py
+++ b/Unified/closor.py
@@ -8,7 +8,7 @@ import json
 import time
 import sys
 import os
-from utils import getDatasetEventsAndLumis, campaignInfo, getDatasetPresence, findLateFiles, updateSubscription, getWorkflowByCampaign
+from utils import getDatasetEventsAndLumis, campaignInfo, getDatasetPresence, getWorkflowByCampaign
 from htmlor import htmlor
 from collections import defaultdict
 import reqMgrClient
@@ -456,11 +456,11 @@ class CloseBuster(threading.Thread):
                 print json.dumps( at_destination )
                 print json.dumps( else_where, indent=2 )
                 ## do the full stuck transfer study, missing files and shit !
-                for there in going_to:
-                    late_info = findLateFiles(url, out, going_to = there )
-                    for l in late_info:
-                        l.update({"workflow":wfo.name,"dataset":out})
-                    self.all_late_files.extend( late_info )
+                #for there in going_to:
+                #    late_info = findLateFiles(url, out, going_to = there )
+                #    for l in late_info:
+                #        l.update({"workflow":wfo.name,"dataset":out})
+                #    self.all_late_files.extend( late_info )
                 if check_fullcopy_to_announce:
                     ## only set this false if the check is relevant
                     all_OK[out] = False

--- a/Unified/htmlor.py
+++ b/Unified/htmlor.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 from assignSession import *
 import time
-from utils import getWorkLoad, campaignInfo, siteInfo, getWorkflows, unifiedConfiguration, getPrepIDs, componentInfo, getAllAgents, sendLog, moduleLock, dataCache, agentInfo, display_time, eosFile, eosRead, StartStopInfo, remainingDatasetInfo, findCustodialLocation
+from utils import getWorkLoad, campaignInfo, siteInfo, getWorkflows, unifiedConfiguration, getPrepIDs, componentInfo, getAllAgents, sendLog, moduleLock, dataCache, agentInfo, display_time, eosFile, eosRead, StartStopInfo, remainingDatasetInfo
 import os
 import json
 from collections import defaultdict
@@ -15,14 +15,7 @@ def htmlor( caller = ""):
     if mlock(): return
 
     up = componentInfo(soft=['mcm','wtc','jira'])
-    if not up.check(): return 
-    #phedex check    
-    try:
-        print "checking on phedex"
-        cust = findCustodialLocation(phedex_url,'/TTJets_mtop1695_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIIWinter15GS-MCRUN2_71_V1-v1/GEN-SIM')
-    except Exception as e:
-        print "fail phedex fail"
-        return  
+    if not up.check(): return  
 
     for backup in ['statuses.json','siteInfo.json','equalizor.json']:
         print "copying",backup,"to old location"

--- a/Unified/injector.py
+++ b/Unified/injector.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 from assignSession import *
-from utils import getWorkflows, getWorkflowById, getWorkLoad, componentInfo, sendEmail, workflowInfo, sendLog, reqmgr_url, getDatasetStatus, unifiedConfiguration, moduleLock, do_html_in_each_module, getDatasetFiles
+from utils import getWorkflows, getWorkflowById, getWorkLoad, componentInfo, sendEmail, workflowInfo, sendLog, reqmgr_url, getDatasetStatus, unifiedConfiguration, moduleLock, do_html_in_each_module
 import sys
 import copy
 import os
@@ -91,11 +91,11 @@ def injector(url, options, specific):
                 #    closeAllBlocks(url, d)
 
                 ## check for any file in phedex, to verify existence
-                _,ph_files,_,_ = getDatasetFiles(url, d)
-                if not ph_files and not ( 'StoreResults' == wfi.request.setdefault('RequestType',None) ):
-                    wfi.sendLog('injector',"One of the input has no file in phedex: %s" % d )
-                    sendLog('injector',"One of the input has no file in phedex: %s"% d, level='critical')
-                    can_add = False
+                #_,ph_files,_,_ = getDatasetFiles(url, d)
+                #if not ph_files and not ( 'StoreResults' == wfi.request.setdefault('RequestType',None) ):
+                #    wfi.sendLog('injector',"One of the input has no file in phedex: %s" % d )
+                #    sendLog('injector',"One of the input has no file in phedex: %s"% d, level='critical')
+                #    can_add = False
 
             ### ban some workflow that you don't like anymore
             #outputs = wfi.request['OutputDatasets']

--- a/Unified/showError.py
+++ b/Unified/showError.py
@@ -357,44 +357,47 @@ def parse_one(url, wfn, options=None):
     html += '<a name=IO></a>'
     if prim:
         html+='Reads in primary<br>'
-        blocks = wfi.getBlocks()
+        #blocks = wfi.getBlocks()
         for dataset in prim:
             html +='<b>%s </b>(events/lumi ~%d)'%(dataset, getDatasetEventsPerLumi( dataset))
+            html += '<br>'
+        #    available = getDatasetBlocksFraction(url, dataset, only_blocks = blocks )
+        #    html +='<br><br>Available %.2f (>1 more than one copy, <1 not in full on disk)<br>'% available
+        #    html +='<ul>'
+        #    presence = getDatasetPresence(url, dataset, only_blocks = blocks )
 
-            available = getDatasetBlocksFraction(url, dataset, only_blocks = blocks )
-            html +='<br><br>Available %.2f (>1 more than one copy, <1 not in full on disk)<br>'% available
-            html +='<ul>'
-            presence = getDatasetPresence(url, dataset, only_blocks = blocks )
+        #    for site in sorted(presence.keys()):
+        #        html += '<li>%s : %.2f %%'%( site, presence[site][1] )
+        #        IO_doc.setdefault('primary',{}).setdefault(dataset,{})[site] = presence[site][1]
+        #    html+='</ul><br>'
 
-            for site in sorted(presence.keys()):
-                html += '<li>%s : %.2f %%'%( site, presence[site][1] )
-                IO_doc.setdefault('primary',{}).setdefault(dataset,{})[site] = presence[site][1]
-            html+='</ul><br>'
 
             
     if sec:
         html+='Reads in secondary<br>'
         for dataset in sec:
-            presence = getDatasetPresence(url, dataset)
+        #    presence = getDatasetPresence(url, dataset)
             html +='<b>%s</b><ul>'%dataset
-            for site in sorted(presence.keys()):
-                html += '<li>%s : %.2f %%'%( site, presence[site][1] )
-                IO_doc.setdefault('secondary',{}).setdefault(dataset,{})[site] = presence[site][1]
-            html+='</ul>'
+            html += '<br>'
+        #    for site in sorted(presence.keys()):
+        #        html += '<li>%s : %.2f %%'%( site, presence[site][1] )
+        #        IO_doc.setdefault('secondary',{}).setdefault(dataset,{})[site] = presence[site][1]
+        #    html+='</ul>'
         
 
     outs = sorted(wfi.request['OutputDatasets'])
     if outs:
         html+='Produces<br>'
         for dataset in outs:
-            presence = getDatasetPresence(url, dataset)
+        #    presence = getDatasetPresence(url, dataset)
             epl = getDatasetEventsPerLumi(dataset)
             html +='<b>%s </b>(events/lumi ~ %d)<ul>'%(dataset, epl)
-            IO_doc.setdefault('outputs',{}).setdefault(dataset,{})['eventsperlumi'] = epl
-            for site in sorted(presence.keys()):
-                html += '<li>%s : %.2f %%'%( site, presence[site][1] )
-                IO_doc.setdefault('outputs',{}).setdefault(dataset,{}).setdefault('location',{})[site] = presence[site][1]
-            html+='</ul>'
+            html += '<br>'
+        #    IO_doc.setdefault('outputs',{}).setdefault(dataset,{})['eventsperlumi'] = epl
+        #    for site in sorted(presence.keys()):
+        #        html += '<li>%s : %.2f %%'%( site, presence[site][1] )
+        #        IO_doc.setdefault('outputs',{}).setdefault(dataset,{}).setdefault('location',{})[site] = presence[site][1]
+        #    html+='</ul>'
             
     time_point("Input checked")
 

--- a/Unified/showError.py
+++ b/Unified/showError.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-from utils import workflowInfo, siteInfo, monitor_dir, monitor_pub_dir, base_dir, global_SI, getDatasetPresence, getDatasetBlocksFraction, getDatasetBlocks, unifiedConfiguration, getDatasetEventsPerLumi, dataCache, unified_url, base_eos_dir, monitor_eos_dir, unified_url_eos, eosFile, ThreadHandler, moduleLock, reportInfo
+from utils import workflowInfo, siteInfo, monitor_dir, monitor_pub_dir, base_dir, global_SI, unifiedConfiguration, getDatasetEventsPerLumi, dataCache, unified_url, base_eos_dir, monitor_eos_dir, unified_url_eos, eosFile, ThreadHandler, moduleLock, reportInfo
 import time
 
 import json


### PR DESCRIPTION
Fixes #669 

#### Status
not tested

#### Description
1. Remove phedex dependant findLateFiles function which is redundant in the new implementatio
2. Remove findCustodialLocation function in checkor which is only used for phedex check
3. Remove findCustodialLocation function in htmlor which is only used for phedex check
4. disable dataset presence and block fraction info in the error reports
5. Remove getDatasetPresence function from checkor module
6. Remove getDatasetFiles function from injector

#### Is it backward compatible (if not, which system it affects?)
no

#### Related PRs
none

#### External dependencies / deployment changes
none

#### Mention people to look at PRs
@z4027163  FYI
