### PR TITLE
Turn off trying getting any gwmsmon in siteInfo

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -1515,7 +1515,7 @@ class siteInfo:
                     self.sites_veto_transfer.append(dse)
 
         ## and glidein info
-        self.fetch_glidein_info(talk=False)
+        #self.fetch_glidein_info(talk=False)
 
     def total_disk(self, what='disk'):
         s = 0


### PR DESCRIPTION
Fixes #805

#### Status
not-tested

#### Description
Turn off `fetch_glidein_info` in `siteInfo` 

#### Is it backward compatible (if not, which system it affects?)

#### Related PRs

#### External dependencies / deployment changes

#### Mention people to look at PRs
@haozturk
