### PR TITLE
Fixing mistakes from the commit for the NanoAODv2 UL

### DIFF
--- a/campaigns.json
+++ b/campaigns.json
@@ -1522,7 +1522,12 @@
     "lumisize": -1, 
     "maxcopies": 1
   }, 
-  "RunIISummer19UL17NanoAODv2": {}, 
+  "RunIISummer19UL17NanoAODv2": {
+    "fractionpass": 0.95,
+    "go": false,
+    "lumisize": -1,
+    "maxcopies": 1
+  }, 
   "RunIISummer19UL17RECO": {
     "fractionpass": 0.95, 
     "go": false, 


### PR DESCRIPTION
Adding in RunIISumer19UL*NanoAOD%v2 and RunIISumer20UL*NanoAOD%v2
*=16,17,18
% is either nothing or APV for when*=16
Added in RunIISummer20UL16wmLHENanoGEN

Also removed CERN from the secondary location for these PU datasets:
/Neutrino_E-10_gun/RunIISummer17PrePremix-PUAutumn18_102X_upgrade2018_realistic_v15-v1/GEN-SIM-DIGI-RAW

/Neutrino_E-10_gun/RunIISummer17PrePremix-MCv2_correctPU_94X_mc2017_realistic_v9-v1/GEN-SIM-DIGI-RAW

/Neutrino_E-10_gun/RunIISpring15PrePremix-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v2-v2/GEN-SIM-DIGI-RAW

/Neutrino_E-10_gun/RunIISummer19ULPrePremix-UL17_106X_mc2017_realistic_v6-v1/PREMIX

/Neutrino_E-10_gun/RunIISummer19ULPrePremix-UL16_106X_mcRun2_asymptotic_v10-v2/PREMIX

FNAL is the only site for these secondaries  