### PR TITLE
Do not push inner level SiteWhitelist as a top level Sitewhitelist in the campaigns

### DIFF
--- a/campaignAPI.py
+++ b/campaignAPI.py
@@ -175,10 +175,6 @@ def _getSiteList(keyName, initialValue, uniRecord):
         print("Found internal %s for campaign: %s" % (keyName, uniRecord['name']))
         initialValue = _intersect(initialValue, uniRecord["parameters"][keyName])
 
-    for _, innerDict in uniRecord.get("secondaries", {}).items():
-        if keyName in innerDict:
-            print("Found internal %s for campaign: %s" % (keyName, uniRecord['name']))
-            initialValue = _intersect(initialValue, innerDict[keyName])
     return initialValue
 
 


### PR DESCRIPTION
Fixes #800

#### Status
not tested

#### Description
This PR removes the following functionality in pushing the campaigns to WMCore/CouchDB: Do not push inner level SiteWhitelist as a top level Sitewhitelist in the campaigns

#### Is it backward compatible (if not, which system it affects?)
no

#### Related PRs
None

#### External dependencies / deployment changes
Does not introduce a new external dependency.

#### Mention people to look at PRs
@amaltaro  @z4027163  FYI
