### PR TITLE
Alter filter efficiency in resubmit.py

### DIFF
--- a/resubmit.py
+++ b/resubmit.py
@@ -136,7 +136,7 @@ def modifySchema(cache, workflow, user, group, events, firstLumi, backfill=False
                     stepName = "Task%s" % str(taskNumber)
                 if stepName in result:
                     if "FilterEfficiency" in result[stepName]:
-                        result["FilterEfficiency"] = float(filterEff)
+                        result[stepName]["FilterEfficiency"] = float(filterEff)
                     else:
                         raise Exception("There is no FilterEfficiency in %s" % stepName)
                 else:

--- a/resubmit.py
+++ b/resubmit.py
@@ -34,7 +34,7 @@ reqmgrCouchURL = "https://cmsweb.cern.ch/couchdb/reqmgr_workload_cache"
 DELTA_EVENTS = 1000
 DELTA_LUMIS = 200
 
-def modifySchema(cache, workflow, user, group, events, firstLumi, backfill=False, memory=None, timeperevent=None):
+def modifySchema(cache, workflow, user, group, events, firstLumi, backfill=False, memory=None, timeperevent=None, filterEff=None, taskNumber=None):
     """
     Adapts schema to right parameters.
     If the original workflow points to DBS2, DBS3 URL is fixed instead.
@@ -127,16 +127,35 @@ def modifySchema(cache, workflow, user, group, events, firstLumi, backfill=False
     if 'Step1' in result and 'InputDataset' in result['Step1'] and result['Step1']['InputDataset']:
         result['Step1'].pop('RequestNumEvents', None)
 
+    if filterEff:
+        if taskNumber:
+            if "RequestType" in result:
+                if result["RequestType"] == "StepChain":
+                    stepName = "Step%s" % str(taskNumber)
+                else:
+                    stepName = "Task%s" % str(taskNumber)
+                if stepName in result:
+                    if "FilterEfficiency" in result[stepName]:
+                        result["FilterEfficiency"] = float(filterEff)
+                    else:
+                        raise Exception("There is no FilterEfficiency in %s" % stepName)
+                else:
+                    raise Exception("There is no step called %s" % stepName)
+            else:
+                raise Exception("The Request Type is not identified")
+        else:
+            raise Exception("A task number should be provided for which to update filter efficiency")
+
     return result
 
-def cloneWorkflow(workflow, user, group, verbose=True, backfill=False, testbed=False, memory=None, timeperevent=None, bwl=None):
+def cloneWorkflow(workflow, user, group, verbose=True, backfill=False, testbed=False, memory=None, timeperevent=None, bwl=None, filterEff=None, taskNumber=None):
     """
     clones a workflow
     """
     # Adapt schema and add original request to it
     cache = reqMgrClient.getWorkflowInfo(url, workflow)
 
-    schema = modifySchema(cache, workflow, user, group, None, None, backfill, memory, timeperevent)
+    schema = modifySchema(cache, workflow, user, group, None, None, backfill, memory, timeperevent, filterEff, taskNumber)
 
     if verbose:
         pprint(schema)
@@ -272,6 +291,8 @@ def main():
     parser.add_option("--TimePerEvent", help="Set the TimePerEvent on the clone")
     parser.add_option("--testbed", action="store_true", dest="testbed", default=False,
                       help="Clone to testbed reqmgr insted of production")
+    parser.add_option('--filterEff', help='filter efficiency of given task/step', dest='filterEff', default=None)
+    parser.add_option('--taskNumber', help='taskNumber for which to change filterEff', dest='taskNumber', default=None)
     (options, args) = parser.parse_args()
 
     # Check the arguments, get info from them
@@ -301,7 +322,7 @@ def main():
             if options.TimePerEvent:
                 timeperevent = float(options.TimePerEvent)
             cloneWorkflow(
-                wf, user, options.group, options.verbose, options.backfill, options.testbed, memory,timeperevent,bwl=options.bwl)
+                wf, user, options.group, options.verbose, options.backfill, options.testbed, memory,timeperevent,bwl=options.bwl, filterEff=options.filterEff, taskNumber=options.taskNumber)
     elif options.action == 'extend':
         for wf in wfs:
             extendWorkflow(wf, user, options.group, options.verbose, options.events, options.firstlumi)


### PR DESCRIPTION
Fixes #847

#### Status
tested w/ a stepchain: https://cmsweb.cern.ch/reqmgr2/fetch?rid=haozturk_task_BPH-RunIISummer20UL16GENAPV-00054__v1_T_210612_132502_1869
not tested w/ a taskchain yet

#### Description
With this PR, we can alter filter efficiency of a given task or step of a workflow. Example usage: 
```
python resubmit.py -a clone -b --filterEff 0.0002 --taskNumber 1 cmsunified_task_BPH-RunIISummer20UL16GENAPV-00054__v1_T_210506_102253_8154
```

#### Related PRs
None

#### External dependencies / deployment changes
No additional dependency

#### Mention people to look at PRs
@z4027163  FYI
