### PR TITLE
Updating for pilots that were successful

### DIFF
--- a/campaigns.json
+++ b/campaigns.json
@@ -1694,7 +1694,7 @@
   }, 
   "RunIISummer19UL18NanoAODv2": {
     "fractionpass": 0.95, 
-    "go": false, 
+    "go": true, 
     "lumisize": -1, 
     "maxcopies": 1
   }, 
@@ -2160,7 +2160,7 @@
   }, 
   "RunIISummer20UL16wmLHENanoGEN": {
     "fractionpass": 0.95, 
-    "go": false, 
+    "go": true, 
     "lumisize": -1, 
     "maxcopies": 1, 
     "overflow": {
@@ -2466,7 +2466,7 @@
   }, 
   "RunIISummer20UL18NanoAODv2": {
     "fractionpass": 0.95, 
-    "go": false, 
+    "go": true, 
     "lumisize": -1, 
     "maxcopies": 1, 
     "overflow": {


### PR DESCRIPTION
https://its.cern.ch/jira/projects/PRCAMPAIGNS/issues/PRCAMPAIGNS-161?filter=allopenissues&orderby=updated+DESC%2C+priority+DESC
https://its.cern.ch/jira/projects/PRCAMPAIGNS/issues/PRCAMPAIGNS-165?filter=allopenissues&orderby=updated+DESC%2C+priority+DESC
https://its.cern.ch/jira/projects/PRCAMPAIGNS/issues/PRCAMPAIGNS-167?filter=allopenissues&orderby=updated+DESC%2C+priority+DESC
https://its.cern.ch/jira/projects/PRCAMPAIGNS/issues/PRCAMPAIGNS-157?filter=allopenissues&orderby=updated+DESC%2C+priority+DESC
https://its.cern.ch/jira/projects/PRCAMPAIGNS/issues/PRCAMPAIGNS-155?filter=allopenissues&orderby=updated+DESC%2C+priority+DESC

All the nanoAOD campaigns that were requested to be open are open but the NanoAOD20UL17 because of an issue that seems to be related to the release that pdmv is aware of.