### PR TITLE
Stop duplicate check in checkor and lumilist specific check in getDatasetLumisAndFiles

### DIFF
--- a/Unified/checkor.py
+++ b/Unified/checkor.py
@@ -494,7 +494,7 @@ class CheckBuster(threading.Thread):
         assistance_tags = set()
 
         is_closing = True
-        stop_duplicate_check = False
+        stop_duplicate_check = True
 
         ## get it from somewhere
         bypass_checks = False

--- a/utils.py
+++ b/utils.py
@@ -2668,10 +2668,10 @@ def getDatasetLumisAndFiles(dataset, runs=None, lumilist=None, with_cache=False,
     if runs and lumilist:
         print "should not be used that way"
         return {},{}
-    lumis =set()
-    if lumilist:
-        for r in lumilist:
-            lumis.update( [(r,l) for l in lumilist[r]])
+    #lumis =set()
+    #if lumilist:
+    #    for r in lumilist:
+    #        lumis.update( [(r,l) for l in lumilist[r]])
 
     now = time.mktime(time.gmtime())
     dbsapi = DbsApi(url=dbs_url)
@@ -2739,7 +2739,8 @@ def getDatasetLumisAndFiles(dataset, runs=None, lumilist=None, with_cache=False,
     elif lumilist:
         runs = map(int(lumilist.keys()))
         lumi_json = dict([(int(k),v) for (k,v) in full_lumi_json.items() if int(k) in runs])
-        files_json = dict([(tuple(map(int,k.split(":"))),v) for (k,v) in files_per_lumi.items() if map(int,k.split(":")) in lumis])
+        # This file json is only necessary for duplicate check in checkor. It's disabled.
+        #files_json = dict([(tuple(map(int,k.split(":"))),v) for (k,v) in files_per_lumi.items() if map(int,k.split(":")) in lumis])
 
     return lumi_json,files_json
 


### PR DESCRIPTION
Fixes #941 

#### Status
not tested

#### Description
This PR stops duplicate check in checkor and lumilist specific check in getDatasetLumisAndFiles. Duplicate check is very expensive and there was not even one single incident in the last year due to duplicates. So we can say that, our system is reliable and no need to do this expensive check anymore. 

#### Related PRs
None

#### External dependencies / deployment changes
None

#### Mention people to look at PRs
@z4027163 
