### PR TITLE
Add CERN as a secondary location for RunIISummer19UL16DIGIPremixAPV

### DIFF
--- a/campaigns.json
+++ b/campaigns.json
@@ -1254,6 +1254,7 @@
     "secondaries": {
       "/Neutrino_E-10_gun/RunIISummer19ULPrePremix-UL16_106X_mcRun2_asymptotic_v10-v2/PREMIX": {
         "SecondaryLocation": [
+          "T2_CH_CERN",
           "T1_US_FNAL"
         ]
       }


### PR DESCRIPTION
Since, these are LHE workflows and they are assigned to CERN. If CERN is not defined as a secondary location in the campaign, MSTransferor does not take them into account. 