### PR TITLE
Do not close-out a workflow if it's incomplete even if there is no recovery doc in ACDC server

### DIFF
--- a/Unified/checkor.py
+++ b/Unified/checkor.py
@@ -947,6 +947,8 @@ class CheckBuster(threading.Thread):
                 sendLog('checkor','%s is not completed, but has nothing to be recovered, passing along ?'%wfo.name, level='critical')
                 ## do not bypass for now, until Alan understands why we are loosing ACDC docs 
                 bypass_checks = True
+                is_closing = False
+                assistance_tags.add('noRecoveryDoc')
             else:
                 wfi.sendLog('checkor','%s is not completed.\nCurrent stats:\n%s \nRequired stats:\n%s'%( 
                         wfo.name, json.dumps(percent_completions, indent=2), json.dumps(fractions_pass, indent=2) ))


### PR DESCRIPTION
Fixes #915

#### Status
not tested

#### Description
This PR blocks the completed to closed-out transition for incomplete workflows even if there is no recovery doc for it. In such cases, I introduced a new assistance tag called `noRecoveryDoc`. For such cases, we should understand why there is no recovery doc. 

A recent incident: https://its.cern.ch/jira/browse/CMSCOMPPR-21526 

#### Related PRs
None

#### External dependencies / deployment changes
None

#### Mention people to look at PRs
@z4027163 @jenimal  FYI
