### PR TITLE
Make acdc console address configurable

### DIFF
--- a/Unified/showError.py
+++ b/Unified/showError.py
@@ -345,9 +345,8 @@ def parse_one(url, wfn, options=None):
     if r_type in ['ReReco']:
         html += '<a href=../datalumi/lumi.%s.html>Lumisection Summary</a>, '% wfi.request['PrepID']
     html += '<a href="https://its.cern.ch/jira/issues/?jql=text~%s AND project = CMSCOMPPR" target="_blank">jira</a>, '% (wfi.request['PrepID'])
-    html += '<a href="https://vocms0113.cern.ch/seeworkflow2/?workflow=%s">console</a>,'% wfn
-    #html += '<a href="http://vocms0276.cern.ch/tasks?page=1&filter=%s">new console</a>,'% wfn
-    #html += '<a href="http://wc-dev.cern.ch/tasks?page=1&filter=%s">dev console</a>'% wfn
+    html += '<a href="https://vocms0113.cern.ch/seeworkflow2/?workflow=%s">old console</a>,'% wfn
+    html += '<a href="%s/seeworkflow2/?workflow=%s">new console</a>,'% (wfn, UC.get('acdc_console_url'))
     html+='<hr>'
     html += '<a href=#IO>I/O</a>, <a href=#ERROR>Errors</a>, <a href=#BLOCK>blocks</a>, <a href=#FILE>files</a>, <a href=#CODES>Error codes</a><br>'
     html+='<hr>'

--- a/unifiedConfiguration.json
+++ b/unifiedConfiguration.json
@@ -420,5 +420,9 @@
   "HEPCloud_sites": {
     "value" : ["T3_US_NERSC","T3_US_PSC","T3_US_SDSC","T3_US_TACC"],
     "description" : "HEPCloud sites"
+  },
+  "acdc_console_url": {
+    "value" : "https://vocms0113.cern.ch",
+    "description" : "Base url to the ACDC console"
   }
 }

--- a/unifiedConfiguration.json
+++ b/unifiedConfiguration.json
@@ -422,7 +422,7 @@
     "description" : "HEPCloud sites"
   },
   "acdc_console_url": {
-    "value" : "https://vocms0113.cern.ch",
+    "value" : "https://workflowrecovery.cern.ch",
     "description" : "Base url to the ACDC console"
   }
 }


### PR DESCRIPTION
Fixes #720

#### Status
not tested

#### Description
As the ACDC console address changes, we need to make unified compatible with the new console. For now, only necessary change that I can think of for Unified is to update the hyperlink to the Console in the error report and this PR does that.

#### Is it backward compatible (if not, which system it affects?)
no

#### Related PRs
none

#### External dependencies / deployment changes
none

#### Mention people to look at PRs
@z4027163  FYI
