### PR TITLE
Take into account transfer_ops account as well for the assignment of workflows with MB PU

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -7372,8 +7372,9 @@ class workflowInfo:
                 # Get PU locations which are protected by wmcore_transferor in terms of CE/PSN name
                 rucioClient = RucioClient()
                 for sec in secondary:
-                    pileup_locations = rucioClient.getDatasetLocationsByAccount(sec, "wmcore_transferor")
-                    sites_allowed += pileup_locations
+                    pileup_locations_mstransferor = rucioClient.getDatasetLocationsByAccount(sec, "wmcore_transferor")
+                    pileup_locations_transferops = rucioClient.getDatasetLocationsByAccount(sec, "transfer_ops")
+                    sites_allowed += pileup_locations_mstransferor + pileup_locations_transferops
                 sites_allowed = sorted(set(sites_allowed))
                 print "Reading minbias"
             else:


### PR DESCRIPTION
Fixes #804 

#### Status
not tested

#### Description
Take into account transfer_ops account as well for the assignment of workflows with MB PU

#### Is it backward compatible (if not, which system it affects?)
no

#### Related PRs
#796 

#### External dependencies / deployment changes
None

#### Mention people to look at PRs
@z4027163  FYI
