### PR TITLE
Removing the secondary addition

### DIFF
--- a/campaigns.json
+++ b/campaigns.json
@@ -2188,8 +2188,7 @@
         "pending": 0
       }
     }, 
-    "resize": "auto", 
-    "secondary_AAA": false, 
+    "resize": "auto",  
     "tune": true
   }, 
   "RunIISummer20UL16wmLHEGEN": {


### PR DESCRIPTION
Removing "secondary_AAA": false, RunIISummer20UL16wmLHEGENAPV because there is no secondary_AAA 