### PR TITLE
Remove dynamo lock check from assignor

### DIFF
--- a/Unified/assignor.py
+++ b/Unified/assignor.py
@@ -26,7 +26,8 @@ def assignor(url ,specific = None, talk=True, options=None):
     ###NLI = newLockInfo()
     ###if not NLI.free() and not options.go: return
     LI = lockInfo()
-    if not LI.free() and not options.go and not options.manual: return
+    #if not LI.free() and not options.go and not options.manual: return
+    if not options.go and not options.manual: return
 
     n_assigned = 0
     n_stalled = 0

--- a/utils.py
+++ b/utils.py
@@ -790,11 +790,11 @@ def _lock_DDM(owner=None, lock=True, wait=True, timeout=None):
 class lockInfo:
     def __init__(self, andwrite=True):
         self.owner = "%s-%s"%(socket.gethostname(), os.getpid())
-        self.ddmlock = DynamoLock( owner = None, timeout = 10*60)
+        #self.ddmlock = DynamoLock( owner = None, timeout = 10*60)
         self.unifiedlock = UnifiedLock()
 
-    def free(self):
-        return self.ddmlock.free()
+    #def free(self):
+    #    return self.ddmlock.free()
         
     def release(self, item ):
         try:


### PR DESCRIPTION
Fixes #683 

#### Status
not tested

#### Description
We do not need dynamo locking in assignor, since there is no DDM call in the module.

#### Is it backward compatible (if not, which system it affects?)
No

#### Related PRs
None

#### External dependencies / deployment changes
None

#### Mention people to look at PRs
@z4027163 
