### PR TITLE
Update campaigns

### DIFF
--- a/campaigns.json
+++ b/campaigns.json
@@ -2537,8 +2537,7 @@
     "secondaries": {
       "/MinBias_TuneCUETP8M1_2017_5p02TeV-pythia8/RunIIpp5Spring18GS-94X_mc2017_realistic_v10For2017G_v3-v2/GEN-SIM": {
         "SiteWhitelist": [
-          "T2_US_MIT", 
-          "T2_DE_DESY"
+          "T2_US_MIT"
         ]
       }, 
       "/MinBias_TuneCUETP8M1_5p02TeV-pythia8/HINppWinter17GS-92X_upgrade2017_realistic_v11-v1/GEN-SIM": {

--- a/campaigns.json
+++ b/campaigns.json
@@ -2055,7 +2055,8 @@
   }, 
   "RunIISummer20UL17DIGIPremix": {
     "SecondaryLocation": [
-      "T2_CH_CERN"
+      "T2_CH_CERN",
+      "T1_US_FNAL"
     ], 
     "fractionpass": 0.95, 
     "go": true, 

--- a/campaigns.json
+++ b/campaigns.json
@@ -2070,7 +2070,7 @@
     }, 
     "resize": "auto", 
     "secondaries": {
-      "/Neutrino_E-10_gun/RunIISummer19ULPrePremix-UL17_106X_mc2017_realistic_v6-v1/PREMIX": {}
+      "/Neutrino_E-10_gun/RunIISummer20ULPrePremix-UL17_106X_mc2017_realistic_v6-v3/PREMIX": {}
     }, 
     "secondary_AAA": true, 
     "tune": true

--- a/campaigns.json
+++ b/campaigns.json
@@ -674,12 +674,6 @@
     "lumisize": -1, 
     "maxcopies": 1, 
     "resize": "auto"
-  },
-  "RunIIAutumn18NanoAOD": {
-    "fractionpass": 0.95,
-    "go": true,
-    "lumisize": -1,
-    "maxcopies": 1
   }, 
   "RunIIAutumn18NanoAODv5": {
     "fractionpass": 0.95, 
@@ -781,13 +775,13 @@
     "tune": true
   }, 
   "RunIIFall17GS": {
+    "SiteBlacklist": [
+      "T2_US_Caltech"
+    ], 
     "force-complete": 0.99, 
     "fractionpass": 0.95, 
     "go": true, 
-    "lumisize": -1,
-    "SiteBlacklist": [
-      "T2_US_Caltech"
-    ],     
+    "lumisize": -1, 
     "resize": "auto", 
     "tune": true
   }, 
@@ -835,12 +829,12 @@
     "tune": true
   }, 
   "RunIIFall18GS": {
-    "fractionpass": 0.95, 
-    "go": true, 
-    "lumisize": -1,
     "SiteBlacklist": [
       "T2_US_Caltech"
     ], 
+    "fractionpass": 0.95, 
+    "go": true, 
+    "lumisize": -1, 
     "resize": "auto", 
     "tune": true
   }, 
@@ -858,13 +852,13 @@
     "tune": true
   }, 
   "RunIISummer15GS": {
+    "SiteBlacklist": [
+      "T2_US_Caltech"
+    ], 
     "force-complete": 0.99, 
     "fractionpass": 0.95, 
     "go": true, 
     "lumisize": 1000, 
-    "SiteBlacklist": [
-      "T2_US_Caltech"
-    ],
     "overflow": {
       "LHE": {
         "site_list": "sites_AAA"
@@ -1002,7 +996,7 @@
         "T2_CH_CERN", 
         "T1_US_FNAL"
       ]
-    },
+    }, 
     "partial_copy": 0.95, 
     "secondaries": {
       "/MinBias_TuneCP2_13TeV-pythia8/RunIIFall17FSPremix-PUMoriond17_94X_mc2017_realistic_v11-v1/GEN-SIM-RECO": {
@@ -1122,8 +1116,8 @@
         "pending": 0
       }
     }, 
-    "resize": "auto",
     "partial_copy": 0.95, 
