### PR TITLE
Set memory within tasks (not global) for the ACDC of taskchains

### DIFF
--- a/Unified/actor.py
+++ b/Unified/actor.py
@@ -76,12 +76,15 @@ def singleRecovery(url, task, initial, actions, do=False, priority_change=False)
                         it += 1
                         if t in initial:
                             tname = payload.setdefault(t, initial[t])['TaskName']
-                            mem = mem_dict.setdefault( tname, payload[t]['Memory'])
-                            mem_dict[tname] = set_to
+                            payload[t]['Memory'] = set_to
+                            #mem = mem_dict.setdefault( tname, payload[t]['Memory'])
+                            #mem_dict[tname] = set_to
                         else:
                             break
-                    payload['Memory'] = mem_dict
-                    print "Memory set to: ",json.dumps( mem_dict, indent=2)
+                    #payload['Memory'] = mem_dict
+                    #print "Memory set to: ",json.dumps( mem_dict, indent=2)
+                    print
+                    "Memory set to: ", set_to
                 else: 
                     payload['Memory'] = set_to
                     print "Memory set to: ", set_to


### PR DESCRIPTION
Fixes #891 

#### Status
not tested

#### Description
With this PR, we set the memory within tasks for the ACDC of taskchains. Global memory setting gives issues.

Will monitor the stuck ACDCs which are https://wfrecovery.cern.ch/getaction?days=15 

#### Related PRs
None

#### External dependencies / deployment changes
No new dependency

#### Mention people to look at PRs
@z4027163  FYI
