### PR TITLE
Convert all PSN names into RSE names in the campaign configuration for the secondary locations

### DIFF
--- a/campaigns.json
+++ b/campaigns.json
@@ -410,7 +410,7 @@
       }, 
       "/RelValMinBias_14TeV/CMSSW_11_1_2_patch3-110X_mcRun4_realistic_v3_2026D49noPU_BSzpz35-v1/GEN-SIM": {
         "SiteWhitelist": [
-          "T1_DE_KIT", 
+          "T1_DE_KIT_Disk", 
           "T2_US_Florida"
         ]
       }
@@ -698,7 +698,7 @@
       }, 
       "/MinBias_TuneCP5_13TeV-pythia8/RunIIFall18GS-newECALCrystalGeometryFor2017_102X_mc2017_realistic_v5-v1/GEN-SIM": {
         "SiteWhitelist": [
-          "T1_DE_KIT"
+          "T1_DE_KIT_Disk"
         ]
       }, 
       "/MinBias_TuneCP5_13TeV-pythia8_Fall18/RunIIFall18GS-102X_upgrade2018_realistic_v11-v1/GEN-SIM": {
@@ -746,7 +746,7 @@
     "SecondaryLocation": [
       "T1_US_FNAL_Disk", 
       "T2_US_Nebraska", 
-      "T1_DE_KIT", 
+      "T1_DE_KIT_Disk", 
       "T1_RU_JINR_Disk"
     ], 
     "SiteBlacklist": [
@@ -837,19 +837,19 @@
     "secondaries": {
       "/MinBias_TuneCP1_13TeV-pythia8/RunIIFall17GS-93X_mc2017_realistic_v3-v1/GEN-SIM": {
         "SiteWhitelist": [
-          "T1_DE_KIT", 
+          "T1_DE_KIT_Disk", 
           "T1_IT_CNAF_Disk"
         ]
       }, 
       "/MinBias_TuneCP5_13TeV-pythia8_Fall17/RunIIFall17GS-93X_mc2017_realistic_v3-v1/GEN-SIM": {
         "SiteWhitelist": [
           "T1_IT_CNAF_Disk", 
-          "T1_DE_KIT"
+          "T1_DE_KIT_Disk"
         ]
       }, 
       "/MinBias_TuneCP5_inelasticON_13TeV-pythia8/RunIIFall17GS-93X_mc2017_realistic_v3-v1/GEN-SIM": {
         "SiteWhitelist": [
-          "T1_DE_KIT", 
+          "T1_DE_KIT_Disk", 
           "T1_FR_CCIN2P3"
         ]
       }
@@ -1097,7 +1097,7 @@
       "/Neutrino_E-10_gun/RunIISummer16FSPremix-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v4-v1/GEN-SIM-DIGI-RAW": {
         "SiteWhitelist": [
           "T2_US_Purdue", 
-          "T1_DE_KIT"
+          "T1_DE_KIT_Disk"
         ], 
         "secondary_AAA": true
       }
@@ -1195,7 +1195,7 @@
       "/MinBias_TuneCP5_inelasticON_13TeV-pythia8/RunIIFall17GS-93X_mc2017_realistic_v3-v1/GEN-SIM": {
         "SiteWhitelist": [
           "T1_FR_CCIN2P3", 
-          "T1_DE_KIT"
+          "T1_DE_KIT_Disk"
         ]
       }, 
       "/MinBias_TuneCUETP8M1_13TeV-pythia8/RunIISummer17GS-92X_upgrade2017_realistic_v2-v1/GEN-SIM": {

--- a/campaigns.json
+++ b/campaigns.json
@@ -508,7 +508,7 @@
       }, 
       "/MinBias_TuneCP5_14TeV-pythia8/Run3Summer19GS-2018Scenario_106X_upgrade2021_realistic_v5-v1/GEN-SIM": {
         "SiteWhitelist": [
-          "T1_ES_PIC"
+          "T1_ES_PIC_Disk"
         ]
       }
     }, 
@@ -571,7 +571,7 @@
     "secondaries": {
       "/MinBias_TuneCP5_14TeV-pythia8/Run3Winter20GS-110X_mcRun3_2021_realistic_v6-v1/GEN-SIM": {
         "SiteWhitelist": [
-          "T1_ES_PIC", 
+          "T1_ES_PIC_Disk", 
           "T1_US_FNAL_Disk"
         ]
       }
@@ -615,7 +615,7 @@
     "secondaries": {
       "/MinBias_TuneCP5_14TeV-pythia8/Run3Winter20GS-110X_mcRun3_2021_realistic_v6-v1/GEN-SIM": {
         "SiteWhitelist": [
-          "T1_ES_PIC", 
+          "T1_ES_PIC_Disk", 
           "T1_US_FNAL_Disk"
         ]
       }
@@ -713,7 +713,7 @@
       }, 
       "/MinBias_TuneCP5_13TeV_NeutronXS-pythia8/RunIIFall18GS-SNB_102X_upgrade2018_realistic_v17-v1/GEN-SIM": {
         "SiteWhitelist": [
-          "T1_ES_PIC"
+          "T1_ES_PIC_Disk"
         ]
       }
     }, 
@@ -1188,7 +1188,7 @@
       }, 
       "/MinBias_TuneCP5_14TeV-pythia8/Run3Winter20GS-110X_mcRun3_2021_realistic_v6-v1/GEN-SIM": {
         "SiteWhitelist": [
-          "T1_ES_PIC", 
+          "T1_ES_PIC_Disk", 
           "T1_US_FNAL_Disk"
         ]
       }, 

--- a/campaigns.json
+++ b/campaigns.json
@@ -1245,7 +1245,7 @@
       }, 
       "/MinBias_TuneCP5_13TeV-pythia8/RunIISummer19UL16SIM-106X_mcRun2_asymptotic_v3-v1/GEN-SIM": {
         "SiteWhitelist": [
-          "T1_UK_RAL", 
+          "T1_UK_RAL_Disk", 
           "T1_US_FNAL_Disk"
         ]
       }
