### PR TITLE
Change daily OpenSearch index to monthly index

### DIFF
--- a/es_opensearch.py
+++ b/es_opensearch.py
@@ -17,7 +17,7 @@ _host = "es-unified1.cern.ch/es"
 # Global Elastic and Open Search connections obj
 _opensearch_client = None
 
-# Global index cache, keep tracks of daily indices that are already created with mapping for all clusters
+# Global index cache, keep tracks of monthly indices that are already created with mapping for all clusters
 _index_cache = set()
 
 
@@ -94,15 +94,15 @@ class OpenSearchInterface(object):
     @staticmethod
     def get_index(timestamp, template=_index_template):
         """
-        Returns daily index string and creates it if it does not exist.
+        Returns monthly index string and creates it if it does not exist.
 
         - It checks if index mapping is already created by checking _index_cache set.
         - And returns from _index_cache set if index exists
-        - Else, it creates the index with mapping which happens in the first batch of the day ideally.
+        - Else, it creates the index with mapping which happens in the first batch of the month ideally.
         """
         global _index_cache
         idx = time.strftime(
-            "%s-%%Y-%%m-%%d" % template,
+            "%s-%%Y-%%m" % template,
             datetime.datetime.utcfromtimestamp(timestamp).timetuple(),
         )
         if idx in _index_cache:
@@ -144,7 +144,7 @@ class OpenSearchInterface(object):
     @staticmethod
     def get_index_schema():
         """
-        Creates mapping dictionary for the unified-logs daily index
+        Creates mapping dictionary for the unified-logs monthly index
         """
         return {
             "settings": {


### PR DESCRIPTION
Fixes #<GH_Issue_Number>

#### Status
<ready>

#### Description
Daily indices size of unified-logs is very small and it is switched to MONTHLY indices to correspond with ES/OpenSearch index management best practices. They will have 1 replica and 1 shard which is enough.

#### Is it backward compatible (if not, which system it affects?)
<NO> Daily indices should be deleted in test OpenSearch cluster. No effect to production.

#### Related PRs
<If it's a follow up work; or porting a fix from a different branch, please mention them here.>

#### External dependencies / deployment changes
<Does it require deployment changes? Does it rely on third-party libraries?> 

#### Mention people to look at PRs
<Always mention people to check and review proposed changed.>
