### PR TITLE
Comment out the redundant line which gives errors

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -2434,7 +2434,7 @@ class siteInfo:
             ## bypass
 
             if 'MSS' in site: continue
-            queued = self.queue.get(site,0)
+            #queued = self.queue.get(site,0)
             #print site,self.queue.get(site,0)
             ## consider quota to be 80% of what's available
             queued_used = 0


### PR DESCRIPTION
Fixes #753

#### Status
not tested

#### Description
This PR intends to solve the following error:
```
cmsunified
vocms0269.cern.ch
module batchor

    SI = global_SI()
  File "/data/unified/WmAgentScripts/Unified/utils.py", line 2705, in global_SI
    global_SI.instance = siteInfo(a)
  File "/data/unified/WmAgentScripts/Unified/utils.py", line 2270, in __init__
    self.fetch_detox_info(talk=False, buffer_level=UC.get('DDM_buffer_level'), sites_space_override=sites_space_override)
  File "/data/unified/WmAgentScripts/Unified/utils.py", line 2437, in fetch_detox_info
    queued = self.queue.get(site,0)
AttributeError: 'str' object has no attribute 'get'

Abnormal termination with exit code 1
```

#### Is it backward compatible (if not, which system it affects?)
no
#### Related PRs
#754 

#### External dependencies / deployment changes
none

#### Mention people to look at PRs
None
