### PR TITLE
Add T2_UA_KIPT, T2_AT_Vienna, T2_ES_IFCA to goodAAA list

### DIFF
--- a/unifiedConfiguration.json
+++ b/unifiedConfiguration.json
@@ -101,7 +101,7 @@
     "description" : "The sites identified as having good storage bandwidth"
  },
  "sites_with_goodAAA": {
-    "value" : ["T2_CH_CSCS","T2_DE_DESY","T2_DE_RWTH","T2_ES_CIEMAT","T2_FR_GRIF_LLR", "T2_FR_GRIF_IRFU", "T2_FR_IPHC","T2_FR_CCIN2P3","T2_IT_Bari", "T2_IT_Legnaro", "T2_IT_Pisa", "T2_IT_Rome","T2_UK_London_Brunel", "T2_UK_London_IC","T2_US_Caltech","T2_US_MIT","T2_US_Nebraska","T2_US_Purdue","T2_US_UCSD","T2_US_Wisconsin","T2_US_Florida","T2_BE_IIHE","T2_EE_Estonia","T2_PL_Swierk","T2_CH_CERN","T2_CH_CERN_HLT","T2_TW_NCHC","T2_IN_TIFR","T2_HU_Budapest","T2_KR_KISTI","T2_BR_SPRACE","T2_RU_JINR","T2_UK_SGrid_RALPP","T2_US_Vanderbilt","T2_BE_UCL","T2_CN_Beijing"],
+    "value" : ["T2_CH_CSCS","T2_DE_DESY","T2_DE_RWTH","T2_ES_CIEMAT","T2_FR_GRIF_LLR", "T2_FR_GRIF_IRFU", "T2_FR_IPHC","T2_FR_CCIN2P3","T2_IT_Bari", "T2_IT_Legnaro", "T2_IT_Pisa", "T2_IT_Rome","T2_UK_London_Brunel", "T2_UK_London_IC","T2_US_Caltech","T2_US_MIT","T2_US_Nebraska","T2_US_Purdue","T2_US_UCSD","T2_US_Wisconsin","T2_US_Florida","T2_BE_IIHE","T2_EE_Estonia","T2_PL_Swierk","T2_CH_CERN","T2_CH_CERN_HLT","T2_TW_NCHC","T2_IN_TIFR","T2_HU_Budapest","T2_KR_KISTI","T2_BR_SPRACE","T2_RU_JINR","T2_UK_SGrid_RALPP","T2_US_Vanderbilt","T2_BE_UCL","T2_CN_Beijing","T2_UA_KIPT","T2_AT_Vienna","T2_ES_IFCA"],
     "description" : "The sites identified as having good AAA bandwidth"
  },
  "blow_up_limits" : {


### PR DESCRIPTION
Partially fixes #725 

#### Status
ready

#### Description
Add T2_UA_KIPT, T2_AT_Vienna, T2_ES_IFCA to goodAAA list. Justification can be found at the related issue.

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
#642  and #699 

#### External dependencies / deployment changes
none

#### Mention people to look at PRs
@z4027163  FYI
