### PR TITLE
Stop running GQ

### DIFF
--- a/acrontab.list
+++ b/acrontab.list
@@ -23,7 +23,7 @@
 */5 * 1-31 * * vocms0269 /data/unified/WmAgentScripts/actcycle.sh &> /dev/null
 30,50 * 1-31 * * vocms0272 /data/unified/WmAgentScripts/clearcycle.sh  &> /dev/null
 25,55 * 1-31 * * vocms0268 /data/unified/WmAgentScripts/shortcycle.sh &> /dev/null
-5,35 * 1-31 * * vocms0269 /data/unified/WmAgentScripts/gqcycle.sh &> /dev/null
+#5,35 * 1-31 * * vocms0269 /data/unified/WmAgentScripts/gqcycle.sh &> /dev/null
 #45,15 * 1-31 * * vocms0268 /data/unified/WmAgentScripts/subscribecycle.sh &> /dev/null
 */10 * 1-31 * * vocms0268 /data/unified/WmAgentScripts/viewcycle.sh &> /dev/null
 45 */4 1-31 * * vocms0268 /data/unified/WmAgentScripts/remainingcycle.sh  &> /dev/null


### PR DESCRIPTION
Fixes #675 
#### Status
ready

#### Description
As discussed in the Rucio transition meeting, we will stop running GQ module and use https://cmsweb.cern.ch/couchdb/workqueue/_design/WorkQueue/_rewrite/stuckElementsInfo to monitor stuck workflows. This link does not show all stuck workflows right now. 
@amaltaro  will fix it in the upcoming weeks.

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
none

#### External dependencies / deployment changes
none

#### Mention people to look at PRs
@z4027163  @amaltaro FYI
