### PR TITLE
Include HEPCloud in the sitewhitelist of regular StepChain workflows

### DIFF
--- a/Unified/assignor.py
+++ b/Unified/assignor.py
@@ -113,6 +113,14 @@ def assignor(url ,specific = None, talk=True, options=None):
 
         ## the site whitelist takes into account siteInfo, campaignInfo, memory and cores
         (lheinput,primary,parent,secondary, sites_allowed) = wfh.getSiteWhiteList()
+
+        # Include HEPCloud sites in the sitewhitelist of non-classical-mixing StepChain requests
+        hepcloud_sites = UC.get('HEPCloud_sites')
+        if wfh.request['RequestType'] == 'StepChain' and not wfh.heavyRead(secondary):
+            sites_allowed += hepcloud_sites
+            wfh.sendLog('assignor',"Include HEPCloud in the sitewhitelist of %s"%wfo.name)
+
+
         output_tiers = list(set([o.split('/')[-1] for o in wfh.request['OutputDatasets']]))
 
         if not output_tiers:

--- a/unifiedConfiguration.json
+++ b/unifiedConfiguration.json
@@ -416,5 +416,9 @@
   "sites_for_DQMHarvest": {
     "value" : ["T2_CH_CERN","T1_US_FNAL"],
     "description" : "The sites to assign DQM/DMQIO harvesting workflows"
+  },
+  "HEPCloud_sites": {
+    "value" : ["T3_US_NERSC","T3_US_PSC","T3_US_SDSC","T3_US_TACC"],
+    "description" : "HEPCloud sites"
   }
 }


### PR DESCRIPTION
#### Status
Tested locally, not tested in production

#### Description
Include HEPCloud sites in the sitewhitelist of non-classical-mixing StepChain workflows in order to automate the assignments to these resources.

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
none

#### External dependencies / deployment changes
none

#### Mention people to look at PRs
@drkovalskyi @z4027163  FYI
