### PR TITLE
Adding new campaigns, turning on FS although waiting for Jordan to up…

### DIFF
--- a/campaigns.json
+++ b/campaigns.json
@@ -1711,10 +1711,6 @@
     "go": true, 
     "lumisize": -1, 
     "maxcopies": 1,
-    "SiteBlacklist": [
-             "T2_CH_CERN",
-             "T2_CH_CERN_HLT"
-                  ],        
     "overflow": {
       "PU": {
         "force": false, 

--- a/campaigns.json
+++ b/campaigns.json
@@ -629,7 +629,7 @@
     "secondaries": {
       "/MinBias_TuneCP5_14TeV-pythia8/Run3Winter20GS-110X_mcRun3_2021_realistic_v6-v1/GEN-SIM": {
         "SiteWhitelist": [
-          "T1_ES_PIC_Disk", 
+          "T1_UK_RAL_Disk", 
           "T1_US_FNAL_Disk"
         ]
       }
@@ -670,14 +670,6 @@
     "lumisize": -1, 
     "maxcopies": 1, 
     "resize": "auto", 
-    "secondaries": {
-      "/MinBias_TuneCP5_14TeV-pythia8/Run3Winter20GS-110X_mcRun3_2021_realistic_v6-v1/GEN-SIM": {
-        "SiteWhitelist": [
-          "T1_ES_PIC_Disk", 
-          "T1_US_FNAL_Disk"
-        ]
-      }
-    }, 
     "secondary_AAA": false
   }, 
   "Run3Winter20DRPremixMiniAOD": {
@@ -795,11 +787,11 @@
     "secondaries": {
            "/MinBias_TuneCP5_14TeV-pythia8/Run3Winter20GS-110X_mcRun3_2021_realistic_v6-v1/GEN-SIM": {
                 "SiteWhitelist": [
-                         "T1_ES_PIC_Disk",
-                         "T1_US_FNAL_Disk"
-                                 ]
-                                     }
-                              },
+                  "T1_ES_PIC_Disk",
+                  "T1_US_FNAL_Disk"
+                           ]
+                      }
+                   },
     "secondary_AAA": false  
   },
   "Phase2D81Spring21GS":{
@@ -1339,9 +1331,9 @@
       }
     },
    "SiteBlacklist": [
-         "T2_CH_CERN",
-         "T2_CH_CERN_HLT"
-               ], 
+     "T2_CH_CERN",
+     "T2_CH_CERN_HLT"
+         ], 
     "partial_copy": 0.95, 
     "resize": "auto", 
     "secondaries": {
@@ -1372,9 +1364,9 @@
       }
     }, 
     "SiteBlacklist": [
-             "T2_CH_CERN",
-             "T2_CH_CERN_HLT"
-                  ], 
+      "T2_CH_CERN",
+      "T2_CH_CERN_HLT"
+          ], 
     "partial_copy": 0.95, 
     "resize": "auto", 
     "secondaries": {
@@ -1397,9 +1389,9 @@
       "T1_US_FNAL_Disk"
     ], 
     "SiteBlacklist": [
-              "T2_CH_CERN",
-               "T2_CH_CERN_HLT"
-                   ],
+      "T2_CH_CERN",
+      "T2_CH_CERN_HLT"
+          ],
     "fractionpass": 0.95, 
     "go": true, 
     "lumisize": -1, 
