### PR TITLE
Fix secondary for pPb816Spring16GS

### DIFF
--- a/campaigns.json
+++ b/campaigns.json
@@ -3034,7 +3034,11 @@
     }, 
     "secondaries": {
       "/ReggeGribovPartonMC_EposLHC_pPb_4080_4080/pPb816Spring16GS-80X_mcRun2_asymptotic_v17-v1/GEN-SIM": {
-        "SiteWhitelist": "T2_US_MIT"
+        "SiteWhitelist": [
+          "T2_CH_CERN",
+          "T2_IT_Pisa",
+          "T1_IT_CNAF_Disk"
+        ]
       }
     }
   }, 


### PR DESCRIPTION
Fixes secondary for pPb816Spring16GS. We should include CERN because of the pLHE requests. Secondary is about 5TB, so, space is not an issue. 
