### PR TITLE
Adding in RunII*NanoAODv6 camapigns because of some WF's in the syste…

### DIFF
--- a/archive_campaigns.json
+++ b/archive_campaigns.json
@@ -426,12 +426,6 @@
     "resize": "auto",
     "tune": true
   },
-  "RunIISummer16NanoAODv6": {
-    "fractionpass": 0.99,
-    "go": true,
-    "lumisize": -1,
-    "maxcopies": 1
-  },
   "RunIISummer16NanoAODv5": {
     "fractionpass": 0.99,
     "go": true,
@@ -445,19 +439,7 @@
     "lumisize": -1,
     "maxcopies": 1
   },
-  "RunIIFall17NanoAODv6": {
-    "fractionpass": 0.99,
-    "go": true,
-    "lumisize": -1,
-    "maxcopies": 1
-  },
   "RunIIFall17NanoAODv5": {
-    "fractionpass": 0.99,
-    "go": true,
-    "lumisize": -1,
-    "maxcopies": 1
-  },
-  "RunIIAutumn18NanoAODv6": {
     "fractionpass": 0.99,
     "go": true,
     "lumisize": -1,

--- a/campaigns.json
+++ b/campaigns.json
@@ -773,6 +773,12 @@
     "lumisize": -1, 
     "maxcopies": 1, 
     "resize": "auto"
+  },
+  "RunIIAutumn18NanoAODv6": {
+    "fractionpass": 0.99,
+    "go": true,
+    "lumisize": -1,
+    "maxcopies": 1
   }, 
   "RunIIAutumn18NanoAODv7": {
     "fractionpass": 0.99, 
@@ -883,6 +889,12 @@
     "lumisize": -1, 
     "maxcopies": 1, 
     "resize": "auto"
+  },
+  "RunIIFall17NanoAODv6": {
+    "fractionpass": 0.99,
+    "go": true,
+    "lumisize": -1,
+    "maxcopies": 1
   }, 
   "RunIIFall17NanoAODv7": {
     "fractionpass": 0.99, 
@@ -1085,6 +1097,12 @@
     "fractionpass": 0.95, 
     "go": true, 
     "lumisize": -1, 
+    "maxcopies": 1
+  },
+  "RunIISummer16NanoAODv6": {
+    "fractionpass": 0.99,
+    "go": true,
+    "lumisize": -1,
     "maxcopies": 1
   }, 
   "RunIISummer16NanoAODv7": {


### PR DESCRIPTION
Some WF's were found injected or unstuck after the decision to close so cross checking with PDMV to see what is going in the mean time un archiving the RunII*NanoAODv6 campaign to fix issues in WMCore.