@@ -1275,7 +1275,7 @@
       }, 
       "/MinBias_TuneCP5_13TeV-pythia8/RunIISummer19UL16SIM-106X_mcRun2_asymptotic_v3-v1/GEN-SIM": {
         "SiteWhitelist": [
-          "T1_UK_RAL", 
+          "T1_UK_RAL_Disk", 
           "T1_US_FNAL_Disk"
         ]
       }
@@ -1587,7 +1587,7 @@
       }, 
       "/MinBias_TuneCP5_13TeV-pythia8/RunIISummer19UL17SIM-106X_mc2017_realistic_v3-v2/SIM": {
         "SiteWhitelist": [
-          "T1_UK_RAL", 
+          "T1_UK_RAL_Disk", 
           "T2_US_Nebraska", 
           "T1_US_FNAL_Disk"
         ]
@@ -1734,7 +1734,7 @@
       }, 
       "/MinBias_TuneCP5_13TeV-pythia8/RunIISummer19UL18SIM-106X_upgrade2018_realistic_v4-v1/SIM": {
         "SiteWhitelist": [
-          "T1_UK_RAL", 
+          "T1_UK_RAL_Disk", 
           "T2_US_Nebraska"
         ]
       }
@@ -1887,23 +1887,23 @@
     "secondaries": {
       "/MinBias_TuneCP5_13TeV-pythia8/RunIISummer19UL16SIM-106X_mcRun2_asymptotic_v3-v1/GEN-SIM": {
         "SiteWhitelist": [
-          "T1_UK_RAL", 
+          "T1_UK_RAL_Disk", 
           "T1_US_FNAL_Disk"
         ]
       }, 
       "/MinBias_TuneCP5_13TeV-pythia8/RunIISummer19UL16SIM-106X_mcRun2_asymptotic_v3-v1/SIM": {
         "SiteWhitelist": [
-          "T1_UK_RAL"
+          "T1_UK_RAL_Disk"
         ]
       }, 
       "/MinBias_TuneCP5_13TeV-pythia8/RunIISummer19UL17SIM-106X_mc2017_realistic_v3-v2/SIM": {
         "SiteWhitelist": [
-          "T1_UK_RAL"
+          "T1_UK_RAL_Disk"
         ]
       }, 
       "/MinBias_TuneCP5_13TeV-pythia8/RunIISummer19UL18SIM-106X_upgrade2018_realistic_v4-v1/SIM": {
         "SiteWhitelist": [
-          "T1_UK_RAL", 
+          "T1_UK_RAL_Disk", 
           "T2_US_Nebraska"
         ]
       }, 

--- a/campaigns.json
+++ b/campaigns.json
@@ -35,7 +35,7 @@
       "/MinBias_Hydjet_Drum5F_2018_5p02TeV/HINPbPbAutumn18GS-103X_upgrade2018_realistic_HI_v11-v1/GEN-SIM": {
         "SiteWhitelist": [
           "T1_RU_JINR_Disk", 
-          "T1_FR_CCIN2P3"
+          "T1_FR_CCIN2P3_Disk"
         ]
       }
     }, 