@@ -1425,9 +1417,9 @@
       }
     },
     "SiteBlacklist": [
-             "T2_CH_CERN",
-             "T2_CH_CERN_HLT"
-                     ], 
+      "T2_CH_CERN",
+      "T2_CH_CERN_HLT"
+           ], 
     "partial_copy": 0.95, 
     "resize": "auto", 
     "secondaries": {
@@ -1445,9 +1437,9 @@
     "go": true, 
     "lumisize": -1, 
     "SiteBlacklist": [
-              "T2_CH_CERN",
-             "T2_CH_CERN_HLT"
-               ],
+      "T2_CH_CERN",
+      "T2_CH_CERN_HLT"
+          ],
     "parameters": {
       "NonCustodialSites": [
         "T2_CH_CERN", 
@@ -1466,9 +1458,9 @@
     "lumisize": -1, 
     "maxcopies": 1, 
     "SiteBlacklist": [
-              "T2_CH_CERN",
-              "T2_CH_CERN_HLT"
-                ],
+      "T2_CH_CERN",
+      "T2_CH_CERN_HLT"
+          ],
     "overflow": {
       "PU": {
         "force": false, 
@@ -1485,9 +1477,9 @@
     "lumisize": -1, 
     "maxcopies": 1, 
     "SiteBlacklist": [
-              "T2_CH_CERN",
-              "T2_CH_CERN_HLT"
-                ],
+       "T2_CH_CERN",
+       "T2_CH_CERN_HLT"
+           ],
     "overflow": {
       "PU": {
         "force": false, 
@@ -1511,9 +1503,9 @@
       }
     }, 
     "SiteBlacklist": [
-              "T2_CH_CERN",
-              "T2_CH_CERN_HLT"
-                 ],
+       "T2_CH_CERN",
+       "T2_CH_CERN_HLT"
+           ],
     "resize": "auto", 
     "secondary_AAA": false, 
     "tune": true
@@ -1522,9 +1514,9 @@
     "fractionpass": 0.95, 
     "go": true, 
     "SiteBlacklist": [
-              "T2_CH_CERN",
-              "T2_CH_CERN_HLT"
-                  ],
+      "T2_CH_CERN",
+      "T2_CH_CERN_HLT"
+         ],
     "lumisize": -1, 
     "maxcopies": 1, 
     "resize": "auto"
@@ -1533,9 +1525,9 @@
     "fractionpass": 0.95, 
     "go": true, 
     "SiteBlacklist": [
-              "T2_CH_CERN",
-              "T2_CH_CERN_HLT"
-                ],
+       "T2_CH_CERN",
+       "T2_CH_CERN_HLT"
+         ],
     "lumisize": -1, 
     "maxcopies": 1, 
     "overflow": {
@@ -1555,9 +1547,9 @@
     "lumisize": -1, 
     "maxcopies": 1,
     "SiteBlacklist": [
-             "T2_CH_CERN",
-             "T2_CH_CERN_HLT"
-                ], 
+       "T2_CH_CERN",
+       "T2_CH_CERN_HLT"
+         ], 
     "overflow": {
       "PU": {
         "force": false, 
@@ -1573,9 +1565,9 @@
     "fractionpass": 0.95, 
     "go": true,
     "SiteBlacklist": [
-            "T2_CH_CERN",
-            "T2_CH_CERN_HLT"
-                  ], 
+       "T2_CH_CERN",
+       "T2_CH_CERN_HLT"
+           ], 
     "lumisize": -1, 
     "maxcopies": 1, 
     "resize": "auto"
@@ -1584,9 +1576,9 @@
     "fractionpass": 0.99, 
     "go": true, 
     "SiteBlacklist": [
-             "T2_CH_CERN",
-             "T2_CH_CERN_HLT"
-               ],
+        "T2_CH_CERN",
+        "T2_CH_CERN_HLT"  
+    ],
     "lumisize": -1, 
     "maxcopies": 1
   }, 
@@ -1595,9 +1587,9 @@
     "go": true, 
     "lumisize": -1, 
     "SiteBlacklist": [
-                  "T2_CH_CERN",
-                  "T2_CH_CERN_HLT"
-                      ],
+       "T2_CH_CERN",
+       "T2_CH_CERN_HLT"
+         ],
     "maxcopies": 1, 
     "overflow": {
       "PU": {
@@ -1614,9 +1606,9 @@
     "fractionpass": 0.99, 
     "go": true, 
     "SiteBlacklist": [
-                 "T2_CH_CERN",
-                 "T2_CH_CERN_HLT"
-                    ],    
+       "T2_CH_CERN",
+       "T2_CH_CERN_HLT"
+          ],    
     "lumisize": -1, 
     "maxcopies": 1
   }, 
