### PR TITLE
Close unnecessary JIRA tickets automatically

### DIFF
--- a/Unified/jiraHandler.py
+++ b/Unified/jiraHandler.py
@@ -1,10 +1,7 @@
 #!/usr/bin/env python
-from utils import  componentInfo, reqmgr_url, getWorkflowById
-import sys
+from utils import  reqmgr_url, getWorkflowById
 from JIRAClient import JIRAClient
 
-up = componentInfo(soft=['mcm','wtc','jira'])
-if not up.check(): sys.exit(0)
 
 JC = JIRAClient() if up.status.get('jira',False) else None
 if JC:

--- a/Unified/jiraHandler.py
+++ b/Unified/jiraHandler.py
@@ -2,8 +2,7 @@
 from utils import  reqmgr_url, getWorkflowById
 from JIRAClient import JIRAClient
 
-
-JC = JIRAClient() if up.status.get('jira',False) else None
+JC = JIRAClient()
 if JC:
     those = JC.find({'status' : '!CLOSED'})
     for t in those:

--- a/Unified/jiraHandler.py
+++ b/Unified/jiraHandler.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python
+from utils import  componentInfo, reqmgr_url, getWorkflowById
+import sys
+from JIRAClient import JIRAClient
+
+up = componentInfo(soft=['mcm','wtc','jira'])
+if not up.check(): sys.exit(0)
+
+JC = JIRAClient() if up.status.get('jira',False) else None
+if JC:
+    those = JC.find({'status' : '!CLOSED'})
+    for t in those:
+        s= t.fields.summary
+        s = s.replace('issues','')
+        s = s.strip()
+        if s.count(' ')!=0: continue
+        print s
+        wfs = getWorkflowById(reqmgr_url, s, details=True)
+        statuses = set([r['RequestStatus'] for r in wfs])
+        check_against = ['assignment-approved', 'running-open','running-closed','completed','acquired', 'staging', 'staged', 'assigned', 'closed-out', 'failed']
+        if statuses:
+            if all([s not in check_against for s in statuses]):
+                print t.key,"can be closed"
+                print statuses
+                JC.close(t.key) ## uncomment to close JIRAs
+                continue
+        print t.key,statuses

--- a/jiraCycle.sh
+++ b/jiraCycle.sh
@@ -1,0 +1,11 @@
+BASE_DIR=/data/unified/WmAgentScripts/
+HTML_DIR=/var/www/html/unified/
+
+lock_name=`echo $BASH_SOURCE | cut -f 1 -d "."`.lock
+source $BASE_DIR/cycle_common.sh $lock_name
+
+## JIRA ops
+$BASE_DIR/cWrap.sh Unified/jiraHandler.py
+
+rm -f $lock_name
+


### PR DESCRIPTION
Fixes #967 

#### Status
tested locally, works fine: ready

#### Description
If the workflow status isn't one of the following states, JIRA closes automatically:
```
['assignment-approved', 'running-open','running-closed','completed','acquired', 'staging', 'staged', 'assigned', 'closed-out', 'failed']
```

#### Related PRs
None

#### External dependencies / deployment changes
JIRA

#### Mention people to look at PRs
@jenimal @z4027163 
