### PR TITLE
Do not include CERN HLT in the sitewhitelist of workflows whose AAA is enabled

### DIFF
--- a/Unified/assignor.py
+++ b/Unified/assignor.py
@@ -216,6 +216,10 @@ def assignor(url ,specific = None, talk=True, options=None):
 
         wfh.sendLog('assignor',"Initial values for primary_AAA=%s and secondary_AAA=%s"%(primary_aaa, secondary_aaa))
 
+        if primary_aaa or secondary_aaa:
+            if "T2_CH_CERN_HLT" in sites_allowed:
+                sites_allowed.remove("T2_CH_CERN_HLT")
+
         ## keep track of this, after secondary input location restriction : that's how you want to operate it
         initial_sites_allowed = copy.deepcopy( sites_allowed )
 


### PR DESCRIPTION
Fixes #761 

#### Status
tested locally

#### Description
This PR excludes CERN HLT from the sitewhitelist of workflows whose AAA is enabled. Details are at #761 

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
None

#### External dependencies / deployment changes
None

#### Mention people to look at PRs
@z4027163  FYI