@@ -1624,9 +1616,9 @@
     "fractionpass": 0.99, 
     "go": true, 
     "SiteBlacklist": [
-               "T2_CH_CERN",
-               "T2_CH_CERN_HLT"
-                   ],    
+      "T2_CH_CERN",
+      "T2_CH_CERN_HLT"
+          ],    
     "lumisize": -1, 
     "maxcopies": 1
   }, 
@@ -1634,9 +1626,9 @@
     "fractionpass": 0.95, 
     "go": true, 
     "SiteBlacklist": [
-              "T2_CH_CERN",
-              "T2_CH_CERN_HLT"
-                  ],    
+      "T2_CH_CERN",
+      "T2_CH_CERN_HLT"
+          ],    
     "lumisize": -1, 
     "maxcopies": 1, 
     "resize": "auto", 
@@ -1647,9 +1639,9 @@
     "go": true, 
     "lumisize": -1, 
     "SiteBlacklist": [
-             "T2_CH_CERN",
-             "T2_CH_CERN_HLT"
-                   ],        
+       "T2_CH_CERN",
+       "T2_CH_CERN_HLT"
+           ],        
     "maxcopies": 1, 
     "overflow": {
       "PU": {
@@ -1667,9 +1659,9 @@
     "lumisize": -1, 
     "maxcopies": 1,
     "SiteBlacklist": [
-             "T2_CH_CERN",
-             "T2_CH_CERN_HLT"
-                    ],        
+       "T2_CH_CERN",
+       "T2_CH_CERN_HLT"
+          ],        
     "primary_AAA": true, 
     "resize": "auto", 
     "tune": true
@@ -1678,9 +1670,9 @@
     "fractionpass": 0.95, 
     "go": true,
     "SiteBlacklist": [
-                "T2_CH_CERN",
-                "T2_CH_CERN_HLT"
-                    ],    
+       "T2_CH_CERN",
+       "T2_CH_CERN_HLT"
+         ],    
     "lumisize": -1, 
     "maxcopies": 1, 
     "overflow": {

--- a/campaigns.json
+++ b/campaigns.json
@@ -175,10 +175,12 @@
     "secondaries": {
       "/Hydjet_Quenched_Cymbal5Ev8_PbPbMinBias_5020GeV/HiFall15-75X_mcRun2_HeavyIon_v14_75X_mcRun2_HeavyIon_v14-v1/GEN-SIM": {
         "SiteWhitelist": [
-          "T2_US_MIT"
+          "T2_ES_CIEMAT",
+          "T1_RU_JINR_Disk"
         ]
       }
-    }
+    },
+  "secondary_AAA": false
   }, 
   "HINPbPbWinter16pLHE": {
     "custodial": "T1_FR_CCIN2P3_MSS", 
@@ -245,10 +247,12 @@
        "secondaries": {
          "/Hydjet_Quenched_Cymbal5Ev8_PbPbMinBias_5020GeV/HiFall15-75X_mcRun2_HeavyIon_v14_75X_mcRun2_HeavyIon_v14-v1/GEN-SIM": {
           "SiteWhitelist": [
-                     "T2_ES_CIEMAT"
+                     "T2_ES_CIEMAT",
+                     "T1_RU_JINR_Disk"
                            ]
                  }
-         }
+         },
+   "secondary_AAA": false
    },
   "HINPbPbSpring21MiniAOD": {
        "custodial": "T1_FR_CCIN2P3_MSS",
@@ -781,7 +785,44 @@
     }, 
     "secondary_AAA": false, 
     "tune": true
