### PR TITLE
Adding secondary_AAA: true for 4 campaigns

### DIFF
--- a/campaigns.json
+++ b/campaigns.json
@@ -949,7 +949,7 @@
                       "T2_CH_CERN"
                                     ]
         }
-    }
+    },
     "secondary_AAA": true
   },
   "Run3Winter22MiniAOD": {
@@ -3483,7 +3483,7 @@
                    "T1_FR_CCIN2P3_Disk"
                ]
            }
-       }
+       },
        "secondary_AAA": true
   },
   "RunIISpring21UL18FSGSPremixLLPBugFix": {
@@ -3643,7 +3643,7 @@
                    "T1_DE_KIT_Disk"
                     ]
            }
-       }
+       },
        "secondary_AAA": true
   },       
   "RunIISpring21UL17FSGSPremixLLPBugFix": {
@@ -3834,7 +3834,7 @@
                    "T1_US_FNAL_Disk"
                        ]
           }
-      }
+      },
       "secondary_AAA": true
   },
   "RunIISpring21UL16FSGSPremixLLPBugFix": {

--- a/campaigns.json
+++ b/campaigns.json
@@ -950,6 +950,7 @@
                                     ]
         }
     }
+    "secondary_AAA": true
   },
   "Run3Winter22MiniAOD": {
     "fractionpass": 0.95,
@@ -3482,7 +3483,8 @@
                    "T1_FR_CCIN2P3_Disk"
                ]
            }
-        }
+       }
+       "secondary_AAA": true
   },
   "RunIISpring21UL18FSGSPremixLLPBugFix": {
       "fractionpass": 0.95,
@@ -3642,6 +3644,7 @@
                     ]
            }
        }
+       "secondary_AAA": true
   },       
   "RunIISpring21UL17FSGSPremixLLPBugFix": {
     "fractionpass": 0.95,
@@ -3831,7 +3834,8 @@
                    "T1_US_FNAL_Disk"
                        ]
           }
-     }
+      }
+      "secondary_AAA": true
   },
   "RunIISpring21UL16FSGSPremixLLPBugFix": {
     "fractionpass": 0.95,

--- a/campaigns.json
+++ b/campaigns.json
@@ -671,7 +671,8 @@
     "go": true, 
     "lumisize": -1, 
     "maxcopies": 1, 
-    "resize": "auto"
+    "resize": "auto",
+    "secondary_AAA": false
   }, 
   "Run3Winter21GS": {
     "fractionpass": 0.95, 
@@ -860,7 +861,8 @@
                       "T2_US_Florida"
                                   ]
                       }
-           }        
+    },
+    "secondary_AAA": false        
   },   
   "Run3Winter22PbPbNoMixGS" : {
     "fractionpass": 0.95,
@@ -904,7 +906,8 @@
                      "T2_US_Florida"
                               ]
                       }
-            }        
+    },
+    "secondary_AAA": false        
   },
   "Run3Winter22GS": {
     "fractionpass": 0.95,
@@ -934,7 +937,8 @@
                     "T1_ES_PIC_Disk"
                      ]
                 }
-          }
+    },
+    "secondary_AAA": false   
   },
   "Run3Winter22DRPremix": {
     "fractionpass": 0.95,


### PR DESCRIPTION
The new FS and the Run3 campaign had no secondaryAAA true so adding that for 4 campaigns
