### PR TITLE
Redoing the turning of campaigns

### DIFF
--- a/campaigns.json
+++ b/campaigns.json
@@ -804,21 +804,21 @@
   },
   "Phase2D81Spring21GS":{
       "fractionpass": 0.95,
-      "go": false,
+      "go": true,
       "lumisize": -1,
       "maxcopies": 1,
       "resize": "auto"
   },
   "Phase2D80Spring21GS":{
     "fractionpass": 0.95,
-    "go": false,
+    "go": true,
     "lumisize": -1,
     "maxcopies": 1,
     "resize": "auto"
   },
   "Phase2D76Spring21GS":{
     "fractionpass": 0.95,
-    "go": false,
+    "go": true,
     "lumisize": -1,
     "maxcopies": 1,
     "resize": "auto"
@@ -3426,9 +3426,9 @@
     "secondaries": {
       "/RelValFS_PREMIXUP17_PU50/CMSSW_10_6_22-PU_106X_mc2017_realistic_v9_FastSim-v1/PREMIX": 
       {
-            "SiteWhitelist": [
-               "T2_CH_CERN"
-             ]
+          "SiteWhitelist": [
+              "T2_CH_CERN"
+          ]
       }
     },
     "SecondaryLocation": [
@@ -3442,12 +3442,12 @@
     "lumisize": -1,
     "maxcopies": 1,
     "secondaries": {
-      "/RelValFS_PREMIXUP17_PU50/CMSSW_10_6_22-PU_106X_mc2017_realistic_v9_FastSim-v1/PREMIX": 
-                {
-                 "SiteWhitelist": [
-                             "T2_CH_CERN"
-                                           ]
-                              }
+       "/RelValFS_PREMIXUP17_PU50/CMSSW_10_6_22-PU_106X_mc2017_realistic_v9_FastSim-v1/PREMIX": 
+       {
+           "SiteWhitelist": [
+               "T2_CH_CERN"
+           ]
+       }
     },
     "SecondaryLocation": [
       "T2_CH_CERN"
@@ -3461,11 +3461,11 @@
     "maxcopies": 1,
     "secondaries": {
       "/RelValFS_PREMIXUP15_PU25/CMSSW_10_6_22-PU_106X_mcRun2_asymptotic_v16_FastSim-v1/PREMIX": 
-                {
-                     "SiteWhitelist": [
-                               "T2_CH_CERN"
-                                       ]
-                           }
+      {
+          "SiteWhitelist": [
+              "T2_CH_CERN"
+          ]
+      }
     },
     "SecondaryLocation": [
       "T2_CH_CERN"
@@ -3479,11 +3479,11 @@
     "maxcopies": 1,
     "secondaries": {
       "/RelValFS_PREMIXUP15_PU25/CMSSW_10_6_22-PU_106X_mcRun2_asymptotic_v16_FastSim-v1/PREMIX": 
-                {
-                     "SiteWhitelist": [
-                                "T2_CH_CERN"
-                                              ]
-                                         }
+      {
+          "SiteWhitelist": [
+              "T2_CH_CERN"
+          ]
+      }
     },
     "SecondaryLocation": [
       "T2_CH_CERN"
@@ -3497,11 +3497,11 @@
     "maxcopies": 1,
     "secondaries": {
       "/RelValFS_PREMIXUP15_PU25/CMSSW_10_6_22-PU_106X_mcRun2_asymptotic_v16_FastSim-v1/PREMIX": 
-                {
-                      "SiteWhitelist": [
-                                "T2_CH_CERN"
-                                                   ]
-                                            }
+      {
+          "SiteWhitelist": [
+              "T2_CH_CERN"
+          ]
+      }
     },
     "SecondaryLocation": [
       "T2_CH_CERN"


### PR DESCRIPTION
PRCAMPAIGNS-201 pilot successful
PRCAMPAIGNS-202 pilot successful
PRCAMPAIGNS-203 pilot successful

Yes pilot was successful 2.1 days ago

PRCAMPAIGNS-191 open pilot successful This one finished this morning and showed 

Number of events requested | 20,000
-- | --
Number of events produced | 19,764 (98.8%)
But is I checked:
/DYJetsToLL_TuneCUETP8M1_5020GeV-amcatnloFXFX-pythia8/HINPbPbWinter16wmLHEGSHIMix-75X_mcRun2_HeavyIon_v14-v1/GEN-SIM 21/21 = 100.00%
/DYJetsToLL_TuneCUETP8M1_5020GeV-amcatnloFXFX-pythia8/HINPbPbWinter16wmLHEGSHIMix-75X_mcRun2_HeavyIon_v14-v1/LHE 21/21 = 100.00%

It seems to think it is 100% of the lumi blocks are done. There was an issue that talks about this so I think it is done and left it as go is true.
https://dmytro.web.cern.ch/dmytro/cmsprodmon/workflows.php?prep_id=task_PPD-HINPbPbWinter16wmLHEGSHIMix-00002
https://cms-unified.web.cern.ch/cms-unified/showlog/?search=task_PPD-HINPbPbWinter16wmLHEGSHIMix-00002
The WF has not errors and everything looks ok so I say open it but again double check if you agree.
Also mentioned it on slack. 
Let me know what you think Hasan.