-  }, 
+  },
+  "Phase2Spring21DRMiniAOD":{
+    "fractionpass": 0.95,
+    "go": true,
+    "lumisize": -1,
+    "maxcopies": 1,
+    "resize": "auto",
+    "secondaries": {
+           "/MinBias_TuneCP5_14TeV-pythia8/Run3Winter20GS-110X_mcRun3_2021_realistic_v6-v1/GEN-SIM": {
+                "SiteWhitelist": [
+                         "T1_ES_PIC_Disk",
+                         "T1_US_FNAL_Disk"
+                                 ]
+                                     }
+                              },
+    "secondary_AAA": false  
+  },
+  "Phase2D81Spring21GS":{
+      "fractionpass": 0.95,
+      "go": true,
+      "lumisize": -1,
+      "maxcopies": 1,
+      "resize": "auto"
+  },
+  "Phase2D80Spring21GS":{
+    "fractionpass": 0.95,
+    "go": true,
+    "lumisize": -1,
+    "maxcopies": 1,
+    "resize": "auto"
+  },
+  "Phase2D76Spring21GS":{
+    "fractionpass": 0.95,
+    "go": true,
+    "lumisize": -1,
+    "maxcopies": 1,
+    "resize": "auto"
+  },
   "RunIIAutumn18DRPremix": {
     "SecondaryLocation": [
       "T1_US_FNAL_Disk"
@@ -1296,7 +1337,11 @@
         "max": 0, 
         "pending": 0
       }
-    }, 
+    },
+   "SiteBlacklist": [
+         "T2_CH_CERN",
+         "T2_CH_CERN_HLT"
+               ], 
     "partial_copy": 0.95, 
     "resize": "auto", 
     "secondaries": {
@@ -1306,8 +1351,7 @@
         ]
       }, 
       "/MinBias_TuneCP5_13TeV-pythia8/RunIISummer19UL16SIM-106X_mcRun2_asymptotic_v3-v1/GEN-SIM": {
-        "SiteWhitelist": [
-          "T1_UK_RAL_Disk", 
+        "SiteWhitelist": [ 
           "T1_US_FNAL_Disk"
         ]
       }
@@ -1327,6 +1371,10 @@
         "pending": 0
       }
     }, 
+    "SiteBlacklist": [
+             "T2_CH_CERN",
+             "T2_CH_CERN_HLT"
+                  ], 
     "partial_copy": 0.95, 
     "resize": "auto", 
     "secondaries": {
@@ -1336,8 +1384,7 @@
         ]
       }, 
       "/MinBias_TuneCP5_13TeV-pythia8/RunIISummer19UL16SIM-106X_mcRun2_asymptotic_v3-v1/GEN-SIM": {
-        "SiteWhitelist": [
-          "T1_UK_RAL_Disk", 
+        "SiteWhitelist": [ 
           "T1_US_FNAL_Disk"
         ]
       }
@@ -1349,6 +1396,10 @@
     "SecondaryLocation": [
       "T1_US_FNAL_Disk"
     ], 
+    "SiteBlacklist": [
+              "T2_CH_CERN",
+               "T2_CH_CERN_HLT"
+                   ],
     "fractionpass": 0.95, 
     "go": true, 
     "lumisize": -1, 
@@ -1372,13 +1423,16 @@
         "max": 0, 
         "pending": 0
       }
