### PR TITLE
Removing campaigns that have to long of a name

### DIFF
--- a/campaigns.json
+++ b/campaigns.json
@@ -3465,26 +3465,6 @@
     },
     "secondary_AAA": true
   },
-  "RunIISpring21UL18FSwmLHEGSPremixLLPBugFix": {
-      "fractionpass": 0.95,
-      "go": false,
-      "lumisize": -1,
-      "maxcopies": 1,
-      "SiteBlacklist": [
-          "T2_CH_CERN",
-          "T2_CH_CERN_HLT"
-      ],
-      "secondaries": {
-          "/Neutrino_E-10_gun/RunIIFall17FSPrePremix-PUFSUL18CP5_106X_upgrade2018_realistic_v16-v1/PREMIX":
-          {
-              "SecondaryLocation": [
-                  "T1_US_FNAL_Disk",
-                  "T1_FR_CCIN2P3_Disk"
-              ]
-          }
-      },
-      "secondary_AAA": true
-  },
   "RunIISpring22UL18FSwmLHEGSPremix": {
       "fractionpass": 0.95,
       "go": false,
@@ -3641,26 +3621,6 @@
                     "T1_DE_KIT_Disk"
                      ]
          }
-    },
-    "secondary_AAA": true
-  },
-  "RunIISpring21UL17FSwmLHEGSPremixLLPBugFix": {
-    "fractionpass": 0.95,
-    "go": false,
-    "lumisize": -1,
-    "maxcopies": 1,
-    "SiteBlacklist": [
-       "T2_CH_CERN",
-       "T2_CH_CERN_HLT"
-     ],
-    "secondaries": {
-          "/Neutrino_E-10_gun/RunIIFall17FSPrePremix-PUFSUL17CP5_106X_mc2017_realistic_v9-v2/PREMIX" :
-          {
-                 "SecondaryLocation": [
-                    "T1_US_FNAL_Disk",
-                    "T1_DE_KIT_Disk"
-                     ]
-          }
     },
     "secondary_AAA": true
   },
@@ -3845,26 +3805,6 @@
                    ]
       },
       "/Neutrino_E-10_gun/RunIIFall17FSPrePremix-PUFSUL16CP5_106X_mcRun2_asymptotic_v16-v1/PREMIX" : 
-      {
-              "SecondaryLocation": [
-                 "T1_RU_JINR_Disk",
-                 "T1_US_FNAL_Disk"
-                   ]
-      }
-    },
-    "secondary_AAA": true
-  },
-  "RunIISpring21UL16FSwmLHEGSPremixLLPBugFix": {
-    "fractionpass": 0.95,
-    "go": false,
-    "lumisize": -1,
-    "maxcopies": 1,
-    "SiteBlacklist": [
-       "T2_CH_CERN",
-       "T2_CH_CERN_HLT"
-    ],
-    "secondaries": {
-      "/Neutrino_E-10_gun/RunIIFall17FSPrePremix-PUFSUL16CP5_106X_mcRun2_asymptotic_v16-v1/PREMIX" :
       {
               "SecondaryLocation": [
                  "T1_RU_JINR_Disk",


### PR DESCRIPTION
Hi Jordan, because there are limitations with the relational database where an index cannot be larger than X bytes (I guess 4k). And we have an index in the database which is based on the nested task name, e.g.:
/workflow_name/task_name1/merge_task_name1/task_name2/....
please truncate the task name on the submission side. Or even enforce such limit (or something much shorter) to make things easier in the long run.
It was from Feb 15th on the combined slack
[PRCAMPAIGNS-268](https://its.cern.ch/jira/browse/PRCAMPAIGNS-268)
[PRCAMPAIGNS-270](https://its.cern.ch/jira/browse/PRCAMPAIGNS-270)
[PRCAMPAIGNS-272](https://its.cern.ch/jira/browse/PRCAMPAIGNS-272)
Removing these campaigns because the names are to long and we have replacement campaigns  





[9:31](https://cms-compops-pnr.slack.com/archives/C01F2201NDP/p1649082665030099)
Literally this name is to long so they rethought of it finally and just added new ones.