### PR TITLE
Main functionality to get workflow parameters

### DIFF
--- a/assistance/Workflow.py
+++ b/assistance/Workflow.py
@@ -5,19 +5,93 @@ Author     : Hasan Ozturk <haozturk AT cern dot com>
 Description: Workflow class provides all the information needed for the filtering of workflows in assistance manual.
 
 """
+from utils.WebTools import getResponse
+from utils.SearchTools import findKeys
 
 class Workflow:
 
-    def _init_(self, workflow, url='cmsweb.cern.ch'):
+    def __init__(self, workflowName, url='cmsweb.cern.ch'):
         """
         Initialize the Workflow class
-        :param str workflow: is the name of the workflow
+        :param str workflowName: is the name of the workflow
         :param str url: is the url to fetch information from
         """
 
-        super(Workflow, self)._init_()
-        self.workflow = workflow
+        self.workflowName = workflowName
         self.url = url
+        self.workflowParams = self.getWorkflowParams()
+
+    def getWorkflowParams(self):
+
+        """
+        Get the workflow parameters from ReqMgr2.
+        See the `ReqMgr 2 wiki <https://github.com/dmwm/WMCore/wiki/reqmgr2-apis>`_
+        for more details.
+        :returns: Parameters for the workflow from ReqMgr2.
+        :rtype: dict
+        """
+
+        try:
+            result = getResponse(url=self.url,
+                                 endpoint='/reqmgr2/data/request/',
+                                 param=self.workflowName)
+
+            for params in result['result']:
+                for key, item in params.items():
+                    if key == self.workflowName:
+                        self.workflowParams = item
+                        return item
+
+        except Exception as error:
+            print 'Failed to get workflow params from reqmgr for %s '% self.workflowName
+            print str(error) 
+
+    def getPrepID(self):
+        """
+        :param: None
+        :returns: PrepID
+        :rtype: string
+        """
+        return self.workflowParams.get('PrepID')
+
+    def getNumberOfEvents(self):
+        """
+        :param: None
+        :returns: Number of events requested
+        :rtype: int
+        """
+        return self.workflowParams.get('TotalInputEvents')
+
+    def getRequestType(self):
+        """
+        :param: None
+        :returns: Request Type
+        :rtype: string
+        """
+
+        return self.workflowParams.get('RequestType')
+
+    def getSiteWhitelist(self):
+        """
+        :param: None
+        :returns: SiteWhitelist
+        :rtype: string
+        """
+
+        return self.workflowParams.get('SiteWhitelist')
+
+
+    def getCampaigns(self):
+        """
+        Function to get the list of campaigns that this workflow belongs to
+
+        :param: None
+        :returns: list of campaigns that this workflow belongs to
+        :rtype: list of strings
+        """
+        
+        return findKeys('Campaign',self.workflowParams)
+
 
     ## Get runtime related values
 
@@ -65,7 +139,7 @@ class Workflow:
 
     ## Get request related values
 
-    def getPrimaryDataset():
+    def getPrimaryDataset(self):
         """
         :assumption: every production workflow reads just one PD
 
@@ -73,7 +147,8 @@ class Workflow:
         :returns: the name of the PD that this workflow reads
         :rtype: string 
         """
-        pass
+        
+        return findKeys('InputDataset',self.workflowParams)
 
     def getPrimaryDatasetLocation():
         """
@@ -85,7 +160,7 @@ class Workflow:
         """
         pass
 
-    def getSecondaryDatasets():
+    def getSecondaryDatasets(self):
         """
         :info: a workflow can read more than one secondary datasets
 
@@ -93,7 +168,8 @@ class Workflow:
         :returns: list of the names of PUs that this workflow reads
         :rtype: list of strings
         """
-        pass
+        
+        return findKeys('MCPileup',self.workflowParams)
 
     def getSecondaryDatasetsLocation():
         """
@@ -102,16 +178,6 @@ class Workflow:
         :param: None
         :returns: dictionary containing PU name and location pairs
         :rtype: dict
