### PR TITLE
UnArchiving RunIILowPUSpring18DR campaign also changing the pileup in…

### DIFF
--- a/campaigns.json
+++ b/campaigns.json
@@ -1035,7 +1035,24 @@
     ], 
     "go": true, 
     "tune": true
-  }, 
+  },
+  "RunIILowPUSpring18DR": {
+    "secondary_AAA": false, 
+    "maxcopies": 1, 
+    "lumisize": -1, 
+    "fractionpass": 0.95, 
+    "go": true, 
+    "tune": true, 
+    "secondaries": {
+      "/MinBias_TuneCP5_inelasticON_13TeV-pythia8/RunIIFall17GS-93X_mc2017_realistic_v3-v1/GEN-SIM": {
+        "SiteWhitelist": [
+          "T1_FR_CCIN2P3_Disk", 
+          "T1_DE_KIT_Disk" 
+        ]
+      }
+    }, 
+    "resize": "auto"
+  },  
   "RunIISummer15GS": {
     "SiteBlacklist": [
       "T2_US_Caltech", 


### PR DESCRIPTION
Unarchiving RunIILowPUSpring18DR waiting for confirmation from jordan and a jira ticket so we can merge this. 

Come from a unified issue that said:
MinBias_TuneCP5_inelasticON_13TeV-pythia8/RunIIFall17GS-93X_mc2017_realistic_v3-v1/GEN-SIM is not an allowed secondary
Workflow URL: https://dmytro.web.cern.ch/dmytro/cmsprodmon/workflows.php?prep_id=task_SMP-RunIILowPUSpring18wmLHEGS-00034