### PR TITLE
Restrict the sitewhitelist to the sites hosting the PU for workflows with classical mixing PU 

### DIFF
--- a/RucioClient.py
+++ b/RucioClient.py
@@ -10,6 +10,7 @@ Environment:
 """
 
 from rucio.client import Client
+from WMCore.Services.CRIC.CRIC import CRIC
 
 class RucioClient(Client):
     """
@@ -95,4 +96,25 @@ class RucioClient(Client):
             print(str(e))
             return []
         return blocks
+
+    def getDatasetLocationsByAccount(self, dataset, account):
+        """
+        Returns the dataset locations for the given account in terms of computing element (not RSE name). 
+        This function assumes that the returned RSE expression includes only one RSE 
+        """
+        try:
+            rules = self.list_did_rules(self.scope, dataset)
+            RSEs = []
+            for rule in rules:
+                if rule['account'] == account:
+                    RSEs.append(rule['rse_expression'])
+
+            #RSE to CE conversion
+            cric = CRIC()
+            CEs = cric.PNNstoPSNs(RSEs)
+        except Exception as e:
+            print "Exception while getting the dataset location"
+            print(str(e))
+            return []
+        return CEs
 

--- a/utils.py
+++ b/utils.py
@@ -25,7 +25,9 @@ from email.MIMEMultipart import MIMEMultipart
 from email.MIMEText import MIMEText
 from email.Utils import COMMASPACE, formatdate
 from email.utils import make_msgid
-#
+
+from RucioClient import RucioClient
+
 ## add local python paths
 for p in ['/usr/lib64/python2.7/site-packages','/usr/lib/python2.7/site-packages']:
     if not p in sys.path: sys.path.append(p)
@@ -7367,7 +7369,10 @@ class workflowInfo:
             sites_allowed = sorted(SI.sites_eos) #['T2_CH_CERN'] ## and that's it
         elif secondary:
             if self.heavyRead(secondary):
-                sites_allowed = sorted(set(SI.sites_T0s + SI.sites_T1s + SI.sites_with_goodIO))
+                # Get PU locations which are protected by wmcore_transferor in terms of CE/PSN name
+                rucioClient = RucioClient()
+                pileup_locations = rucioClient.getDatasetLocationsByAccount(secondary, "wmcore_transferor")
+                sites_allowed = sorted(set(pileup_locations))
                 print "Reading minbias"
             else:
                 sites_allowed = sorted(set(SI.sites_T0s + SI.sites_T1s + SI.sites_with_goodAAA))

--- a/utils.py
+++ b/utils.py
@@ -7371,8 +7371,10 @@ class workflowInfo:
             if self.heavyRead(secondary):
                 # Get PU locations which are protected by wmcore_transferor in terms of CE/PSN name
                 rucioClient = RucioClient()
-                pileup_locations = rucioClient.getDatasetLocationsByAccount(secondary, "wmcore_transferor")
-                sites_allowed = sorted(set(pileup_locations))
+                for sec in secondary:
+                    pileup_locations = rucioClient.getDatasetLocationsByAccount(sec, "wmcore_transferor")
+                    sites_allowed += pileup_locations
+                sites_allowed = sorted(set(sites_allowed))
                 print "Reading minbias"
             else:
                 sites_allowed = sorted(set(SI.sites_T0s + SI.sites_T1s + SI.sites_with_goodAAA))


### PR DESCRIPTION
Fixes #796 

#### Status
tested locally on branch 796-fix:

```
>>> from utils import workflowInfo
>>> workflow = workflowInfo('cmsweb.cern.ch','cmsunified_task_JME-RunIISummer20UL16DIGI-00004__v1_T_210116_092125_3670')
>>> (lheinput,primary,parent,secondary, sites_allowed, sites_not_allowed) = workflow.getSiteWhiteList()
...
Reading minbias
Initially allow [u'T1_IT_CNAF', u'T2_US_Nebraska']
After all of these, allowing: [u'T1_IT_CNAF', u'T2_US_Nebraska']
After all of these, not allowing: []
>>> sites_allowed
[u'T1_IT_CNAF', u'T2_US_Nebraska']
```

which is correct:
```
[haozturk@lxplus798 ~]$ rucio list-rules cms:/MinBias_TuneCP5_13TeV-pythia8/RunIISummer20UL16SIM-106X_mcRun2_asymptotic_v13-v2/GEN-SIM
ID                                ACCOUNT            SCOPE:NAME                                                                                     STATE[OK/REPL/STUCK]    RSE_EXPRESSION      COPIES  EXPIRES (UTC)        CREATED (UTC)
--------------------------------  -----------------  ---------------------------------------------------------------------------------------------  ----------------------  ----------------  --------  -------------------  -------------------
13e292fb9bfc4f9f848ae4413d90312b  transfer_ops       cms:/MinBias_TuneCP5_13TeV-pythia8/RunIISummer20UL16SIM-106X_mcRun2_asymptotic_v13-v2/GEN-SIM  OK[24096/0/0]           T1_IT_CNAF_Disk          1  2022-10-03 21:44:58  2020-12-10 21:44:58
6ec95a881f544868ae1f2582433b705b  wmcore_transferor  cms:/MinBias_TuneCP5_13TeV-pythia8/RunIISummer20UL16SIM-106X_mcRun2_asymptotic_v13-v2/GEN-SIM  OK[24096/0/0]           T1_IT_CNAF_Disk          1                       2020-10-07 19:33:23
378f22de0ab94bcf9748a152e5ad80b1  wmcore_transferor  cms:/MinBias_TuneCP5_13TeV-pythia8/RunIISummer20UL16SIM-106X_mcRun2_asymptotic_v13-v2/GEN-SIM  OK[24096/0/0]           T2_US_Nebraska           1                       2020-10-07 19:33:23
```

#### Description
This PR restricts the site allowed list into the sites hosting the pileup for workflows with classical mixing pileup. (See #796 for motivation) . Note that it only takes into account locations which are pointed by `wmcore_transferor` account.

This PR gets the pileup locations by looking at the `rse_expression` field of the return value of [1] and it assumes that this RSE expression includes only one RSE name. It fails for any other rse expression. I did this assumption since this was the case for all pileup input data placements that I have seen so far. @amaltaro  @todor-ivanov  could you please check [2] and see if this is a reasonable assumption or not. I am aware that there could be more robust solutions, but since we're going to migrate assignment soon, I did not put much time on the solution and I believe this will work until the migration happens if I do not miss anything.

Lastly, if there are more than one pileup for a given workflow, it aggregates the sites - i.e. it does not take any intersection (maybe it should?)

[1] https://rucio.readthedocs.io/en/latest/api/did.html#rucio.client.didclient.DIDClient.list_did_rules
[2] https://github.com/CMSCompOps/WmAgentScripts/blob/796-fix/RucioClient.py#L106-L114

#### Is it backward compatible (if not, which system it affects?)
No

#### Related PRs
None

#### External dependencies / deployment changes
Yes - it depends on Rucio [1] and CRIC over WMCore environment [2]

[1]https://rucio.readthedocs.io/en/latest/api/did.html#rucio.client.didclient.DIDClient.list_did_rules
[2] https://github.com/dmwm/WMCore/blob/master/src/python/WMCore/Services/CRIC/CRIC.py#L176

#### Mention people to look at PRs
@z4027163  @jenimal  FYI
