### PR TITLE
Remove core and memory capacity check during assignment

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -7423,21 +7423,20 @@ class workflowInfo:
                     print "Removing",sorted(c_black_list)
                 sites_allowed = list(set(sites_allowed) - set(c_black_list))
 
-        #ncores = self.request.get('Multicore',1)
-        ncores = self.getMulticore()
-        mem = self.getMemory()
-        memory_allowed = SI.sitesByMemory( mem , maxCore=ncores)
-        if memory_allowed!=None:
+        #ncores = self.getMulticore()
+        #mem = self.getMemory()
+        #memory_allowed = SI.sitesByMemory( mem , maxCore=ncores)
+        #if memory_allowed!=None:
             ## mask to sites ready for mcore
-            if verbose:
-                print ("[INFO] Sites allowing {} MB and {} core are".format(mem, ncores, sorted(memory_allowed)))
-            if  ncores>1:
-                memory_allowed = list(set(memory_allowed) & set(SI.sites_mcore_ready))
-            if verbose:
-                print ("[INFO] Sites ready for multicore: {}".format(sorted(list(set(SI.sites_mcore_ready)))))
-            sites_removed = list(set(sites_allowed) - set(memory_allowed))
-            sites_allowed = list(set(sites_allowed) & set(memory_allowed))
-        print("Removing sites due to {} MB and {} core(s) requirements: {}".format(mem, ncores, sorted(sorted(sites_removed))))
+        #    if verbose:
+        #        print ("[INFO] Sites allowing {} MB and {} core are".format(mem, ncores, sorted(memory_allowed)))
+        #    if  ncores>1:
+        #        memory_allowed = list(set(memory_allowed) & set(SI.sites_mcore_ready))
+        #    if verbose:
+        #        print ("[INFO] Sites ready for multicore: {}".format(sorted(list(set(SI.sites_mcore_ready)))))
+        #    sites_removed = list(set(sites_allowed) - set(memory_allowed))
+        #    sites_allowed = list(set(sites_allowed) & set(memory_allowed))
+        #print("Removing sites due to {} MB and {} core(s) requirements: {}".format(mem, ncores, sorted(sorted(sites_removed))))
 
         ## check on CC7 compatibility
         archs = self.getArchs()


### PR DESCRIPTION
Fixes #709 

#### Status
not tested

#### Description
Unified checks if sites can satisfy the core and memory requirements of the requests during the assignment and eliminates the sites which cannot. It gets the site capacity information from `gwmsmon` which we cannot rely on anymore, since it is not supported as a service. This check was also blocking the HEPCloud assignments, since these sites were not included in the response coming from `gwmsmon`. This PR removes this check and leaves this matching to HTCondor. 

Practically speaking, looking at the logs of the past 30 days, only the following sites were eliminated from sitewhitelist during this check in addition of the HEPCloud sites:
```
[u'T2_BR_UERJ', u'T2_FI_HIP', u'T2_FR_GRIF_IRFU', u'T2_GR_Ioannina', u'T2_RU_INR', u'T2_TR_METU']
```



#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
#702 #708 

#### External dependencies / deployment changes
none

#### Mention people to look at PRs
@z4027163  FYI