-        """
-        pass
-
-    def getCampaigns():
-        """
-        Function to get the list of campaigns that this workflow belongs to
-
-        :param: None
-        :returns: list of campaigns that this workflow belongs to
-        :rtype: list of strings
         """
         pass
 

--- a/assistance/utils/SearchTools.py
+++ b/assistance/utils/SearchTools.py
@@ -1,0 +1,22 @@
+"""
+File       : SearchTools.py
+Author     : Hasan Ozturk <haozturk AT cern dot com>
+
+Description: Class which contains helper functions for searching in general
+
+"""
+
+# Search the given dict for the given key in maximum depth 2. Return values for the matches
+def findKeys(key, dictionary):
+	values = set()
+	for k, v in dictionary.iteritems():
+		if type(v) is dict:
+			for k2, v2 in v.iteritems():
+				if k2 == key:
+					values.add(v2)
+		elif k == key:
+			values.add(v)
+
+	return list(values)
+
+

--- a/assistance/utils/UnifiedConfiguration.py
+++ b/assistance/utils/UnifiedConfiguration.py
@@ -1,0 +1,32 @@
+"""
+File       : SearchTools.py
+Author     : Hasan Ozturk <haozturk AT cern dot com>
+
+Description: Class for Unified configuration
+
+"""
+
+import json
+import sys
+
+class UnifiedConfiguration:
+    def __init__(self, configFile='unifiedConfiguration.json'):
+        self.configFile = configFile
+        if self.configFile is None:
+            self.configs = self.configFile
+        else:
+            try:
+                self.configs = json.loads(open(self.configFile).read())
+            except Exception as ex:
+                print("Could not read configuration file: %s\nException: %s" %
+                      (self.configFile, str(ex)))
+                sys.exit(124)
+
+    def get(self, parameter):
+        if self.configs:
+            if parameter in self.configs:
+                return self.configs[parameter]['value']
+            else:
+                print parameter, 'is not defined in global configuration'
+                print ','.join(self.configs.keys()), 'possible'
+                sys.exit(124)

--- a/assistance/utils/WebTools.py
+++ b/assistance/utils/WebTools.py
@@ -1,0 +1,41 @@
+"""
+File       : WebTools.py
+Author     : Hasan Ozturk <haozturk AT cern dot com>
+
+Description: Class which contains helper functions for web interaction
+
+"""
+
+import os
+import httplib
+from UnifiedConfiguration import UnifiedConfiguration
+
+# Get necessary parameters
+SC = UnifiedConfiguration('serviceConfiguration.json')
+reqmgr_url = os.getenv('UNIFIED_REQMGR', SC.get('reqmgr_url'))
+
+def getX509Conn(url=reqmgr_url,max_try=5):
+    tries = 0
+    while tries<max_try:
+        try:
+            conn = httplib.HTTPSConnection(url, cert_file = os.getenv('X509_USER_PROXY'), key_file = os.getenv('X509_USER_PROXY'))
+            return conn
+        except:
+            tries+=1
+            pass
+    return None
+
+def getResponse(url, endpoint, param='', headers=None):
+
+    if headers == None:
+        headers = {"Accept":"application/json"}
+
+    try:
+        conn = getX509Conn(url)
+        request= conn.request("GET",endpoint+param,headers=headers)
+        response=conn.getresponse()
+        data = json.loads(response.read())
+        return data
+    except Exception as e:
+        print "Failed to get response from %s" % url+endpoint+param
+        print str(e)


### PR DESCRIPTION
Fixes #794 and #786 

#### Status
tested locally
```
workflow = Workflow('asikdar_RVCMSSW_11_3_0_pre2BuMixing_14_PU__rsb_210203_115825_5941')

print workflow.getPrepID()
print workflow.getNumberOfEvents()
print workflow.getRequestType()
print workflow.getSiteWhitelist()
print workflow.getCampaigns()
print workflow.getPrimaryDataset()
print workflow.getSecondaryDatasets()
```
Output:
```
CMSSW_11_3_0_pre2__fullsim_PU_2021_14TeV-1612349769-BuMixing_14
11746
TaskChain
[u'T1_US_FNAL']
[u'CMSSW_11_3_0_pre2__fullsim_PU_2021_14TeV-1612349769']
[u'/RelValBuMixing_14/CMSSW_11_3_0_pre2-113X_mcRun3_2021_realistic_v2_rsb-v1/GEN-SIM']
[u'/RelValMinBias_14TeV/CMSSW_11_3_0_pre2-113X_mcRun3_2021_realistic_v2_rsb-v1/GEN-SIM']
```

#### Description
This PR includes getter functions for workflow parameters.

#### Is it backward compatible (if not, which system it affects?)
Yes

#### Related PRs
#771

#### External dependencies / deployment changes
Yes:
```
cmsweb.cern.ch/reqmgr2/data/request/
```
See: https://github.com/CMSCompOps/WmAgentScripts/blob/794-fix/assistance/Workflow.py#L35

#### Mention people to look at PRs
@hbakhshi  @z4027163  @amaltaro  @todor-ivanov 

A few notes:

I gathered all util function under `assistance/utils` with separate modules. I am not happy with Unified's huge utils file [1] and I believe having the util functions in a structured way is much better. I wanted have the `utils` folder in the root directory, but I could not make it work due to the Python's challenging package/import structure. If you know how we can do it, please let me know.

I used the following resources as a guide for me in several places. Thanks to the authors of these codes:

1. https://github.com/CMSCompOps/WorkflowWebTools/blob/master/workflowwebtools/workflowinfo.py
2. https://github.com/CMSCompOps/WmAgentScripts/blob/master/utils.py#L6470

[1] https://github.com/CMSCompOps/WmAgentScripts/blob/master/utils.py 
