### PR TITLE
Adding neutrinoGun sample for 20UL16DigiPremix* campaigns

### DIFF
--- a/campaigns.json
+++ b/campaigns.json
@@ -1769,10 +1769,6 @@
     "tune": true
   }, 
   "RunIISummer20UL16DIGIPremix": {
-    "SecondaryLocation": [
-      "T1_US_FNAL", 
-      "T2_CH_CERN"
-    ], 
     "fractionpass": 0.95, 
     "go": true, 
     "lumisize": -1, 
@@ -1786,7 +1782,12 @@
     }, 
     "resize": "auto", 
     "secondaries": {
-      "/Neutrino_E-10_gun/RunIISummer19ULPrePremix-UL16_106X_mcRun2_asymptotic_v10-v2/PREMIX": {}
+      "/Neutrino_E-10_gun/RunIISummer20ULPrePremix-UL16_106X_mcRun2_asymptotic_v13-v1/PREMIX": {
+            "SecondaryLocation": [
+          "T1_US_FNAL",
+          "T2_CH_CERN"
+        ]
+      }
     }, 
     "secondary_AAA": true, 
     "tune": true
@@ -1805,7 +1806,7 @@
     }, 
     "resize": "auto", 
     "secondaries": {
-      "/Neutrino_E-10_gun/RunIISummer19ULPrePremix-UL16_106X_mcRun2_asymptotic_v10-v2/PREMIX": {
+      "/Neutrino_E-10_gun/RunIISummer20ULPrePremix-UL16_106X_mcRun2_asymptotic_v13-v1/PREMIX": {
         "SecondaryLocation": [
           "T1_US_FNAL", 
           "T2_CH_CERN"


### PR DESCRIPTION
Updated neutrinoGun samples for the RunIISumer20UL16DigiPremix* campaigns from the 19 neutrino one to the 20 neutrino one. Also removed the top site list for one of the campaings.