### PR TITLE
Enable secondary AAA for 3 Neutrino campaigns

### DIFF
--- a/campaigns.json
+++ b/campaigns.json
@@ -949,7 +949,8 @@
                       "T2_CH_CERN"
                                     ]
         }
-    }
+    },
+    "secondary_AAA": true
   },
   "Run3Winter22MiniAOD": {
     "fractionpass": 0.95,
@@ -3482,7 +3483,8 @@
                    "T1_FR_CCIN2P3_Disk"
                ]
            }
-        }
+        },
+       "secondary_AAA": true 
   },
   "RunIISpring21UL18FSGSPremixLLPBugFix": {
       "fractionpass": 0.95,
@@ -3831,7 +3833,8 @@
                    "T1_US_FNAL_Disk"
                        ]
           }
-     }
+     },
+     "secondary_AAA": true
   },
   "RunIISpring21UL16FSGSPremixLLPBugFix": {
     "fractionpass": 0.95,


### PR DESCRIPTION
Enable secondary AAA for 3 Neutrino campaigns.

Thanks to Justin's report, I realized this missing param and I made a scan in the file and enabled AAA for all missing campaigns.

And example error: https://cms-unified.web.cern.ch/cms-unified/report/cmsunified_task_JME-Run3Winter22DRPremix-00002__v1_T_220324_145750_1681 