### PR TITLE
Set global memory parameter, too for custom memory ACDCs

### DIFF
--- a/Unified/actor.py
+++ b/Unified/actor.py
@@ -77,12 +77,9 @@ def singleRecovery(url, task, initial, actions, do=False, priority_change=False)
                         if t in initial:
                             tname = payload.setdefault(t, initial[t])['TaskName']
                             payload[t]['Memory'] = set_to
-                            #mem = mem_dict.setdefault( tname, payload[t]['Memory'])
-                            #mem_dict[tname] = set_to
                         else:
                             break
-                    #payload['Memory'] = mem_dict
-                    #print "Memory set to: ",json.dumps( mem_dict, indent=2)
+                    payload['Memory'] = set_to
                     print
                     "Memory set to: ", set_to
                 else: 


### PR DESCRIPTION
Fixes #891 

#### Status
not tested

#### Description
#894 was not enough. We need to also set global memory parameter. https://github.com/CMSCompOps/WmAgentScripts/issues/891#issuecomment-893297027 

#### Related PRs
#894 

#### External dependencies / deployment changes
No

#### Mention people to look at PRs
@z4027163 
