### PR TITLE
Stop spawning harvesting workflows

### DIFF
--- a/Unified/closor.py
+++ b/Unified/closor.py
@@ -470,13 +470,13 @@ class CloseBuster(threading.Thread):
 
     
         ## verify if we have to do harvesting
-        if not options.no_harvest and not jump_the_line:
-            #(OK, requests) = spawn_harvesting(url, wfi, in_full)
-            sites_for_DQMHarvest = UC.get("sites_for_DQMHarvest")
-            (OK, requests) = spawn_harvesting(url, wfi, sites_for_DQMHarvest)
-            print "Harvesting workflow has been created and assigned to: "
-            print sites_for_DQMHarvest
-            all_OK.update( OK )
+        #if not options.no_harvest and not jump_the_line:
+        #    #(OK, requests) = spawn_harvesting(url, wfi, in_full)
+        #    sites_for_DQMHarvest = UC.get("sites_for_DQMHarvest")
+        #    (OK, requests) = spawn_harvesting(url, wfi, sites_for_DQMHarvest)
+        #    print "Harvesting workflow has been created and assigned to: "
+        #    print sites_for_DQMHarvest
+        #    all_OK.update( OK )
 
         ## only that status can let me go into announced
         if all(all_OK.values()) and ((wfi.request['RequestStatus'] in ['closed-out']) or options.force or jump_the_line):


### PR DESCRIPTION
Fixes #729 

#### Status
not tested

#### Description
The necessity of spawning harvesting workflows is under discussion and it is expected to be resolved in the next PdmV-PnR meeting at `11.01.2021`. This PR stops spawning harvesting workflows temporarily. Upcoming development should be done after the meeting once the requirements are in place.

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
None

#### External dependencies / deployment changes
None

#### Mention people to look at PRs
@z4027163  FYI
