### PR TITLE
Fix the logic in HEPCloud assignments

### DIFF
--- a/Unified/assignor.py
+++ b/Unified/assignor.py
@@ -114,11 +114,6 @@ def assignor(url ,specific = None, talk=True, options=None):
         ## the site whitelist takes into account siteInfo, campaignInfo, memory and cores
         (lheinput,primary,parent,secondary, sites_allowed) = wfh.getSiteWhiteList()
 
-        # Include HEPCloud sites in the sitewhitelist of non-classical-mixing StepChain requests
-        hepcloud_sites = UC.get('HEPCloud_sites')
-        if wfh.request['RequestType'] == 'StepChain' and not wfh.heavyRead(secondary):
-            sites_allowed += hepcloud_sites
-            wfh.sendLog('assignor',"Include HEPCloud in the sitewhitelist of %s"%wfo.name)
 
 
         output_tiers = list(set([o.split('/')[-1] for o in wfh.request['OutputDatasets']]))

--- a/utils.py
+++ b/utils.py
@@ -2177,6 +2177,9 @@ class siteInfo:
         self.sites_with_goodAAA = self.sites_with_goodAAA + add_on_good_aaa
         self.sites_with_goodAAA = list(set([ s for s in self.sites_with_goodAAA if s in self.sites_ready]))
 
+        self.HEPCloud_sites = UC.get('HEPCloud_sites')
+        self.HEPCloud_sites = [s for s in self.HEPCloud_sites if s in self.sites_ready]
+
 
         self.storage = defaultdict(int)
         self.disk = defaultdict(int)
@@ -7366,13 +7369,22 @@ class workflowInfo:
                 print "Reading minbias"
             else:
                 sites_allowed = sorted(set(SI.sites_T0s + SI.sites_T1s + SI.sites_with_goodAAA))
+                if self.request['RequestType'] == 'StepChain':
+                    sites_allowed += SI.HEPCloud_sites
+                    print "Include HEPCloud in the sitewhitelist of ",self.request['RequestName']
                 print "Reading premix"
         elif primary:
             sites_allowed =sorted(set(SI.sites_T0s + SI.sites_T1s + SI.sites_T2s))# + SI.sites_T3s))
+            if self.request['RequestType'] == 'StepChain':
+                    sites_allowed += SI.HEPCloud_sites
+                    print "Include HEPCloud in the sitewhitelist of ",self.request['RequestName']
         else:
             # no input at all
             ## all site should contribute
             sites_allowed =sorted(set( SI.sites_T0s + SI.sites_T2s + SI.sites_T1s))# + SI.sites_T3s ))
+            if self.request['RequestType'] == 'StepChain':
+                    sites_allowed += SI.HEPCloud_sites
+                    print "Include HEPCloud in the sitewhitelist of ",self.request['RequestName']
         if pickone:
             sites_allowed = sorted([SI.pick_CE( sites_allowed )])
 


### PR DESCRIPTION
Fixes #707 

#### Status
tested locally, not in production

#### Description
Earlier, we were including HEPCloud sites in the sitewhitelist of every StepChain request unless it reads classical mixing PU. With this PR, we include those sites to the sitewhitelist of workflows which read either PREMIX PU, primary input or no input. In other words, we do not include them in the whitelist of LHE workflows anymore, which are supposed to run at CERN.


#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
https://github.com/CMSCompOps/WmAgentScripts/pull/702

#### External dependencies / deployment changes
None

#### Mention people to look at PRs
@z4027163  @drkovalskyi  FYI
