### PR TITLE
Add some T3 sites to goodAAA list

### DIFF
--- a/unifiedConfiguration.json
+++ b/unifiedConfiguration.json
@@ -101,7 +101,7 @@
     "description" : "The sites identified as having good storage bandwidth"
  },
  "sites_with_goodAAA": {
-    "value" : ["T2_CH_CSCS","T2_DE_DESY","T2_DE_RWTH","T2_ES_CIEMAT","T2_FR_GRIF_LLR", "T2_FR_GRIF_IRFU", "T2_FR_IPHC","T2_FR_CCIN2P3","T2_IT_Bari", "T2_IT_Legnaro", "T2_IT_Pisa", "T2_IT_Rome","T2_UK_London_Brunel", "T2_UK_London_IC","T2_US_Caltech","T2_US_MIT","T2_US_Nebraska","T2_US_Purdue","T2_US_UCSD","T2_US_Wisconsin","T2_US_Florida","T2_BE_IIHE","T2_EE_Estonia","T2_PL_Swierk","T2_CH_CERN","T2_CH_CERN_HLT","T2_TW_NCHC","T2_IN_TIFR","T2_HU_Budapest","T2_KR_KISTI","T2_BR_SPRACE","T2_RU_JINR","T2_UK_SGrid_RALPP","T2_US_Vanderbilt","T2_BE_UCL","T2_CN_Beijing"],
+    "value" : ["T2_CH_CSCS","T2_DE_DESY","T2_DE_RWTH","T2_ES_CIEMAT","T2_FR_GRIF_LLR", "T2_FR_GRIF_IRFU", "T2_FR_IPHC","T2_FR_CCIN2P3","T2_IT_Bari", "T2_IT_Legnaro", "T2_IT_Pisa", "T2_IT_Rome","T2_UK_London_Brunel", "T2_UK_London_IC","T2_US_Caltech","T2_US_MIT","T2_US_Nebraska","T2_US_Purdue","T2_US_UCSD","T2_US_Wisconsin","T2_US_Florida","T2_BE_IIHE","T2_EE_Estonia","T2_PL_Swierk","T2_CH_CERN","T2_CH_CERN_HLT","T2_TW_NCHC","T2_IN_TIFR","T2_HU_Budapest","T2_KR_KISTI","T2_BR_SPRACE","T2_RU_JINR","T2_UK_SGrid_RALPP","T2_US_Vanderbilt","T2_BE_UCL","T2_CN_Beijing","T3_US_Baylor","T3_US_Colorado","T3_UK_London_RHUL","T3_UK_SGrid_Oxford"],
     "description" : "The sites identified as having good AAA bandwidth"
  },
  "blow_up_limits" : {

--- a/utils.py
+++ b/utils.py
@@ -2174,7 +2174,8 @@ class siteInfo:
 
         ## new site lists for better matching
         self.sites_with_goodAAA = UC.get('sites_with_goodAAA')
-        self.sites_with_goodAAA = self.sites_with_goodAAA + add_on_good_aaa
+        #self.sites_with_goodAAA = self.sites_with_goodAAA + add_on_good_aaa
+        self.sites_with_goodAAA = self.sites_with_goodAAA
         self.sites_with_goodAAA = list(set([ s for s in self.sites_with_goodAAA if s in self.sites_ready]))
 
         self.HEPCloud_sites = UC.get('HEPCloud_sites')


### PR DESCRIPTION
#### Status
tested

#### Description
It is seen that some T3 sites are not used in production very well. After running a test workflow in these sites, here is what we get:
```
    T3_US_Rutgers: submitted-retry:57, pending:150, first:93,
    T3_US_Baylor: success:1321, submitted-running:11, retry:54, pending:150, first:107,
    T3_US_Colorado: success:5921, submitted-running:36, retry:290, pending:714, first:460, failure-exception:4, queued-retry:49, cooloff-job:102,
    T3_UK_London_RHUL: success:1021, submitted-retry:146, pending:238, first:94, running:2, queued-retry:103, cooloff-job:88,
    T3_UK_SGrid_Oxford: success:940, submitted-running:9, retry:861, pending:954, first:102, queued-retry:30, cooloff-job:89,
    T3_US_OSG: submitted-retry:31, pending:280, first:249, 
```
This was the sitewhitelist:
```
"SiteWhitelist": [
    "T3_FR_IPNL", 
    "T3_KR_KISTI", 
    "T3_UK_London_RHUL", 
    "T3_UK_SGrid_Oxford", 
    "T3_US_Baylor", 
    "T3_US_Colorado", 
    "T3_US_OSG", 
    "T3_US_Rutgers"
  ]
```
`T3_US_Rutgers` and `T3_US_OSG` failed. No job created for `T3_FR_IPNL`, `T3_KR_KISTI`. Therefore the test is inconclusive for these 2 sites.

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
#642 

#### External dependencies / deployment changes
none

#### Mention people to look at PRs
@z4027163  FYI
