### PR TITLE
Disable some campaings and fix one secondary

### DIFF
--- a/campaigns.json
+++ b/campaigns.json
@@ -669,7 +669,15 @@
     "go": true, 
     "lumisize": -1, 
     "maxcopies": 1, 
-    "resize": "auto", 
+    "resize": "auto",
+    "secondaries": {
+      "/MinBias_TuneCP5_14TeV-pythia8/Run3Winter20GS-110X_mcRun3_2021_realistic_v6-v1/GEN-SIM": {
+        "SiteWhitelist": [
+          "T1_UK_RAL_Disk",
+          "T1_US_FNAL_Disk"
+        ]
+      }
+    },
     "secondary_AAA": false
   }, 
   "Run3Winter20DRPremixMiniAOD": {
@@ -780,7 +788,7 @@
   },
   "Phase2Spring21DRMiniAOD":{
     "fractionpass": 0.95,
-    "go": true,
+    "go": false,
     "lumisize": -1,
     "maxcopies": 1,
     "resize": "auto",
@@ -796,21 +804,21 @@
   },
   "Phase2D81Spring21GS":{
       "fractionpass": 0.95,
-      "go": true,
+      "go": false,
       "lumisize": -1,
       "maxcopies": 1,
       "resize": "auto"
   },
   "Phase2D80Spring21GS":{
     "fractionpass": 0.95,
-    "go": true,
+    "go": false,
     "lumisize": -1,
     "maxcopies": 1,
     "resize": "auto"
   },
   "Phase2D76Spring21GS":{
     "fractionpass": 0.95,
-    "go": true,
+    "go": false,
     "lumisize": -1,
     "maxcopies": 1,
     "resize": "auto"


### PR DESCRIPTION
Disable: 
```
Phase2Spring21DRMiniAOD
Phase2D81Spring21GS
Phase2D80Spring21GS
Phase2D76Spring21GS
```
Since pilots are not finished, yet. 

Fix secondary for: `Run3Winter20DRMiniAOD`
```
$ rucio list-rules cms:/MinBias_TuneCP5_14TeV-pythia8/Run3Winter20GS-110X_mcRun3_2021_realistic_v6-v1/GEN-SIM
/cvmfs/cms.cern.ch/rucio/x86_64/slc7/py2/current/lib/python2.7/site-packages/urllib3/contrib/pyopenssl.py:47: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in the next release.
  from cryptography import x509
ID                                ACCOUNT            SCOPE:NAME                                                                                  STATE[OK/REPL/STUCK]    RSE_EXPRESSION      COPIES  EXPIRES (UTC)    CREATED (UTC)
--------------------------------  -----------------  ------------------------------------------------------------------------------------------  ----------------------  ----------------  --------  ---------------  -------------------
e6917e1a28f546bb91223e28be6575c9  wmcore_transferor  cms:/MinBias_TuneCP5_14TeV-pythia8/Run3Winter20GS-110X_mcRun3_2021_realistic_v6-v1/GEN-SIM  OK[9293/0/0]            T1_UK_RAL_Disk           1                   2020-10-07 17:51:55
6b33200e5d84427b9eab9d5a08714a3f  wmcore_transferor  cms:/MinBias_TuneCP5_14TeV-pythia8/Run3Winter20GS-110X_mcRun3_2021_realistic_v6-v1/GEN-SIM  OK[9293/0/0]            T1_US_FNAL_Disk          1                   2020-10-07 17:51:55
```