@@ -82,7 +82,7 @@
       "/MinBias_Hydjet_Drum5F_2018_5p02TeV/HINPbPbAutumn18GS-103X_upgrade2018_realistic_HI_v11-v1/GEN-SIM": {
         "SiteWhitelist": [
           "T1_RU_JINR_Disk", 
-          "T1_FR_CCIN2P3"
+          "T1_FR_CCIN2P3_Disk"
         ]
       }
     }, 
@@ -150,7 +150,7 @@
       "/MinBias_Hydjet_Drum5F_2018_5p02TeV/HINPbPbAutumn18GS-103X_upgrade2018_realistic_HI_v11-v1/GEN-SIM": {
         "SiteWhitelist": [
           "T1_RU_JINR_Disk", 
-          "T1_FR_CCIN2P3"
+          "T1_FR_CCIN2P3_Disk"
         ]
       }
     }, 
@@ -850,7 +850,7 @@
       "/MinBias_TuneCP5_inelasticON_13TeV-pythia8/RunIIFall17GS-93X_mc2017_realistic_v3-v1/GEN-SIM": {
         "SiteWhitelist": [
           "T1_DE_KIT_Disk", 
-          "T1_FR_CCIN2P3"
+          "T1_FR_CCIN2P3_Disk"
         ]
       }
     }, 
@@ -1166,13 +1166,13 @@
       }, 
       "/MinBias_TuneCP5_13TeV-pythia8/RunIIWinter19PFCalib16GS-105X_mcRun2_asymptotic_v2-v1/GEN-SIM": {
         "SiteWhitelist": [
-          "T1_FR_CCIN2P3", 
+          "T1_FR_CCIN2P3_Disk", 
           "T2_IT_Legnaro"
         ]
       }, 
       "/MinBias_TuneCP5_13TeV-pythia8/RunIIWinter19PFCalib17GS-105X_mc2017_realistic_v5_ext1-v1/GEN-SIM": {
         "SiteWhitelist": [
-          "T1_FR_CCIN2P3", 
+          "T1_FR_CCIN2P3_Disk", 
           "T1_IT_CNAF_Disk"
         ]
       }, 
@@ -1194,7 +1194,7 @@
       }, 
       "/MinBias_TuneCP5_inelasticON_13TeV-pythia8/RunIIFall17GS-93X_mc2017_realistic_v3-v1/GEN-SIM": {
         "SiteWhitelist": [
-          "T1_FR_CCIN2P3", 
+          "T1_FR_CCIN2P3_Disk", 
           "T1_DE_KIT_Disk"
         ]
       }, 
