### PR TITLE
Adding new pile and removing wrong RSE

### DIFF
--- a/campaigns.json
+++ b/campaigns.json
@@ -846,7 +846,15 @@
           "T2_US_UCSD",
           "T2_US_Wisconsin"
         ]
-     }
+     },
+    "secondaries": {
+         "/MinBias_Hydjet_Drum5F_5p02TeV/Run3Winter22PbPbNoMixGS-122X_mcRun3_2021_realistic_HI_v10-v1/GEN-SIM": {
+                 "SiteWhitelist": [
+                      "T1_IT_CNAF_Disk",
+                      "T2_US_Florida"
+                                  ]
+                      }
+           }        
   },   
   "Run3Winter22PbPbNoMixGS" : {
     "fractionpass": 0.95,
@@ -882,7 +890,15 @@
           "T2_US_UCSD",
           "T2_US_Wisconsin"
         ]
-     }
+     },
+    "secondaries": {
+         "/MinBias_Hydjet_Drum5F_5p02TeV/Run3Winter22PbPbNoMixGS-122X_mcRun3_2021_realistic_HI_v10-v1/GEN-SIM": {
+               "SiteWhitelist": [
+                     "T1_IT_CNAF_Disk",
+                     "T2_US_Florida"
+                              ]
+                      }
+            }        
   },
   "Run3Winter22GS": {
     "fractionpass": 0.95,
@@ -1665,7 +1681,7 @@
       }, 
       "/MinBias_TuneCP5_13TeV-pythia8/RunIISummer19UL16SIM-106X_mcRun2_asymptotic_v3-v1/GEN-SIM": {
        "SiteWhitelist": [
-         "T1_US_FNAL"
+         "T1_US_FNAL_DISK"
         ]
       }
     }, 

--- a/campaigns.json
+++ b/campaigns.json
@@ -1684,7 +1684,7 @@
       }, 
       "/MinBias_TuneCP5_13TeV-pythia8/RunIISummer19UL16SIM-106X_mcRun2_asymptotic_v3-v1/GEN-SIM": {
        "SiteWhitelist": [
-         "T1_US_FNAL_DISK"
+         "T1_US_FNAL_Disk"
         ]
       }
     }, 

--- a/campaigns.json
+++ b/campaigns.json
@@ -257,7 +257,7 @@
   "HINppWinter16wmLHEGS": {
       "custodial": "T1_FR_CCIN2P3_MSS",
       "fractionpass": 0.95,
-      "go": false,
+      "go": true,
       "lumisize": -1,
       "maxcopies": 1,
       "parameters": {
@@ -934,7 +934,10 @@
     "go": false,
     "lumisize": -1,
     "maxcopies": 1,
-    "resize": "auto"
+    "resize": "auto",
+    "secondaries": {
+        "/Neutrino_E-10_gun/Run3Summer21PrePremix-Winter22_122X_mcRun3_2021_realistic_v9-v1/PREMIX": {}
+    }
   },
   "Run3Winter22MiniAOD": {
     "fractionpass": 0.95,


### PR DESCRIPTION
Changing RunIISummer19UL16DIGI because T1_US_FNAL instead of T1_US_FNAL_DISK
[PRCAMPAIGNS-258](https://its.cern.ch/jira/browse/PRCAMPAIGNS-258)

[PRCAMPAIGNS-280](https://its.cern.ch/jira/browse/PRCAMPAIGNS-280) go is true pilot successful

Run3Winter22PbPbGS campaign adding minbais
[PRCAMPAIGNS-275](https://its.cern.ch/jira/browse/PRCAMPAIGNS-275) adding minbias 