### PR TITLE
Updates on JIRA tickets etc so a massive update

### DIFF
--- a/archive_campaigns.json
+++ b/archive_campaigns.json
@@ -1,5 +1,16 @@
 {
-
+  "Run3Autumn21GS": {
+    "fractionpass": 0.95,
+    "go": true,
+    "lumisize": -1,
+    "maxcopies": 1
+  },
+  "Run3Autumn21wmLHEGS": {
+      "fractionpass": 0.95,
+      "go": true,
+      "lumisize": -1,
+      "maxcopies": 1
+  },
   "RunIISummer19ULPrePremix": {
     "fractionpass": 0.95,
     "go": true,

--- a/campaigns.json
+++ b/campaigns.json
@@ -1235,6 +1235,27 @@
         "secondary_AAA": true
       }
     }
+  },
+  "RunIISpring16FSSIMDRPremix": {
+    "fractionpass": 0.95,
+    "go": false,
+    "SiteBlacklist": [
+      "T2_CH_CERN",
+      "T2_CH_CERN_HLT"
+      ],
+    "lumisize": -1,
+    "parameters": {
+      "EventsPerLumi": "x2"
+    },
+    "secondaries": {
+      "/Neutrino_E-10_gun/RunIISummer16FSPremix-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v4-v1/GEN-SIM-DIGI-RAW": {
+        "SiteWhitelist": [
+          "T2_US_Purdue",
+          "T1_DE_KIT_Disk"
+        ],
+        "secondary_AAA": true
+      }
+    }
   }, 
   "RunIISummer16MiniAODv3": {
     "force-complete": 0.99, 
@@ -2841,7 +2862,7 @@
   },
   "RunIISummer20UL17pp5TeVRECO": {
     "fractionpass": 0.95,
-    "go": false,
+    "go": true,
     "lumisize": -1,
     "resize": "auto",
     "parameters": {
@@ -2859,7 +2880,7 @@
   },
   "RunIISummer20UL17pp5TeVHLT": {
     "fractionpass": 0.95,
-    "go": false,
+    "go": true,
     "lumisize": -1,
     "resize": "auto",
     "parameters": {
@@ -2877,7 +2898,7 @@
   },
   "RunIISummer20UL17pp5TeVDIGI": {
     "fractionpass": 0.95,
-    "go": false,
+    "go": true,
     "lumisize": -1,
     "resize": "auto",
     "parameters": {
@@ -2991,6 +3012,16 @@
         "SiteWhitelist": [
           "T2_IT_Pisa",
           "T1_IT_CNAF_Disk"
+        ]
+      },
+      "/ReggeGribovPartonMC_EposLHC_PbP_4080_4080_DataBS/pPb816Spring16GS-MB_80X_mcRun2_pA_v4-v2/GEN-SIM": {
+        "SiteWhitelist": [
+          "T1_IT_CNAF_Disk",
+        ]
+      },
+      "/ReggeGribovPartonMC_EposLHC_pPb_4080_4080_DataBS/pPb816Spring16GS-MB_80X_mcRun2_pA_v4-v2/GEN-SIM": {
+        "SiteWhitelist": [
+          "T2_US_MIT"
         ]
       }
     }
@@ -3308,7 +3339,7 @@
   },
   "RunIISpring21UL16FSSIMDR": { 
       "fractionpass": 0.95,
-      "go": false,
+      "go": true,
       "lumisize": -1,
       "maxcopies": 1,
       "SiteBlacklist": [
@@ -3327,7 +3358,7 @@
   },
   "RunIISpring21UL16FSSIMDRPremix": {     
       "fractionpass": 0.95,
-      "go": false,
+      "go": true,
       "lumisize": -1,
       "maxcopies": 1, 
       "SiteBlacklist": [

--- a/campaigns.json
+++ b/campaigns.json
@@ -461,6 +461,30 @@
      "resize": "auto",
      "tune": true
     },
+  "Commissioning900wmLHEGS": {
+      "go": false,
+      "lumisize": -1,
+      "maxcopies": 1,
+      "fractionpass": 1
+  },
+  "Commissioning900GS": {
+      "go": false,
+      "lumisize": -1,
+      "maxcopies": 1,
+      "fractionpass": 1
+  },
+  "Commissioning900DR": {
+      "go": false,
+      "lumisize": -1,
+      "maxcopies": 1,
+      "fractionpass": 1
+  },
+  "Commissioning900MiniAOD": {
+      "go": false,
+      "lumisize": -1,
+      "maxcopies": 1,
+      "fractionpass": 1
+  },
   "Phase2HLTTDRSummer20L1T": {
     "fractionpass": 0.95, 
     "go": true, 
@@ -725,17 +749,40 @@
     "lumisize": -1,
     "maxcopies": 1
   },
-  "Run3Autumn21GS": {
-    "fractionpass": 0.95,   
-    "go": true,
+  "Run3Winter22GS": {
+    "fractionpass": 0.95,
+    "go": false,
     "lumisize": -1,
-    "maxcopies": 1
+    "maxcopies": 1,
+    "resize": "auto"
   },
-  "Run3Autumn21wmLHEGS": {
-      "fractionpass": 0.95,
-      "go": true,
-      "lumisize": -1,
-      "maxcopies": 1
+  "Run3Winter22wmLHEGS": {
+    "fractionpass": 0.95,
+    "go": false,
+    "lumisize": -1,
+    "maxcopies": 1,
+    "resize": "auto"
+  },
+  "Run3Winter22DR": {
+    "fractionpass": 0.95,
+    "go": false,
+    "lumisize": -1,
+    "maxcopies": 1,
+    "resize": "auto"
+  },
+  "Run3Winter22DRPremix": {
+    "fractionpass": 0.95,
+    "go": false,
+    "lumisize": -1,
+    "maxcopies": 1,
+    "resize": "auto"
+  },
+  "Run3Winter22MiniAOD": {
+    "fractionpass": 0.95,
+    "go": false,
+    "lumisize": -1,
+    "maxcopies": 1,
+    "resize": "auto"
   },
   "RunIIAutumn18DR": {
     "fractionpass": 0.95, 
@@ -3257,7 +3304,7 @@
   },
   "RunIISpring21UL17FSSIMDR": {
       "fractionpass": 0.95,
-      "go": false,
+      "go": true,
       "lumisize": -1,
       "maxcopies": 1,
       "SiteBlacklist": [

--- a/campaigns.json
+++ b/campaigns.json
@@ -2800,8 +2800,7 @@
     "secondaries": {
        "/MinBias_TuneCP5_5TeV-pythia8/RunIISummer20UL17pp5TeVGS-106X_mc2017_realistic_forppRef5TeV_v3-v1/GEN-SIM": {
           "SiteWhitelist": [
-             "T2_US_Nebraska",
-             "T2_DE_DESY"
+             "T2_CH_CERN"
                       ]
               }
        }
@@ -2916,8 +2915,7 @@
     "secondaries": {
        "/MinBias_TuneCP5_5TeV-pythia8/RunIISummer20UL17pp5TeVGS-106X_mc2017_realistic_forppRef5TeV_v3-v1/GEN-SIM": {
           "SiteWhitelist": [
-             "T2_US_Nebraska",
-             "T2_DE_DESY"
+             "T2_CH_CERN"
                       ]
               }
        }

--- a/campaigns.json
+++ b/campaigns.json
@@ -3016,7 +3016,7 @@
       },
       "/ReggeGribovPartonMC_EposLHC_PbP_4080_4080_DataBS/pPb816Spring16GS-MB_80X_mcRun2_pA_v4-v2/GEN-SIM": {
         "SiteWhitelist": [
-          "T1_IT_CNAF_Disk",
+          "T1_IT_CNAF_Disk"
         ]
       },
       "/ReggeGribovPartonMC_EposLHC_pPb_4080_4080_DataBS/pPb816Spring16GS-MB_80X_mcRun2_pA_v4-v2/GEN-SIM": {

--- a/campaigns.json
+++ b/campaigns.json
@@ -465,25 +465,25 @@
       "go": false,
       "lumisize": -1,
       "maxcopies": 1,
-      "fractionpass": 1
+      "fractionpass": 0.95
   },
   "Commissioning900GS": {
       "go": false,
       "lumisize": -1,
       "maxcopies": 1,
-      "fractionpass": 1
+      "fractionpass": 0.95
   },
   "Commissioning900DR": {
       "go": false,
       "lumisize": -1,
       "maxcopies": 1,
-      "fractionpass": 1
+      "fractionpass": 0.95
   },
   "Commissioning900MiniAOD": {
       "go": false,
       "lumisize": -1,
       "maxcopies": 1,
-      "fractionpass": 1
+      "fractionpass": 0.95
   },
   "Phase2HLTTDRSummer20L1T": {
     "fractionpass": 0.95, 


### PR DESCRIPTION
PRCAMPAIGNS-35 adding pileup to pPb816Spring16GS will check WF's
PRCAMPAIGNS-254 RunIISpring16FSSIMDRPremix This is the one I checked with Jordan should be good to go.
PRCAMPAIGNS-251 RunIISummer20UL17pp5TeVDIGI pilot successful 
PRCAMPAIGNS-252 RunIISummer20UL17pp5TeVHLT pilot successful 
PRCAMPAIGNS-253 RunIISummer20UL17pp5TeVRECO pilot successful
PRCAMPAIGNS-243 RunIISpring21UL16FSSIMDR pilot successful although still dealing with pileup placement which is weird but we will talk to data management about it
PRCAMPAIGNS-244 RunIISpring21UL16FSSIMDRPremix pilot successful although still dealing with pileup placement which is weird but we will talk to data management about it