### PR TITLE
Add UCL and Beijing to goodAAA

### DIFF
--- a/unifiedConfiguration.json
+++ b/unifiedConfiguration.json
@@ -101,7 +101,7 @@
     "description" : "The sites identified as having good storage bandwidth"
  },
  "sites_with_goodAAA": {
-    "value" : ["T2_CH_CSCS","T2_DE_DESY","T2_DE_RWTH","T2_ES_CIEMAT","T2_FR_GRIF_LLR", "T2_FR_GRIF_IRFU", "T2_FR_IPHC","T2_FR_CCIN2P3","T2_IT_Bari", "T2_IT_Legnaro", "T2_IT_Pisa", "T2_IT_Rome","T2_UK_London_Brunel", "T2_UK_London_IC","T2_US_Caltech","T2_US_MIT","T2_US_Nebraska","T2_US_Purdue","T2_US_UCSD","T2_US_Wisconsin","T2_US_Florida","T2_BE_IIHE","T2_EE_Estonia","T2_PL_Swierk","T2_CH_CERN","T2_CH_CERN_HLT","T2_TW_NCHC","T2_IN_TIFR","T2_HU_Budapest","T2_KR_KISTI","T2_BR_SPRACE","T2_RU_JINR","T2_UK_SGrid_RALPP","T2_US_Vanderbilt"],
+    "value" : ["T2_CH_CSCS","T2_DE_DESY","T2_DE_RWTH","T2_ES_CIEMAT","T2_FR_GRIF_LLR", "T2_FR_GRIF_IRFU", "T2_FR_IPHC","T2_FR_CCIN2P3","T2_IT_Bari", "T2_IT_Legnaro", "T2_IT_Pisa", "T2_IT_Rome","T2_UK_London_Brunel", "T2_UK_London_IC","T2_US_Caltech","T2_US_MIT","T2_US_Nebraska","T2_US_Purdue","T2_US_UCSD","T2_US_Wisconsin","T2_US_Florida","T2_BE_IIHE","T2_EE_Estonia","T2_PL_Swierk","T2_CH_CERN","T2_CH_CERN_HLT","T2_TW_NCHC","T2_IN_TIFR","T2_HU_Budapest","T2_KR_KISTI","T2_BR_SPRACE","T2_RU_JINR","T2_UK_SGrid_RALPP","T2_US_Vanderbilt","T2_BE_UCL","T2_CN_Beijing"],
     "description" : "The sites identified as having good AAA bandwidth"
  },
  "blow_up_limits" : {


### PR DESCRIPTION
#### Status
ready

#### Description
T2_BE_UCL and T2_CH_Beijing shows a good success with good pressure in running [our backfill test workflow](https://cmsweb.cern.ch/reqmgr2/fetch?rid=haozturk_TEST-BACKFILL-task_EGM-Run3Summer19wmLHEGS-00003__v1_T_201007_215727_4041) for goodAAA list:
```
T2_RU_IHEP: failure-exception:1, queued-retry:3211, success:60,
T2_CN_Beijing: transition:1, queued-retry:4, submitted-running:9, retry:588, pending:579, success:1897, cooloff-job:10,
T2_TR_METU: queued-retry:2404, submitted-retry:627, pending:627,
T2_RU_INR: queued-retry:143, submitted-retry:164, pending:164,
T2_BE_UCL: failure-exception:1, queued-retry:50, submitted-running:7, retry:1697, pending:1691, success:2240, cooloff-job:115
```
This PR adds these two sites to goodAAA list.
#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
Previous iteration: https://github.com/CMSCompOps/WmAgentScripts/pull/642

#### External dependencies / deployment changes
none
#### Mention people to look at PRs
@z4027163  FYI