+    "resize": "auto", 
     "secondaries": {
       "/MinBias_TuneCP1_13TeV-pythia8/RunIISummer19UL16SIM-106X_mcRun2_asymptotic_v10-v2/GEN-SIM": {
         "SiteWhitelist": [
@@ -1398,8 +1392,8 @@
     "go": true, 
     "lumisize": -1, 
     "maxcopies": 1, 
-    "resize": "auto",
     "partial_copy": 0.95, 
+    "resize": "auto", 
     "secondaries": {
       "/MinBias_TuneCP1_13TeV-pythia8/RunIISummer19UL17SIM-106X_mc2017_realistic_v6-v2/GEN-SIM": {
         "SiteWhitelist": [
@@ -1532,8 +1526,8 @@
     "go": true, 
     "lumisize": -1, 
     "maxcopies": 1, 
-    "resize": "auto",
     "partial_copy": 0.95, 
+    "resize": "auto", 
     "secondaries": {
       "/MinBias_TuneCP1_13TeV-pythia8/RunIISummer19UL18SIM-106X_upgrade2018_realistic_v11_L1v1-v2/GEN-SIM": {
         "SiteWhitelist": [
@@ -1559,8 +1553,8 @@
     "go": true, 
     "lumisize": -1, 
     "maxcopies": 1, 
-    "resize": "auto",
     "partial_copy": 0.95, 
+    "resize": "auto", 
     "secondaries": {
       "/Neutrino_E-10_gun/RunIISummer19ULPrePremix-UL18_106X_upgrade2018_realistic_v11_L1v1-v2/PREMIX": {}
     }, 
@@ -1665,7 +1659,7 @@
         "T2_CH_CERN", 
         "T1_US_FNAL"
       ]
-    },
+    }, 
     "partial_copy": 0.049, 
     "secondaries": {
       "/MinBias_TuneCP5_13TeV-pythia8/RunIISummer19UL16SIM-106X_mcRun2_asymptotic_v3-v1/GEN-SIM": {
@@ -1747,8 +1741,7 @@
     "fractionpass": 0.95, 
     "go": true, 
     "lumisize": -1, 
-    "maxcopies": 1,
-    "partial_copy": 0.95,
+    "maxcopies": 1, 
     "overflow": {
       "PU": {
         "force": false, 
@@ -1756,11 +1749,12 @@
         "pending": 0
       }
     }, 
+    "partial_copy": 0.95, 
     "resize": "auto", 
     "secondaries": {
       "/Neutrino_E-10_gun/RunIISummer20ULPrePremix-UL16_106X_mcRun2_asymptotic_v13-v1/PREMIX": {
-            "SecondaryLocation": [
-          "T1_US_FNAL",
+        "SecondaryLocation": [
+          "T1_US_FNAL", 
           "T2_CH_CERN"
         ]
       }
@@ -2061,7 +2055,6 @@
   }, 
   "RunIISummer20UL17DIGIPremix": {
     "SecondaryLocation": [
-      "T1_US_FNAL", 
       "T2_CH_CERN"
     ], 
     "fractionpass": 0.95, 
@@ -2220,15 +2213,15 @@
         "SiteWhitelist": [
           "T1_IT_CNAF"
         ]
-      } 
+      }
     }, 
     "secondary_AAA": false, 
     "tune": true
   }, 
   "RunIISummer20UL18DIGIPremix": {
     "SecondaryLocation": [
-      "T1_IT_CNAF",
-      "T1_US_FNAL",
+      "T1_IT_CNAF", 
+      "T1_US_FNAL", 
       "T2_CH_CERN"
     ], 
     "fractionpass": 0.95, 
@@ -2370,8 +2363,7 @@
     "tune": true
   }, 
   "RunIISummer20ULPrePremix": {
-    "fractionpass": 0.95,
-    "partial_copy": 0.95, 
+    "fractionpass": 0.95, 
     "go": true, 
     "lumisize": -1, 
     "maxcopies": 1, 
@@ -2382,24 +2374,25 @@
         "pending": 0
       }
     }, 
-    "resize": "auto",
+    "partial_copy": 0.95, 
+    "resize": "auto", 
     "secondaries": {
       "/MinBias_TuneCP5_13TeV-pythia8/RunIISummer20UL16SIM-106X_mcRun2_asymptotic_v13-v2/GEN-SIM": {
         "SiteWhitelist": [
           "T2_US_Nebraska"
         ]
-      },
+      }, 
       "/MinBias_TuneCP5_13TeV-pythia8/RunIISummer20UL17SIM-106X_mc2017_realistic_v6-v2/GEN-SIM": {
         "SiteWhitelist": [
-         "T1_US_FNAL"
+          "T1_US_FNAL"
         ]
-      },
-      "/MinBias_TuneCP5_13TeV-pythia8/RunIISummer20UL18SIM-106X_upgrade2018_realistic_v11_L1v1-v2/GEN-SIM":{
+      }, 
+      "/MinBias_TuneCP5_13TeV-pythia8/RunIISummer20UL18SIM-106X_upgrade2018_realistic_v11_L1v1-v2/GEN-SIM": {
         "SiteWhitelist": [
-         "T1_IT_CNAF"
+          "T1_IT_CNAF"
         ]
       }
-    },
+    }, 
     "secondary_AAA": false, 
     "tune": true
   }, 
@@ -2568,7 +2561,27 @@
     }, 
     "resize": "auto", 
     "tune": true
-  }, 
+  },
+"RunIIpp5Spring18GSFixBeamspot": {
+    "custodial": "T1_FR_CCIN2P3_MSS", 
+    "fractionpass": 0.95, 
+    "go": true, 
+    "lumisize": -1, 
+    "parameters": {
+      "MergedLFNBase": "/store/himc", 
+      "SiteBlacklist": [
+        "T1_US_FNAL", 
+        "T2_US_Purdue", 
+        "T2_US_Caltech", 
+        "T2_US_Florida", 
+        "T2_US_Nebraska", 
+        "T2_US_UCSD", 
+        "T2_US_Wisconsin"
+      ]
+    }, 
+    "resize": "auto", 
+    "tune": true
+  },  
   "RunIIpp5Spring18MiniAOD": {
     "fractionpass": 0.95, 
     "go": true, 


### PR DESCRIPTION
Adding in RunIIpp5Spring18GSFixBeamspot this new campaign no pilot PRCAMPAIGNS-154

Removing FNAL from the New Campaigns: RunIISummer20UL17DIGIPremix in order to force MSTransfer with a dummy WF to transfer to CERN so we will have the PU input at both FNAL and CERN. PRCAMPAIGNS-140