### PR TITLE
Correcting a few mistakes, Opening HINPbPbWinter16wmLHEGSHIMix, RunII…

### DIFF
--- a/campaigns.json
+++ b/campaigns.json
@@ -227,7 +227,7 @@
   "HINPbPbWinter16wmLHEGSHIMix": {
        "custodial": "T1_FR_CCIN2P3_MSS",
        "fractionpass": 0.95,
-       "go": false,
+       "go": true,
        "lumisize": -1,
        "maxcopies": 1,
        "parameters": {
@@ -418,7 +418,15 @@
     }, 
     "resize": "auto", 
     "tune": true
-  }, 
+  },
+  "NanoAODv9UL17Data": {
+     "fractionpass": 1,
+     "go": false,
+     "lumisize": -1,
+     "maxcopies": 1,
+     "resize": "auto",
+     "tune": true
+    },
   "Phase2HLTTDRSummer20L1T": {
     "fractionpass": 0.95, 
     "go": true, 
@@ -780,18 +788,10 @@
   },
   "Phase2Spring21DRMiniAOD":{
     "fractionpass": 0.95,
-    "go": true,
+    "go": false,
     "lumisize": -1,
     "maxcopies": 1,
     "resize": "auto",
-    "secondaries": {
-           "/MinBias_TuneCP5_14TeV-pythia8/Run3Winter20GS-110X_mcRun3_2021_realistic_v6-v1/GEN-SIM": {
-                "SiteWhitelist": [
-                  "T1_ES_PIC_Disk",
-                  "T1_US_FNAL_Disk"
-                           ]
-                      }
-                   },
     "secondary_AAA": false  
   },
   "Phase2D81Spring21GS":{
@@ -1153,7 +1153,7 @@
     }, 
     "SecondaryLocation": [
       "T1_US_FNAL_Disk", 
-      "T2_CH_CERN"
+      "T1_RU_JINR_Disk"
     ], 
     "SiteBlacklist": [
       "T2_CH_CERN", 
@@ -1331,9 +1331,9 @@
       }
     },
    "SiteBlacklist": [
-     "T2_CH_CERN",
-     "T2_CH_CERN_HLT"
-         ], 
+         "T2_CH_CERN",
+         "T2_CH_CERN_HLT"
+               ], 
     "partial_copy": 0.95, 
     "resize": "auto", 
     "secondaries": {
@@ -1364,9 +1364,9 @@
       }
     }, 
     "SiteBlacklist": [
-      "T2_CH_CERN",
-      "T2_CH_CERN_HLT"
-          ], 
+             "T2_CH_CERN",
+             "T2_CH_CERN_HLT"
+                  ], 
     "partial_copy": 0.95, 
     "resize": "auto", 
     "secondaries": {
@@ -1389,9 +1389,9 @@
       "T1_US_FNAL_Disk"
     ], 
     "SiteBlacklist": [
-      "T2_CH_CERN",
-      "T2_CH_CERN_HLT"
-          ],
+              "T2_CH_CERN",
+               "T2_CH_CERN_HLT"
+                   ],
     "fractionpass": 0.95, 
     "go": true, 
     "lumisize": -1, 
@@ -1417,9 +1417,9 @@
       }
     },
     "SiteBlacklist": [
-      "T2_CH_CERN",
-      "T2_CH_CERN_HLT"
-           ], 
+             "T2_CH_CERN",
+             "T2_CH_CERN_HLT"
+                     ], 
     "partial_copy": 0.95, 
     "resize": "auto", 
     "secondaries": {
@@ -1437,9 +1437,9 @@
     "go": true, 
     "lumisize": -1, 
     "SiteBlacklist": [
-      "T2_CH_CERN",
-      "T2_CH_CERN_HLT"
-          ],
+              "T2_CH_CERN",
+             "T2_CH_CERN_HLT"
+               ],
     "parameters": {
       "NonCustodialSites": [
         "T2_CH_CERN", 
@@ -1458,9 +1458,9 @@
     "lumisize": -1, 
     "maxcopies": 1, 
     "SiteBlacklist": [
-      "T2_CH_CERN",
-      "T2_CH_CERN_HLT"
-          ],
+              "T2_CH_CERN",
+              "T2_CH_CERN_HLT"
+                ],
     "overflow": {
       "PU": {
         "force": false, 
@@ -1477,9 +1477,9 @@
     "lumisize": -1, 
     "maxcopies": 1, 
     "SiteBlacklist": [
-       "T2_CH_CERN",
-       "T2_CH_CERN_HLT"
-           ],
+              "T2_CH_CERN",
+              "T2_CH_CERN_HLT"
+                ],
     "overflow": {
       "PU": {
         "force": false, 
@@ -1503,9 +1503,9 @@
       }
     }, 
     "SiteBlacklist": [
-       "T2_CH_CERN",
-       "T2_CH_CERN_HLT"
-           ],
+              "T2_CH_CERN",
+              "T2_CH_CERN_HLT"
+                 ],
     "resize": "auto", 
     "secondary_AAA": false, 
     "tune": true
@@ -1514,9 +1514,9 @@
     "fractionpass": 0.95, 
     "go": true, 
     "SiteBlacklist": [
-      "T2_CH_CERN",
-      "T2_CH_CERN_HLT"
-         ],
+              "T2_CH_CERN",
+              "T2_CH_CERN_HLT"
+                  ],
     "lumisize": -1, 
     "maxcopies": 1, 
     "resize": "auto"