@@ -1270,7 +1270,7 @@
     "secondaries": {
       "/MinBias_TuneCP1_13TeV-pythia8/RunIISummer19UL16SIM-106X_mcRun2_asymptotic_v10-v2/GEN-SIM": {
         "SiteWhitelist": [
-          "T1_FR_CCIN2P3"
+          "T1_FR_CCIN2P3_Disk"
         ]
       }, 
       "/MinBias_TuneCP5_13TeV-pythia8/RunIISummer19UL16SIM-106X_mcRun2_asymptotic_v3-v1/GEN-SIM": {
@@ -1582,7 +1582,7 @@
     "secondaries": {
       "/MinBias_TuneCP1_13TeV-pythia8/RunIISummer19UL17SIM-106X_mc2017_realistic_v6-v2/GEN-SIM": {
         "SiteWhitelist": [
-          "T1_FR_CCIN2P3"
+          "T1_FR_CCIN2P3_Disk"
         ]
       }, 
       "/MinBias_TuneCP5_13TeV-pythia8/RunIISummer19UL17SIM-106X_mc2017_realistic_v3-v2/SIM": {
@@ -2844,13 +2844,13 @@
     "secondaries": {
       "/MinBias_TuneCP5_13TeV-pythia8/RunIIWinter19PFCalib16GS-105X_mcRun2_asymptotic_v2-v1/GEN-SIM": {
         "SiteWhitelist": [
-          "T1_FR_CCIN2P3", 
+          "T1_FR_CCIN2P3_Disk", 
           "T2_IT_Legnaro"
         ]
       }, 
       "/MinBias_TuneCP5_13TeV-pythia8/RunIIWinter19PFCalib17GS-105X_mc2017_realistic_v5_ext1-v1/GEN-SIM": {
         "SiteWhitelist": [
-          "T1_FR_CCIN2P3", 
+          "T1_FR_CCIN2P3_Disk", 
           "T1_IT_CNAF_Disk"
         ]
       }, 

--- a/campaigns.json
+++ b/campaigns.json
@@ -516,7 +516,7 @@
   }, 
   "Run3Summer19DRPremix": {
     "SecondaryLocation": [
-      "T1_US_FNAL", 
+      "T1_US_FNAL_Disk", 
       "T2_CH_CERN"
     ], 
     "fractionpass": 0.95, 
@@ -572,7 +572,7 @@
       "/MinBias_TuneCP5_14TeV-pythia8/Run3Winter20GS-110X_mcRun3_2021_realistic_v6-v1/GEN-SIM": {
         "SiteWhitelist": [
           "T1_ES_PIC", 
-          "T1_US_FNAL"
+          "T1_US_FNAL_Disk"
         ]
       }
     }, 
@@ -616,7 +616,7 @@
       "/MinBias_TuneCP5_14TeV-pythia8/Run3Winter20GS-110X_mcRun3_2021_realistic_v6-v1/GEN-SIM": {
         "SiteWhitelist": [
           "T1_ES_PIC", 
-          "T1_US_FNAL"
+          "T1_US_FNAL_Disk"
         ]
       }
     }, 
@@ -624,7 +624,7 @@
   }, 
   "Run3Winter20DRPremixMiniAOD": {
     "SecondaryLocation": [
-      "T1_US_FNAL", 
+      "T1_US_FNAL_Disk", 
       "T2_CH_CERN"
     ], 
     "fractionpass": 0.95, 
@@ -688,12 +688,12 @@
       }, 
       "/MinBias_TuneCP5_13TeV-pythia8/RunIIFall18GS-IdealGeometry_102X_upgrade2018_design_v9-v1/GEN-SIM": {
         "SiteWhitelist": [
-          "T1_US_FNAL"
+          "T1_US_FNAL_Disk"
         ]
       }, 
       "/MinBias_TuneCP5_13TeV-pythia8/RunIIFall18GS-newECALCrystalGeometryFor2016_102X_mcRun2_asymptotic_v5-v1/GEN-SIM": {
         "SiteWhitelist": [
-          "T1_US_FNAL"
+          "T1_US_FNAL_Disk"
         ]
       }, 
       "/MinBias_TuneCP5_13TeV-pythia8/RunIIFall18GS-newECALCrystalGeometryFor2017_102X_mc2017_realistic_v5-v1/GEN-SIM": {
@@ -722,7 +722,7 @@
   }, 
   "RunIIAutumn18DRPremix": {
     "SecondaryLocation": [
-      "T1_US_FNAL"
+      "T1_US_FNAL_Disk"
     ],
     "SiteBlacklist": [
       "T2_CH_CERN",
@@ -744,7 +744,7 @@
   }, 
   "RunIIAutumn18FSPremix": {
     "SecondaryLocation": [
-      "T1_US_FNAL", 
+      "T1_US_FNAL_Disk", 
       "T2_US_Nebraska", 
       "T1_DE_KIT", 
       "T1_RU_JINR"
@@ -802,7 +802,7 @@
   }, 
   "RunIIFall17DRPremix": {
     "SecondaryLocation": [
-      "T1_US_FNAL"
+      "T1_US_FNAL_Disk"
     ],
     "SiteBlacklist": [
       "T2_CH_CERN",
@@ -1046,7 +1046,7 @@
     "secondaries": {
       "/MinBias_TuneCUETP8M1_13TeV-pythia8/RunIISummer15GS-MCRUN2_71_V1_ext1-v1/GEN-SIM": {
         "SiteWhitelist": [
-          "T1_US_FNAL", 
+          "T1_US_FNAL_Disk", 
           "T2_US_Nebraska"
         ]
       }
@@ -1061,7 +1061,7 @@
       "T2_CH_CERN_HLT"
     ], 
     "SecondaryLocation": [
-      "T1_US_FNAL",
+      "T1_US_FNAL_Disk",
       "T2_CH_CERN"
     ], 
     "force-complete": 0.99, 
@@ -1189,7 +1189,7 @@
       "/MinBias_TuneCP5_14TeV-pythia8/Run3Winter20GS-110X_mcRun3_2021_realistic_v6-v1/GEN-SIM": {
         "SiteWhitelist": [
           "T1_ES_PIC", 
-          "T1_US_FNAL"
+          "T1_US_FNAL_Disk"
         ]
       }, 
       "/MinBias_TuneCP5_inelasticON_13TeV-pythia8/RunIIFall17GS-93X_mc2017_realistic_v3-v1/GEN-SIM": {
@@ -1246,7 +1246,7 @@
       "/MinBias_TuneCP5_13TeV-pythia8/RunIISummer19UL16SIM-106X_mcRun2_asymptotic_v3-v1/GEN-SIM": {
         "SiteWhitelist": [
           "T1_UK_RAL", 
-          "T1_US_FNAL"
+          "T1_US_FNAL_Disk"
         ]
       }
     }, 
@@ -1276,7 +1276,7 @@
       "/MinBias_TuneCP5_13TeV-pythia8/RunIISummer19UL16SIM-106X_mcRun2_asymptotic_v3-v1/GEN-SIM": {
         "SiteWhitelist": [
           "T1_UK_RAL", 
-          "T1_US_FNAL"
+          "T1_US_FNAL_Disk"
         ]
       }
     }, 
@@ -1285,7 +1285,7 @@
   }, 
   "RunIISummer19UL16DIGIPremix": {
     "SecondaryLocation": [
-      "T1_US_FNAL"
+      "T1_US_FNAL_Disk"
     ], 
     "fractionpass": 0.95, 
     "go": true, 
@@ -1317,7 +1317,7 @@
       "/Neutrino_E-10_gun/RunIISummer19ULPrePremix-UL16_106X_mcRun2_asymptotic_v10-v2/PREMIX": {
         "SecondaryLocation": [
           "T2_CH_CERN", 
-          "T1_US_FNAL"
+          "T1_US_FNAL_Disk"
         ]
       }
     }, 
@@ -1589,7 +1589,7 @@
         "SiteWhitelist": [
           "T1_UK_RAL", 
           "T2_US_Nebraska", 
-          "T1_US_FNAL"
+          "T1_US_FNAL_Disk"
         ]
       }
     }, 
@@ -1598,7 +1598,7 @@
   }, 
   "RunIISummer19UL17DIGIPremix": {
     "SecondaryLocation": [
-      "T1_US_FNAL"
+      "T1_US_FNAL_Disk"
     ], 
     "fractionpass": 0.95, 
     "go": true, 
@@ -1744,7 +1744,7 @@
   }, 
   "RunIISummer19UL18DIGIPremix": {
     "SecondaryLocation": [
-      "T1_US_FNAL", 
+      "T1_US_FNAL_Disk", 
       "T2_CH_CERN"
     ],
     "SiteBlacklist": [
@@ -1888,7 +1888,7 @@
       "/MinBias_TuneCP5_13TeV-pythia8/RunIISummer19UL16SIM-106X_mcRun2_asymptotic_v3-v1/GEN-SIM": {
         "SiteWhitelist": [
           "T1_UK_RAL", 
-          "T1_US_FNAL"
+          "T1_US_FNAL_Disk"
         ]
       }, 
       "/MinBias_TuneCP5_13TeV-pythia8/RunIISummer19UL16SIM-106X_mcRun2_asymptotic_v3-v1/SIM": {
@@ -1979,7 +1979,7 @@
     "secondaries": {
       "/Neutrino_E-10_gun/RunIISummer20ULPrePremix-UL16_106X_mcRun2_asymptotic_v13-v1/PREMIX": {
         "SecondaryLocation": [
-          "T1_US_FNAL", 
+          "T1_US_FNAL_Disk", 
           "T2_CH_CERN"
         ]
       }
@@ -2004,7 +2004,7 @@
     "secondaries": {
       "/Neutrino_E-10_gun/RunIISummer20ULPrePremix-UL16_106X_mcRun2_asymptotic_v13-v1/PREMIX": {
         "SecondaryLocation": [
-          "T1_US_FNAL", 
+          "T1_US_FNAL_Disk", 
           "T2_CH_CERN"
         ]
       }
@@ -2360,7 +2360,7 @@
   "RunIISummer20UL17DIGIPremix": {
     "SecondaryLocation": [
       "T2_CH_CERN", 
-      "T1_US_FNAL"
+      "T1_US_FNAL_Disk"
     ], 
     "fractionpass": 0.95, 
     "go": true, 
@@ -2558,7 +2558,7 @@
   "RunIISummer20UL18DIGIPremix": {
     "SecondaryLocation": [
       "T1_IT_CNAF", 
-      "T1_US_FNAL", 
+      "T1_US_FNAL_Disk", 
       "T2_CH_CERN"
     ], 
     "fractionpass": 0.95, 
@@ -2752,7 +2752,7 @@
       }, 
       "/MinBias_TuneCP5_13TeV-pythia8/RunIISummer20UL17SIM-106X_mc2017_realistic_v6-v2/GEN-SIM": {
         "SiteWhitelist": [
-          "T1_US_FNAL"
+          "T1_US_FNAL_Disk"
         ]
       }, 
       "/MinBias_TuneCP5_13TeV-pythia8/RunIISummer20UL18SIM-106X_upgrade2018_realistic_v11_L1v1-v2/GEN-SIM": {

--- a/campaigns.json
+++ b/campaigns.json
@@ -34,7 +34,7 @@
     "secondaries": {
       "/MinBias_Hydjet_Drum5F_2018_5p02TeV/HINPbPbAutumn18GS-103X_upgrade2018_realistic_HI_v11-v1/GEN-SIM": {
         "SiteWhitelist": [
-          "T1_RU_JINR", 
+          "T1_RU_JINR_Disk", 
           "T1_FR_CCIN2P3"
         ]
       }
@@ -81,7 +81,7 @@
     "secondaries": {
       "/MinBias_Hydjet_Drum5F_2018_5p02TeV/HINPbPbAutumn18GS-103X_upgrade2018_realistic_HI_v11-v1/GEN-SIM": {
         "SiteWhitelist": [
-          "T1_RU_JINR", 
+          "T1_RU_JINR_Disk", 
           "T1_FR_CCIN2P3"
         ]
       }
@@ -149,7 +149,7 @@
     "secondaries": {
       "/MinBias_Hydjet_Drum5F_2018_5p02TeV/HINPbPbAutumn18GS-103X_upgrade2018_realistic_HI_v11-v1/GEN-SIM": {
         "SiteWhitelist": [
-          "T1_RU_JINR", 
+          "T1_RU_JINR_Disk", 
           "T1_FR_CCIN2P3"
         ]
       }
@@ -405,7 +405,7 @@
     "secondaries": {
       "/MinBias_TuneCP5_14TeV-pythia8/Phase2HLTTDRWinter20GS-110X_mcRun4_realistic_v3_ext1-v1/GEN-SIM": {
         "SiteWhitelist": [
-          "T1_RU_JINR"
+          "T1_RU_JINR_Disk"
         ]
       }, 
       "/RelValMinBias_14TeV/CMSSW_11_1_2_patch3-110X_mcRun4_realistic_v3_2026D49noPU_BSzpz35-v1/GEN-SIM": {
@@ -503,7 +503,7 @@
     "secondaries": {
       "/MinBias_TuneCP5_14TeV-pythia8/Run3Summer19GS-106X_upgrade2021_realistic_v5-v1/GEN-SIM": {
         "SiteWhitelist": [
-          "T1_RU_JINR"
+          "T1_RU_JINR_Disk"
         ]
       }, 
       "/MinBias_TuneCP5_14TeV-pythia8/Run3Summer19GS-2018Scenario_106X_upgrade2021_realistic_v5-v1/GEN-SIM": {
@@ -747,7 +747,7 @@
       "T1_US_FNAL_Disk", 
       "T2_US_Nebraska", 
       "T1_DE_KIT", 
-      "T1_RU_JINR"
+      "T1_RU_JINR_Disk"
     ], 
     "SiteBlacklist": [
       "T2_CH_CERN_HLT"

--- a/campaigns.json
+++ b/campaigns.json
@@ -703,7 +703,7 @@
       }, 
       "/MinBias_TuneCP5_13TeV-pythia8_Fall18/RunIIFall18GS-102X_upgrade2018_realistic_v11-v1/GEN-SIM": {
         "SiteWhitelist": [
-          "T1_IT_CNAF"
+          "T1_IT_CNAF_Disk"
         ]
       }, 
       "/MinBias_TuneCP5_13TeV_NeutronHP-pythia8/RunIIFall18GS-SNB_102X_upgrade2018_realistic_v17-v1/GEN-SIM": {
@@ -838,12 +838,12 @@
       "/MinBias_TuneCP1_13TeV-pythia8/RunIIFall17GS-93X_mc2017_realistic_v3-v1/GEN-SIM": {
         "SiteWhitelist": [
           "T1_DE_KIT", 
-          "T1_IT_CNAF"
+          "T1_IT_CNAF_Disk"
         ]
       }, 
       "/MinBias_TuneCP5_13TeV-pythia8_Fall17/RunIIFall17GS-93X_mc2017_realistic_v3-v1/GEN-SIM": {
         "SiteWhitelist": [
-          "T1_IT_CNAF", 
+          "T1_IT_CNAF_Disk", 
           "T1_DE_KIT"
         ]
       }, 
@@ -1173,7 +1173,7 @@
       "/MinBias_TuneCP5_13TeV-pythia8/RunIIWinter19PFCalib17GS-105X_mc2017_realistic_v5_ext1-v1/GEN-SIM": {
         "SiteWhitelist": [
           "T1_FR_CCIN2P3", 
-          "T1_IT_CNAF"
+          "T1_IT_CNAF_Disk"
         ]
       }, 
       "/MinBias_TuneCP5_13TeV-pythia8/RunIIWinter19PFCalib18GS-105X_upgrade2018_realistic_v4-v1/GEN-SIM": {
@@ -1200,7 +1200,7 @@
       }, 
       "/MinBias_TuneCUETP8M1_13TeV-pythia8/RunIISummer17GS-92X_upgrade2017_realistic_v2-v1/GEN-SIM": {
         "SiteWhitelist": [
-          "T1_IT_CNAF", 
+          "T1_IT_CNAF_Disk", 
           "T2_US_MIT"
         ]
       }
@@ -2350,8 +2350,8 @@
     "secondaries": {
       "/MinBias_TuneCP5_13TeV-pythia8/RunIISummer20UL17SIM-106X_mc2017_realistic_v6-v2/GEN-SIM": {
         "SiteWhitelist": [
-          "T1_IT_CNAF_Disk", 
-          "T1_IT_CNAF"
+          "T1_IT_CNAF_Disk_Disk", 
+          "T1_IT_CNAF_Disk"
         ]
       }
     }, 
@@ -2548,7 +2548,7 @@
     "secondaries": {
       "/MinBias_TuneCP5_13TeV-pythia8/RunIISummer20UL18SIM-106X_upgrade2018_realistic_v11_L1v1-v2/GEN-SIM": {
         "SiteWhitelist": [
-          "T1_IT_CNAF"
+          "T1_IT_CNAF_Disk"
         ]
       }
     }, 
@@ -2557,7 +2557,7 @@
   }, 
   "RunIISummer20UL18DIGIPremix": {
     "SecondaryLocation": [
-      "T1_IT_CNAF", 
+      "T1_IT_CNAF_Disk", 
       "T1_US_FNAL_Disk", 
       "T2_CH_CERN"
     ], 
@@ -2757,7 +2757,7 @@
       }, 
       "/MinBias_TuneCP5_13TeV-pythia8/RunIISummer20UL18SIM-106X_upgrade2018_realistic_v11_L1v1-v2/GEN-SIM": {
         "SiteWhitelist": [
-          "T1_IT_CNAF"
+          "T1_IT_CNAF_Disk"
         ]
       }
     }, 
@@ -2851,7 +2851,7 @@
       "/MinBias_TuneCP5_13TeV-pythia8/RunIIWinter19PFCalib17GS-105X_mc2017_realistic_v5_ext1-v1/GEN-SIM": {
         "SiteWhitelist": [
           "T1_FR_CCIN2P3", 
-          "T1_IT_CNAF"
+          "T1_IT_CNAF_Disk"
         ]
       }, 
       "/MinBias_TuneCP5_13TeV-pythia8/RunIIWinter19PFCalib18GS-105X_upgrade2018_realistic_v4-v1/GEN-SIM": {


### PR DESCRIPTION
Fixes #788 

#### Status
not tested

#### Description
This PR converts all PSN names into RSE names in the campaign configuration for the secondary locations.

#### Is it backward compatible (if not, which system it affects?)
no

#### Related PRs
none

#### External dependencies / deployment changes
none

#### Mention people to look at PRs
@amaltaro  @scarletnorberg  @jenimal  @z4027163  FYI
