### PR TITLE
Drop unnecessary parameters in ACDC submission

### DIFF
--- a/Unified/actor.py
+++ b/Unified/actor.py
@@ -23,14 +23,13 @@ def singleRecovery(url, task, initial, actions, do=False, priority_change=False)
     print "Inside single recovery!"
     payload = {
         "Requestor" : os.getenv('USER'),
-        "Group" : 'DATAOPS',
         "RequestType" : "Resubmission",
         "ACDCServer" : initial['ConfigCacheUrl'],
         "ACDCDatabase" : "acdcserver",
         "OriginalRequestName" : initial['RequestName'],
         "OpenRunningTimeout" : 0
     }
-    copy_over = ['PrepID','Campaign','RequestPriority', 'TimePerEvent', 'SizePerEvent', 'Group', 'Memory', 'RequestString' ,'CMSSWVersion']
+    copy_over = ['RequestPriority', 'RequestString' ,'CMSSWVersion']
     for c in copy_over:
         if c in initial:
             payload[c] = copy.deepcopy(initial[c])


### PR DESCRIPTION
Fixes #934 

#### Status
not tested

#### Description
After checking w/ Alan, we spotted the unnecessary parameters in ACDCs and this PR removes them. I'm not sure about `OpenRunningTimeout` and `CMSSWVersion`, so keeping them for now

#### Related PRs
None

#### External dependencies / deployment changes
No new dependency

#### Mention people to look at PRs
@z4027163  FYI