@@ -1525,9 +1525,9 @@
     "fractionpass": 0.95, 
     "go": true, 
     "SiteBlacklist": [
-       "T2_CH_CERN",
-       "T2_CH_CERN_HLT"
-         ],
+              "T2_CH_CERN",
+              "T2_CH_CERN_HLT"
+                ],
     "lumisize": -1, 
     "maxcopies": 1, 
     "overflow": {
@@ -1543,13 +1543,13 @@
   }, 
   "RunIISummer19UL16MiniAODAPVv2": {
     "fractionpass": 0.95, 
-    "go": true, 
+    "go": false, 
     "lumisize": -1, 
     "maxcopies": 1,
     "SiteBlacklist": [
-       "T2_CH_CERN",
-       "T2_CH_CERN_HLT"
-         ], 
+             "T2_CH_CERN",
+             "T2_CH_CERN_HLT"
+                ], 
     "overflow": {
       "PU": {
         "force": false, 
@@ -1563,11 +1563,11 @@
   }, 
   "RunIISummer19UL16MiniAODv2": {
     "fractionpass": 0.95, 
-    "go": true,
+    "go": false,
     "SiteBlacklist": [
-       "T2_CH_CERN",
-       "T2_CH_CERN_HLT"
-           ], 
+            "T2_CH_CERN",
+            "T2_CH_CERN_HLT"
+                  ], 
     "lumisize": -1, 
     "maxcopies": 1, 
     "resize": "auto"
@@ -1576,9 +1576,9 @@
     "fractionpass": 0.99, 
     "go": true, 
     "SiteBlacklist": [
-        "T2_CH_CERN",
-        "T2_CH_CERN_HLT"  
-    ],
+             "T2_CH_CERN",
+             "T2_CH_CERN_HLT"
+               ],
     "lumisize": -1, 
     "maxcopies": 1
   }, 
@@ -1587,9 +1587,9 @@
     "go": true, 
     "lumisize": -1, 
     "SiteBlacklist": [
-       "T2_CH_CERN",
-       "T2_CH_CERN_HLT"
-         ],
+                  "T2_CH_CERN",
+                  "T2_CH_CERN_HLT"
+                      ],
     "maxcopies": 1, 
     "overflow": {
       "PU": {
@@ -1606,9 +1606,9 @@
     "fractionpass": 0.99, 
     "go": true, 
     "SiteBlacklist": [
-       "T2_CH_CERN",
-       "T2_CH_CERN_HLT"
-          ],    
+                 "T2_CH_CERN",
+                 "T2_CH_CERN_HLT"
+                    ],    
     "lumisize": -1, 
     "maxcopies": 1
   }, 
@@ -1616,9 +1616,9 @@
     "fractionpass": 0.99, 
     "go": true, 
     "SiteBlacklist": [
-      "T2_CH_CERN",
-      "T2_CH_CERN_HLT"
-          ],    
+               "T2_CH_CERN",
+               "T2_CH_CERN_HLT"
+                   ],    
     "lumisize": -1, 
     "maxcopies": 1
   }, 
@@ -1626,9 +1626,9 @@
     "fractionpass": 0.95, 
     "go": true, 
     "SiteBlacklist": [
-      "T2_CH_CERN",
-      "T2_CH_CERN_HLT"
-          ],    
+              "T2_CH_CERN",
+              "T2_CH_CERN_HLT"
+                  ],    
     "lumisize": -1, 
     "maxcopies": 1, 
     "resize": "auto", 
