### PR TITLE
Lower stepchain conversion threshold for high priority workflows

### DIFF
--- a/unifiedConfiguration.json
+++ b/unifiedConfiguration.json
@@ -413,6 +413,14 @@
    "description" : "Minimum efficiency threshold for step chain conversion",
    "value" : 0.90
   },
+  "stepchain_threshold_for_high_priority_requests":{
+   "description" : "Minimum efficiency threshold for step chain conversion of high priority requests",
+   "value" : 0.50
+  },
+  "block1_priority":{
+   "description" : "The value determines the priority of block1 requests",
+   "value" : 110000
+  },
   "sites_for_DQMHarvest": {
     "value" : ["T2_CH_CERN","T1_US_FNAL"],
     "description" : "The sites to assign DQM/DMQIO harvesting workflows"

--- a/utils.py
+++ b/utils.py
@@ -3903,6 +3903,12 @@ class workflowInfo:
                         print('EventStreams is ' + str(value['EventStreams']) + ' do not convert')
                         return False
 
+        threshold = self.UC.get("efficiency_threshold_for_stepchain")
+        isHighPriority = False
+        if self.request["RequestPriority"] >= self.UC.get("block1_priority"):
+            threshold = self.UC.get("stepchain_threshold_for_high_priority_requests")
+            isHighPriority = True
+
         all_same_arch = True
 
         ## efficiency 
@@ -3919,7 +3925,7 @@ class workflowInfo:
             if totalTimePerEvent > 0:
                 efficiency /= totalTimePerEvent * max_nCores
                 if debug: print "CPU efficiency of StepChain with %u cores: %0.1f%%" % (max_nCores, efficiency * 100)
-                acceptable_efficiency = efficiency > self.UC.get("efficiency_threshold_for_stepchain")
+                acceptable_efficiency = efficiency > threshold
             else:
                 acceptable_efficiency = False
         except TypeError:
@@ -3959,6 +3965,18 @@ class workflowInfo:
         if not good and talk:
             print "cores",all_same_cores
             print "parentage",output_from_single_task
+
+
+        # Report
+        if good:
+            if isHighPriority:
+                print ("High priority workflow %s is converted to stepchain with efficiency %s" % (self.request['RequestName'], str(efficiency)) )
+            else:
+                print ("Low priority workflow %s is converted to stepchain with efficiency %s" % (
+                self.request['RequestName'], str(efficiency)))
+        else:
+            print("Workflow %s is not converted to stepchain with efficiency %s" % (
+                self.request['RequestName'], str(efficiency)))
         return good
 
 

--- a/utils.py
+++ b/utils.py
@@ -3895,6 +3895,13 @@ class workflowInfo:
         # Conversion is supported only from TaskChain to StepChain
         if self.request['RequestType'] != 'TaskChain': return False
 
+        # Do not convert if there is only 1 task
+        if 'TaskChain' in self.request:
+            if self.request['TaskChain'] <= 1:
+                print("Workflow %s is not converted to stepchain: it has 0 or 1 task" % (
+                    self.request['RequestName']))
+                return False
+
         # Conversion is not supported if there is a task whose EventStreams is nonzero 
         for key,value in self.request.items():
             if key.startswith('Task') and type(value) is dict: 

--- a/utils.py
+++ b/utils.py
@@ -3910,13 +3910,12 @@ class workflowInfo:
             isHighPriority = True
 
         all_same_arch = True
-
+        efficiency = 0
         ## efficiency 
         try:
             time_info = self.getTimeInfoForChain()
             if debug: print time_info
             totalTimePerEvent = 0
-            efficiency = 0
             max_nCores = self.UC.get("max_nCores_for_stepchain")
             for i,info in time_info.items():
                 totalTimePerEvent += info['tpe']

--- a/utils.py
+++ b/utils.py
@@ -3898,7 +3898,7 @@ class workflowInfo:
         # Do not convert if there is only 1 task
         if 'TaskChain' in self.request:
             if self.request['TaskChain'] <= 1:
-                print("Workflow %s is not converted to stepchain: it has 0 or 1 task" % (
+                print("Workflow %s is not converted to stepchain: it has 1 task" % (
                     self.request['RequestName']))
                 return False
 

--- a/utils.py
+++ b/utils.py
@@ -3976,9 +3976,9 @@ class workflowInfo:
         # Report
         if good:
             if isHighPriority:
-                print ("High priority workflow %s is converted to stepchain with efficiency %s" % (self.request['RequestName'], str(efficiency)) )
+                print ("High priority workflow %s is okay to be converted to stepchain with efficiency %s" % (self.request['RequestName'], str(efficiency)) )
             else:
-                print ("Low priority workflow %s is converted to stepchain with efficiency %s" % (
+                print ("Low priority workflow %s is is okay to be converted to stepchain with efficiency %s" % (
                 self.request['RequestName'], str(efficiency)))
         else:
             print("Workflow %s is not converted to stepchain with efficiency %s" % (


### PR DESCRIPTION
Fixes #872

#### Status
tested:
High priority workflow: 
```
$ python Unified/step_chain_test.py pdmvserv_task_EXO-RunIISummer15wmLHEGS-12830__v1_T_210705_212330_4936

{u'Task1': {'cores': 1, 'tpe': 15.995700000000001}, u'Task2': {'cores': 8, 'tpe': 17}, u'Task3': {'cores': 8, 'tpe': 17}, u'Task4': {'cores': 8, 'tpe': 0.1985}}
Total time per event for TaskChain: 50.2
CPU efficiency of StepChain with 4 cores: 76.1%
High priority workflow pdmvserv_task_EXO-RunIISummer15wmLHEGS-12830__v1_T_210705_212330_4936 is okay to be converted to stepchain with efficiency 0.760992803949
pdmvserv_task_EXO-RunIISummer15wmLHEGS-12830__v1_T_210705_212330_4936: True
```
Low priority workflow:
```
$ python Unified/step_chain_test.py pdmvserv_task_B2G-RunIISummer15wmLHEGS-05564__v1_T_210703_205629_7185

{u'Task1': {'cores': 1, 'tpe': 65.1296}, u'Task2': {'cores': 8, 'tpe': 17}, u'Task3': {'cores': 8, 'tpe': 17}, u'Task4': {'cores': 8, 'tpe': 0.1985}}
Total time per event for TaskChain: 99.3
CPU efficiency of StepChain with 4 cores: 50.8%
Workflow pdmvserv_task_B2G-RunIISummer15wmLHEGS-05564__v1_T_210703_205629_7185 is not converted to stepchain with efficiency 0.508223755413
pdmvserv_task_B2G-RunIISummer15wmLHEGS-05564__v1_T_210703_205629_7185: False
```

#### Description
This PR lowers stepchain conversion threshold from `0.9` to `0.5` for high priority workflows. This decision has been discussed and agreed in one of the compops meetings: https://twiki.cern.ch/twiki/bin/view/CMS/CompOpsMeeting?rev=1764#Production_Manager_Report 

This PR also puts an explicit check to avoid conversion for taskchains w/ only 1 task.

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
None

#### External dependencies / deployment changes
None

#### Mention people to look at PRs
@drkovalskyi  @z4027163  @jenimal  FYI
