### PR TITLE
Update secondary of RunIISummer20UL18DIGIPremix

### DIFF
--- a/campaigns.json
+++ b/campaigns.json
@@ -2227,8 +2227,7 @@
   }, 
   "RunIISummer20UL18DIGIPremix": {
     "SecondaryLocation": [
-      "T1_US_FNAL", 
-      "T2_CH_CERN"
+      "T1_IT_CNAF"
     ], 
     "fractionpass": 0.95, 
     "go": true, 
@@ -2243,7 +2242,7 @@
     }, 
     "resize": "auto", 
     "secondaries": {
-      "/Neutrino_E-10_gun/RunIISummer19ULPrePremix-UL18_106X_upgrade2018_realistic_v11_L1v1-v2/PREMIX": {}
+      "/Neutrino_E-10_gun/RunIISummer20ULPrePremix-UL18_106X_upgrade2018_realistic_v11_L1v1-v2/PREMIX": {}
     }, 
     "secondary_AAA": true, 
     "tune": true

--- a/campaigns.json
+++ b/campaigns.json
@@ -2227,7 +2227,9 @@
   }, 
   "RunIISummer20UL18DIGIPremix": {
     "SecondaryLocation": [
-      "T1_IT_CNAF"
+      "T1_IT_CNAF",
+      "T1_US_FNAL",
+      "T2_CH_CERN"
     ], 
     "fractionpass": 0.95, 
     "go": true, 


### PR DESCRIPTION
Update secondary location of RunIISummer20UL18DIGIPremix as 
```
"T1_IT_CNAF",
"T1_US_FNAL",
"T2_CH_CERN"
```