### PR TITLE
Removing labels

### DIFF
--- a/campaigns.json
+++ b/campaigns.json
@@ -3284,15 +3284,6 @@
     ], 
     "fractionpass": 1, 
     "go": true, 
-    "labels": [
-      "PHATTEST", 
-      "25Jul2019", 
-      "27May2019", 
-      "29Jun2019", 
-      "UL17", 
-      "ForPixelALCARECO_UL2017", 
-      "09Aug2019"
-    ], 
     "lumisize": -1, 
     "maxcopies": 1, 
     "overflow": {


### PR DESCRIPTION
Removing labels from a campaign based on this:

"label" in line 5204 is processingString [1] [2]
2.  go of campaignInfo class checks if there is "labels" parameter and then check if s is None [3] (here 's' is 'label' in L5204)
3.  'label' of the WF for which I made the ticket is '15Feb2022_UL2017' thus don't satisfy this line [4][5], which means return false,  and that's also the reason why "Not allowed to go for ~~" isn't shown before "no go due to UltraLegacy2017 15Feb2022_UL2017" [6]
If there's something wrong, please let me know!
[1] https://github.com/CMSCompOps/WmAgentScripts/blob/master/utils.py#L5167
[2] https://github.com/CMSCompOps/WmAgentScripts/blob/master/utils.py#L5173-L5184
[3] https://github.com/CMSCompOps/WmAgentScripts/blob/master/utils.py#L832-L833
[4] https://github.com/CMSCompOps/WmAgentScripts/blob/master/campaigns.json#L3287-L3294
[5] https://github.com/CMSCompOps/WmAgentScripts/blob/master/utils.py#L834
[6] https://cms-unified.web.cern.ch/cms-unified/logs/assignor/2022-06-08_01:33:47.log (edited) 