### PR TITLE
Pilot successful and removing a pileup file from CERN

### DIFF
--- a/campaigns.json
+++ b/campaigns.json
@@ -2854,7 +2854,7 @@
   },
   "RunIISummer20UL17pp5TeVwmLHEGS": {
     "fractionpass": 0.95,
-    "go": false,
+    "go": true,
     "lumisize": -1,
     "resize": "auto",
     "parameters": {
@@ -2950,7 +2950,6 @@
     "secondaries": {
       "/ReggeGribovPartonMC_EposLHC_pPb_4080_4080/pPb816Spring16GS-80X_mcRun2_asymptotic_v17-v1/GEN-SIM": {
         "SiteWhitelist": [
-          "T2_CH_CERN",
           "T2_IT_Pisa",
           "T1_IT_CNAF_Disk"
         ]


### PR DESCRIPTION
Pilot successful PRCAMPAIGNS-217 although it did go through the ringer
pPb816Spring16GS for this campaign /ReggeGribovPartonMC_EposLHC_pPb_4080_4080/pPb816Spring16GS-80X_mcRun2_asymptotic_v17-v1/GEN-SIM removing CERN 
there are 12 WF's all not currently running so now is a good time to switch. Two sites still in use.