### PR TITLE
Adding some campaigns to go

### DIFF
--- a/campaigns.json
+++ b/campaigns.json
@@ -922,7 +922,7 @@
     "resize": "auto",
     "secondaries": {        
          "/MinBias_TuneCP5_13p6TeV-pythia8/Run3Winter22GS-122X_mcRun3_2021_realistic_v9-v1/GEN-SIM": {
-               "SiteWhitelist": [,
+               "SiteWhitelist": [
                     "T2_US_Florida",
                     "T1_ES_PIC_Disk"
                      ]

--- a/campaigns.json
+++ b/campaigns.json
@@ -923,6 +923,7 @@
     "secondaries": {        
          "/MinBias_TuneCP5_13p6TeV-pythia8/Run3Winter22GS-122X_mcRun3_2021_realistic_v9-v1/GEN-SIM": {
                "SiteWhitelist": [
+                   "T1_US_FNAL_Disk",
                     "T2_US_Florida",
                     "T1_ES_PIC_Disk"
                      ]

--- a/campaigns.json
+++ b/campaigns.json
@@ -483,13 +483,13 @@
      "tune": true
     },
   "Commissioning900wmLHEGS": {
-      "go": false,
+      "go": true,
       "lumisize": -1,
       "maxcopies": 1,
       "fractionpass": 0.95
   },
   "Commissioning900GS": {
-      "go": false,
+      "go": true,
       "lumisize": -1,
       "maxcopies": 1,
       "fractionpass": 0.95
@@ -501,7 +501,7 @@
       "fractionpass": 0.95
   },
   "Commissioning900MiniAOD": {
-      "go": false,
+      "go": true,
       "lumisize": -1,
       "maxcopies": 1,
       "fractionpass": 0.95
@@ -778,7 +778,7 @@
   },
   "Run3Winter22PbPbNoMixRECOMiniAOD" : {
     "fractionpass": 0.95,
-    "go": false,
+    "go": true,
     "lumisize": -1,
     "resize": "auto",
     "parameters": {
@@ -814,7 +814,7 @@
   },
   "Run3Winter22PbPbNoMixDIGI" : {
     "fractionpass": 0.95,
-    "go": false,
+    "go": true,
     "lumisize": -1,
     "resize": "auto",
     "parameters": {
@@ -922,8 +922,7 @@
     "resize": "auto",
     "secondaries": {        
          "/MinBias_TuneCP5_13p6TeV-pythia8/Run3Winter22GS-122X_mcRun3_2021_realistic_v9-v1/GEN-SIM": {
-               "SiteWhitelist": [
-                    "T1_US_FNAL_Disk",
+               "SiteWhitelist": [,
                     "T2_US_Florida",
                     "T1_ES_PIC_Disk"
                      ]
@@ -932,7 +931,7 @@
   },
   "Run3Winter22DRPremix": {
     "fractionpass": 0.95,
-    "go": false,
+    "go": true,
     "lumisize": -1,
     "maxcopies": 1,
     "resize": "auto",


### PR DESCRIPTION
These are a go: [PRCAMPAIGNS-278](https://its.cern.ch/jira/browse/PRCAMPAIGNS-278), [PRCAMPAIGNS-276](https://its.cern.ch/jira/browse/PRCAMPAIGNS-276), [PRCAMPAIGNS-259](https://its.cern.ch/jira/browse/PRCAMPAIGNS-259), [PRCAMPAIGNS-260](https://its.cern.ch/jira/browse/PRCAMPAIGNS-260), [PRCAMPAIGNS-261](https://its.cern.ch/jira/browse/PRCAMPAIGNS-261), [PRCAMPAIGNS-258](https://its.cern.ch/jira/browse/PRCAMPAIGNS-258), [PRCAMPAIGNS-257](https://its.cern.ch/jira/browse/PRCAMPAIGNS-257)
The pilots were successful.