### PR TITLE
Set the fractionpass of NanoAODUL1*Data campaigns to 1

### DIFF
--- a/campaigns.json
+++ b/campaigns.json
@@ -295,7 +295,7 @@
     "maxcopies": 1
   }, 
   "NanoAODUL16Data": {
-    "fractionpass": 0.95, 
+    "fractionpass": 1, 
     "go": true, 
     "lumisize": -1, 
     "maxcopies": 1, 
@@ -310,7 +310,7 @@
     "tune": true
   }, 
   "NanoAODUL17Data": {
-    "fractionpass": 0.95, 
+    "fractionpass": 1, 
     "go": true, 
     "lumisize": -1, 
     "maxcopies": 1, 
@@ -325,7 +325,7 @@
     "tune": true
   }, 
   "NanoAODUL18Data": {
-    "fractionpass": 0.95, 
+    "fractionpass": 1, 
     "go": true, 
     "lumisize": -1, 
     "maxcopies": 1, 


### PR DESCRIPTION
Fixes #735 

#### Status
ready

#### Description
Set the fractionpass of NanoAODUL1*Data campaigns to 1 since these are data campaings, not MC.

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
none

#### External dependencies / deployment changes
none

#### Mention people to look at PRs
@scarletnorberg  @z4027163  FYI
