### PR TITLE
Do not set TrustPUSitelist to True if there is no secondary

### DIFF
--- a/Unified/assignor.py
+++ b/Unified/assignor.py
@@ -327,8 +327,10 @@ def assignor(url ,specific = None, talk=True, options=None):
             wfh.sendLog('assignor',"Reading primary through xrootd at %s"%sorted(sites_allowed))            
 
         if secondary_aaa:
-            parameters['TrustPUSitelists'] = True
-            wfh.sendLog('assignor',"Reading secondary through xrootd at %s"%sorted(sites_allowed))            
+            # Do not set TrustPUSitelist to True if there is no secondary
+            if secondary:
+                parameters['TrustPUSitelists'] = True
+                wfh.sendLog('assignor',"Reading secondary through xrootd at %s"%sorted(sites_allowed))
 
         ## plain assignment here
         team='production'


### PR DESCRIPTION
Fixes #<GH_Issue_Number>

#### Status
tested

#### Description
Do not set TrustPUSitelist to True if there is no secondary

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
None

#### External dependencies / deployment changes
None

#### Mention people to look at PRs
@z4027163  FYI
