### PR TITLE
Temporarily disable prioritization in checkor to circumvent issue 886

### DIFF
--- a/Unified/checkor.py
+++ b/Unified/checkor.py
@@ -230,7 +230,7 @@ def checkor(url, spec=None, options=None):
         max_per_round=options.limit
     if max_per_round and not spec: 
         print "limiting to",max_per_round,"this round"
-
+        """
         ##should be ordering by priority if you can
         ## order wfs with rank of wfname
         all_completed_plus = sorted(getWorkflows(url, 'completed' , details=True), key = lambda r : r['RequestPriority'])
@@ -239,6 +239,7 @@ def checkor(url, spec=None, options=None):
             return all_completed_plus.index( wfn ) if wfn in all_completed_plus else 0
         wfs = sorted( wfs, key = lambda wfo : rank( wfo.name ),reverse=True)
         if options.update: random.shuffle( wfs )
+        """
         wfs = wfs[:max_per_round]
 
     total_running_time = 1.*60. 


### PR DESCRIPTION
Not fixes but circumvents #886

#### Status
not tested

#### Description
Prioritization in checkor is not critical. Maximum number of workflows processed in a round is 500 and we have 1.2k workflows in `completed` right now, which is the highest number for months. Checkor's duty cycle is couple of hours in general, so it shouldn't delay the high prio stuff w/ this PR. This quick workaround is needed to digest the workflows in the system quickly and open-up some space in the unmerged space, which is quite critical right now.

#### Is it backward compatible (if not, which system it affects?)
yes

#### Related PRs
None

#### External dependencies / deployment changes
None

#### Mention people to look at PRs
@z4027163  FYI
