### PR TITLE
Set workflows to staged status manually

### DIFF
--- a/reqMgrClient.py
+++ b/reqMgrClient.py
@@ -1346,7 +1346,32 @@ def getInputEventsTaskChain(request):
 #            print "Hey, you have NO block and run black list :-("
 
 
+def setStatusToStaged(url, workflowname, cascade=False):
+    """
+    Closes out a workflow by changing the state to closed-out
+    This does not care about cascade workflows
+    """
+    if isRequestMgr2Request(url, workflowname):
+        params = {"RequestStatus" : "staged",
+                  "cascade": cascade}
+        try:
+            data = requestManagerPut(url,"/reqmgr2/data/request/%s"%workflowname, params)
+        except Exception as e:
+            print "ERROR:"
+            print e
 
+        try:
+            return None if (json.loads(data)['result'][0][workflowname] == 'OK') else "Error"
+        except:
+            return "Error"
+    else:
+        if cascade:
+            params = {"requestName" : workflowname,"cascade" : cascade}
+            data = requestManager1Post(url,"/reqmgr/reqMgr/staged", params)
+        else:
+            params = {"requestName" : workflowname,"status" : "staged"}
+            data = requestManager1Put(url,"/reqmgr/reqMgr/request", params)
+    return data
 
 
 if __name__ == "__main__":

--- a/setReqMgrStatus.py
+++ b/setReqMgrStatus.py
@@ -4,8 +4,7 @@ import optparse
 
 
 def setStatus(url, workflowname, newstatus, cascade):
-    print
-    "Setting %s to %s" % (workflowname, newstatus)
+    print "Setting %s to %s" % (workflowname, newstatus)
     if newstatus == 'closed-out':
         return reqmgr.closeOutWorkflow(url, workflowname, cascade)
     elif newstatus == 'announced':
@@ -13,8 +12,7 @@ def setStatus(url, workflowname, newstatus, cascade):
     elif newstatus == "staged":
         return reqmgr.setStatusToStaged(url, workflowname, cascade)
     else:
-        print
-        "ERROR: Cannot set status to ", newstatus
+        print "ERROR: Cannot set status to ", newstatus
 
 
 def main():
@@ -38,5 +36,5 @@ def main():
         parser.error("You should provide either workflow or file options")
 
 
-if __name__ == "_main_":
+if __name__ == "__main__":
     main()

--- a/setReqMgrStatus.py
+++ b/setReqMgrStatus.py
@@ -30,7 +30,7 @@ def main():
     if options.workflow:
         setStatus(options.url, options.workflow, options.status, options.cascade)
     elif options.file:
-        for workflow in filter(None, open(options.filelist).read().split('\n')):
+        for workflow in filter(None, open(options.file).read().split('\n')):
             setStatus(options.url, workflow, options.status, options.cascade)
     else:
         parser.error("You should provide either workflow or file options")


### PR DESCRIPTION
Fixes #864 

#### Status
tested w/ https://its.cern.ch/jira/browse/CMSCOMPPR-19530 

#### Description
Currently we only support "to staged", "to closed-out" and "to announced" transitions. The script can be improved, but it works for now. 

Example use:
```
python setReqMgrStatus.py -f ~/workflowsToStaged.txt -s staged
```

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
None

#### External dependencies / deployment changes
ReqMgr

#### Mention people to look at PRs
@z4027163 