-    }, 
+    },
+    "SiteBlacklist": [
+             "T2_CH_CERN",
+             "T2_CH_CERN_HLT"
+                     ], 
     "partial_copy": 0.95, 
     "resize": "auto", 
     "secondaries": {
       "/Neutrino_E-10_gun/RunIISummer19ULPrePremix-UL16_106X_mcRun2_asymptotic_v10-v2/PREMIX": {
-        "SecondaryLocation": [
-          "T2_CH_CERN", 
+        "SecondaryLocation": [ 
           "T1_US_FNAL_Disk"
         ]
       }
@@ -1390,6 +1444,10 @@
     "fractionpass": 0.95, 
     "go": true, 
     "lumisize": -1, 
+    "SiteBlacklist": [
+              "T2_CH_CERN",
+             "T2_CH_CERN_HLT"
+               ],
     "parameters": {
       "NonCustodialSites": [
         "T2_CH_CERN", 
@@ -1407,6 +1465,10 @@
     "go": true, 
     "lumisize": -1, 
     "maxcopies": 1, 
+    "SiteBlacklist": [
+              "T2_CH_CERN",
+              "T2_CH_CERN_HLT"
+                ],
     "overflow": {
       "PU": {
         "force": false, 
@@ -1422,6 +1484,10 @@
     "go": true, 
     "lumisize": -1, 
     "maxcopies": 1, 
+    "SiteBlacklist": [
+              "T2_CH_CERN",
+              "T2_CH_CERN_HLT"
+                ],
     "overflow": {
       "PU": {
         "force": false, 
@@ -1444,6 +1510,10 @@
         "pending": 0
       }
     }, 
+    "SiteBlacklist": [
+              "T2_CH_CERN",
+              "T2_CH_CERN_HLT"
+                 ],
     "resize": "auto", 
     "secondary_AAA": false, 
     "tune": true
@@ -1451,6 +1521,10 @@
   "RunIISummer19UL16MiniAOD": {
     "fractionpass": 0.95, 
     "go": true, 
+    "SiteBlacklist": [
+              "T2_CH_CERN",
+              "T2_CH_CERN_HLT"
+                  ],
     "lumisize": -1, 
     "maxcopies": 1, 
     "resize": "auto"
@@ -1458,6 +1532,10 @@
   "RunIISummer19UL16MiniAODAPV": {
     "fractionpass": 0.95, 
     "go": true, 
+    "SiteBlacklist": [
+              "T2_CH_CERN",
+              "T2_CH_CERN_HLT"
+                ],
     "lumisize": -1, 
     "maxcopies": 1, 
     "overflow": {
@@ -1473,9 +1551,13 @@
   }, 
   "RunIISummer19UL16MiniAODAPVv2": {
     "fractionpass": 0.95, 
-    "go": false, 
+    "go": true, 
     "lumisize": -1, 
-    "maxcopies": 1, 
+    "maxcopies": 1,
+    "SiteBlacklist": [
+             "T2_CH_CERN",
+             "T2_CH_CERN_HLT"
+                ], 
     "overflow": {
       "PU": {
         "force": false, 
@@ -1489,7 +1571,11 @@
   }, 
   "RunIISummer19UL16MiniAODv2": {
     "fractionpass": 0.95, 
-    "go": false, 
+    "go": true,
+    "SiteBlacklist": [
+            "T2_CH_CERN",
+            "T2_CH_CERN_HLT"
+                  ], 
     "lumisize": -1, 
     "maxcopies": 1, 
     "resize": "auto"
@@ -1497,6 +1583,10 @@
   "RunIISummer19UL16NanoAOD": {
     "fractionpass": 0.99, 
     "go": true, 
+    "SiteBlacklist": [
+             "T2_CH_CERN",
+             "T2_CH_CERN_HLT"
+               ],
     "lumisize": -1, 
     "maxcopies": 1
   }, 
@@ -1504,6 +1594,10 @@
     "fractionpass": 0.99, 
     "go": true, 
     "lumisize": -1, 
+    "SiteBlacklist": [
+                  "T2_CH_CERN",
+                  "T2_CH_CERN_HLT"
+                      ],
     "maxcopies": 1, 
     "overflow": {
       "PU": {
@@ -1519,18 +1613,30 @@
   "RunIISummer19UL16NanoAODAPVv2": {
     "fractionpass": 0.99, 
     "go": true, 
+    "SiteBlacklist": [
+                 "T2_CH_CERN",
+                 "T2_CH_CERN_HLT"
+                    ],    
     "lumisize": -1, 
     "maxcopies": 1
   }, 
   "RunIISummer19UL16NanoAODv2": {
     "fractionpass": 0.99, 
     "go": true, 
+    "SiteBlacklist": [
+               "T2_CH_CERN",
+               "T2_CH_CERN_HLT"
+                   ],    
     "lumisize": -1, 
     "maxcopies": 1
   }, 
   "RunIISummer19UL16RECO": {
     "fractionpass": 0.95, 
     "go": true, 
+    "SiteBlacklist": [
+              "T2_CH_CERN",
+              "T2_CH_CERN_HLT"
+                  ],    
     "lumisize": -1, 
     "maxcopies": 1, 
     "resize": "auto", 
@@ -1540,6 +1646,10 @@
     "fractionpass": 0.95, 
     "go": true, 
     "lumisize": -1, 
+    "SiteBlacklist": [
+             "T2_CH_CERN",
+             "T2_CH_CERN_HLT"
+                   ],        
     "maxcopies": 1, 
     "overflow": {
       "PU": {
@@ -1555,14 +1665,22 @@
     "fractionpass": 0.95, 
     "go": true, 
     "lumisize": -1, 
-    "maxcopies": 1, 
+    "maxcopies": 1,
+    "SiteBlacklist": [
+             "T2_CH_CERN",
+             "T2_CH_CERN_HLT"
+                    ],        
     "primary_AAA": true, 
     "resize": "auto", 
     "tune": true
   }, 
   "RunIISummer19UL16SIMAPV": {
     "fractionpass": 0.95, 
-    "go": true, 
+    "go": true,
+    "SiteBlacklist": [
+                "T2_CH_CERN",
+                "T2_CH_CERN_HLT"
+                    ],    
     "lumisize": -1, 
     "maxcopies": 1, 
     "overflow": {
@@ -1592,7 +1710,11 @@
     "fractionpass": 0.95, 
     "go": true, 
     "lumisize": -1, 
-    "maxcopies": 1, 
+    "maxcopies": 1,
+    "SiteBlacklist": [
+             "T2_CH_CERN",
+             "T2_CH_CERN_HLT"
+                  ],        
     "overflow": {
       "PU": {
         "force": false, 
@@ -1622,7 +1744,11 @@
   "RunIISummer19UL16wmLHEGENAPV": {
     "fractionpass": 0.95, 
     "go": true, 
-    "lumisize": -1, 
+    "lumisize": -1,
+    "SiteBlacklist": [
+             "T2_CH_CERN",
+             "T2_CH_CERN_HLT"
+                 ],        
     "maxcopies": 1, 
     "overflow": {
       "PU": {
@@ -1988,7 +2114,7 @@
         "max": 0, 
         "pending": 0
       }
-    }, 
+    },
     "partial_copy": 0.95, 
     "resize": "auto", 
     "secondaries": {
@@ -2115,7 +2241,7 @@
         "max": 0, 
         "pending": 0
       }
-    }, 
+    },
     "resize": "auto", 
     "tune": true
   }, 
@@ -3254,7 +3380,7 @@
   },
   "RunIISpring21UL17FSGSPremix": {
     "fractionpass": 0.95,
-    "go": false,
+    "go": true,
     "lumisize": -1,
     "maxcopies": 1,
     "secondaries": {
@@ -3290,7 +3416,7 @@
   },
   "RunIISpring21UL16FSGSPremix": {
     "fractionpass": 0.95,
-    "go": false,
+    "go": true,
     "lumisize": -1,
     "maxcopies": 1,
     "secondaries": {


### PR DESCRIPTION
I want to wait for the FS JIRA to be opened but I hope that will happen tomorrow.

RunIISummer19UL16MiniAODv2 and RunIISummer19UL16MiniAODAPVv2 should be open not sure what happened. This one should have changed that https://github.com/CMSCompOps/WmAgentScripts/pull/836/files 

PRCAMPAIGNS-201
PRCAMPAIGNS-202
PRCAMPAIGNS-203
PRCAMPAIGNS-204 this has a stand in pileup for now

I think the issue with this https://cmsweb.cern.ch/reqmgr2/fetch?rid=pdmvserv_task_PPD-HINPbPbWinter16wmLHEGSHIMix-00002__v1_T_210526_132545_7657 might be that I forgot to add primary_AAA=false so I have added that. Even if there is a different issue because it is GenSim we have decided that it can not be read remotely.

Also last but not least for the RunIISummer19UL16* campaigns I blacklisted CERN and HLT all but the pLHE one. 