@@ -1639,9 +1639,9 @@
     "go": true, 
     "lumisize": -1, 
     "SiteBlacklist": [
-       "T2_CH_CERN",
-       "T2_CH_CERN_HLT"
-           ],        
+             "T2_CH_CERN",
+             "T2_CH_CERN_HLT"
+                   ],        
     "maxcopies": 1, 
     "overflow": {
       "PU": {
@@ -1659,9 +1659,9 @@
     "lumisize": -1, 
     "maxcopies": 1,
     "SiteBlacklist": [
-       "T2_CH_CERN",
-       "T2_CH_CERN_HLT"
-          ],        
+             "T2_CH_CERN",
+             "T2_CH_CERN_HLT"
+                    ],        
     "primary_AAA": true, 
     "resize": "auto", 
     "tune": true
@@ -1670,9 +1670,9 @@
     "fractionpass": 0.95, 
     "go": true,
     "SiteBlacklist": [
-       "T2_CH_CERN",
-       "T2_CH_CERN_HLT"
-         ],    
+                "T2_CH_CERN",
+                "T2_CH_CERN_HLT"
+                    ],    
     "lumisize": -1, 
     "maxcopies": 1, 
     "overflow": {
@@ -1726,7 +1726,11 @@
     }, 
     "toDDM": [
       "GEN"
-    ], 
+    ],
+    "SiteBlacklist": [
+        "T2_CH_CERN",
+        "T2_CH_CERN_HLT"
+  ],
     "tune": true
   }, 
   "RunIISummer19UL16wmLHEGENAPV": {
@@ -1734,9 +1738,9 @@
     "go": true, 
     "lumisize": -1,
     "SiteBlacklist": [
-             "T2_CH_CERN",
-             "T2_CH_CERN_HLT"
-                 ],        
+       "T2_CH_CERN",
+       "T2_CH_CERN_HLT"
+         ],        
     "maxcopies": 1, 
     "overflow": {
       "PU": {
@@ -1775,7 +1779,11 @@
   "RunIISummer19UL17DIGIPremix": {
     "SecondaryLocation": [
       "T1_US_FNAL_Disk"
-    ], 
+    ],
+    "SiteBlacklist": [
+        "T2_CH_CERN",
+        "T2_CH_CERN_HLT"
+    ],
     "fractionpass": 0.95, 
     "go": true, 
     "lumisize": -1, 
@@ -1797,7 +1805,11 @@
         "T2_CH_CERN", 
         "T1_US_FNAL"
       ]
-    }, 
+    },
+    "SiteBlacklist": [ 
+       "T2_CH_CERN",
+       "T2_CH_CERN_HLT"
+           ],
     "resize": "auto", 
     "toDDM": [
       "GEN"
@@ -1809,6 +1821,10 @@
     "go": true, 
     "lumisize": -1, 
     "maxcopies": 1, 
+    "SiteBlacklist": [
+        "T2_CH_CERN",
+        "T2_CH_CERN_HLT"
+            ],
     "overflow": {
       "PU": {
         "force": false, 
@@ -1822,6 +1838,10 @@
   "RunIISummer19UL17MiniAOD": {
     "fractionpass": 0.95, 
     "go": true, 
+    "SiteBlacklist": [
+        "T2_CH_CERN",
+        "T2_CH_CERN_HLT"
+            ],
     "lumisize": -1, 
     "maxcopies": 1, 
     "resize": "auto"
@@ -1830,26 +1850,42 @@
     "fractionpass": 0.95, 
     "go": true, 
     "lumisize": -1, 
+    "SiteBlacklist": [
+        "T2_CH_CERN",
+        "T2_CH_CERN_HLT"
+            ],
     "maxcopies": 1, 
     "resize": "auto"
   }, 
   "RunIISummer19UL17NanoAOD": {
     "fractionpass": 0.99, 
     "go": true, 
-    "lumisize": -1, 
+    "lumisize": -1,
+    "SiteBlacklist": [
+      "T2_CH_CERN",
+      "T2_CH_CERN_HLT"
+         ], 
     "maxcopies": 1
   }, 
   "RunIISummer19UL17NanoAODv2": {
     "fractionpass": 0.99, 
     "go": true, 
     "lumisize": -1, 
+    "SiteBlacklist": [
+        "T2_CH_CERN",
+        "T2_CH_CERN_HLT"
+            ],
     "maxcopies": 1
   }, 
   "RunIISummer19UL17RECO": {
     "fractionpass": 0.95, 
     "go": true, 
     "lumisize": -1, 
-    "maxcopies": 1, 
+    "maxcopies": 1,
+    "SiteBlacklist": [
+      "T2_CH_CERN",
+      "T2_CH_CERN_HLT"
+         ], 
     "resize": "auto", 
     "tune": true
   }, 
@@ -1858,6 +1894,10 @@
     "go": true, 
     "lumisize": -1, 
     "maxcopies": 1, 
+    "SiteBlacklist": [
+        "T2_CH_CERN",
+        "T2_CH_CERN_HLT"
+            ],
     "overflow": {
       "PRIM": {}
     }, 
@@ -1880,7 +1920,11 @@
   "RunIISummer19UL17wmLHEGEN": {
     "fractionpass": 0.95, 
     "go": true, 
-    "lumisize": -1, 
+    "lumisize": -1,
+    "SiteBlacklist": [
+      "T2_CH_CERN",
+      "T2_CH_CERN_HLT"
+         ], 
     "overflow": {
       "PREMIX": {}
     }, 
@@ -1921,7 +1965,7 @@
   "RunIISummer19UL18DIGIPremix": {
     "SecondaryLocation": [
       "T1_US_FNAL_Disk", 
-      "T2_CH_CERN"
+      "T1_FR_CCIN2P3_Disk"
     ], 
     "SiteBlacklist": [
       "T2_CH_CERN", 


### PR DESCRIPTION
RunIISummer19UL17* blacklisted CERN and CERN_HLT all but the pLHE and pLHEGEN https://its.cern.ch/jira/browse/CMSTRANSF-262

PRCAMPAIGNS-191 open pilot successful 
PRCAMPAIGNS-201 pilot successful
PRCAMPAIGNS-202 pilot successful
PRCAMPAIGNS-203 pilot successful

Removed the secondary for Phase2Spring21DRMiniAOD PRCAMPAIGNS-204 as per our agreement

Closed RunIISummer19UL16MiniAOD*v2 as pilot was never actually ran 
