### PR TITLE
Remove pick_SE function call in checkor

### DIFF
--- a/Unified/checkor.py
+++ b/Unified/checkor.py
@@ -1263,9 +1263,9 @@ class CheckBuster(threading.Thread):
                 print "cannot use the custodial:",custodial,"because of limited space"
                 custodial = None
 
-            if not custodial and pick_custodial and not force_custodial:
+            #if not custodial and pick_custodial and not force_custodial:
                 ## pick one at random
-                custodial = SI.pick_SE(size=size_worth_checking)
+            #    custodial = SI.pick_SE(size=size_worth_checking)
 
             if custodial and size_worth_checking > tape_size_limit:
                 wfi.sendLog('checkor',"The total output size (%s TB) is too large for the limit set (%s TB)"%( size_worth_checking, tape_size_limit))


### PR DESCRIPTION
Fixes #691 

#### Status
not tested

#### Description
Remove the `pick_SE` function call in checkor which relies on Phedex node names.

#### Is it backward compatible (if not, which system it affects?)
no

#### External dependencies / deployment changes
none

#### Mention people to look at PRs
@z4027163  FYI
