### PR TITLE
Make campaigns.json pileups consistent

### DIFF
--- a/campaigns.json
+++ b/campaigns.json
@@ -18,7 +18,6 @@
       "T2_RU_INR"
     ]
   },
-
   "Run3Winter23MiniAOD": {
     "fractionpass": 0.95,
     "go": true,
@@ -37,7 +36,6 @@
       "T2_RU_INR"
     ]
   },
-
   "Run3Winter23NanoAOD": {
     "fractionpass": 0.95,
     "go": true,
@@ -56,7 +54,6 @@
       "T2_RU_INR"
     ]
   },
-
   "GenericNoSmearGEN": {
     "fractionpass": 0.95,
     "go": false,
@@ -75,7 +72,6 @@
       "T2_RU_INR"
     ]
   },
-
   "Run3Winter23Reco": {
     "fractionpass": 0.95,
     "go": true,
@@ -94,7 +90,6 @@
       "T2_RU_INR"
     ]
   },
-
   "Phase2Fall22pLHEGS": {
     "fractionpass": 0.95,
     "go": true,
@@ -169,7 +164,7 @@
     "secondaries": {
       "/MinBias_TuneCP5_13p6TeV-pythia8/Run3Winter23GS-126X_mcRun3_2023_forPU65_v1-v1/GEN-SIM": {
         "SiteWhitelist": [
-          "T1_US_FNAL_Disk", 
+          "T1_US_FNAL_Disk",
           "T2_CH_CERN"
         ]
       }
@@ -290,10 +285,10 @@
       "T2_FI_HIP",
       "T2_RU_INR"
     ],
-    "secondaries": { 
+    "secondaries": {
       "/MinBias_TuneCP5_14TeV-pythia8/Phase2Fall22GS-HCalDetIDFix_125X_mcRun4_realistic_v2-v1/GEN-SIM": {
         "SiteWhitelist": [
-          "T1_US_FNAL_Disk", 
+          "T1_US_FNAL_Disk",
           "T2_CH_CERN"
         ]
       }
@@ -378,10 +373,10 @@
       "T2_US_Purdue",
       "T2_US_Vanderbilt"
     ],
-    "secondaries": { 
+    "secondaries": {
       "/MinBias_TuneCP5_13p6TeV-pythia8/Commission22GS-125X_mcRun3_2022_realistic_v3-v1/GEN-SIM": {
         "SiteWhitelist": [
-          "T1_US_FNAL_Disk", 
+          "T1_US_FNAL_Disk",
           "T1_DE_KIT_Disk",
           "T2_CH_CERN"
         ]
@@ -429,7 +424,7 @@
     ]
   },
   "Run3ReReco": {
-    "fractionpass": 1, 
+    "fractionpass": 1,
     "go": true,
     "SiteBlacklist": [
       "T1_ES_PIC",
@@ -454,325 +449,289 @@
     "fractionpass": 1
   },
   "Commissioning2020": {
-    "fractionpass": 0.99, 
-    "go": true, 
-    "lumisize": -1, 
-    "maxcopies": 1 
-  }, 
+    "fractionpass": 0.99,
+    "go": true,
+    "lumisize": -1,
+    "maxcopies": 1
+  },
   "HINPbPbAutumn18DR": {
-    "custodial": "T1_FR_CCIN2P3_MSS", 
-    "fractionpass": 0.95, 
-    "go": true, 
-    "lumisize": -1, 
-    "maxcopies": 1, 
+    "custodial": "T1_FR_CCIN2P3_MSS",
+    "fractionpass": 0.95,
+    "go": true,
+    "lumisize": -1,
+    "maxcopies": 1,
     "parameters": {
-      "MergedLFNBase": "/store/himc", 
+      "MergedLFNBase": "/store/himc",
       "SiteBlacklist": [
-        "T1_US_FNAL", 
-        "T2_US_Purdue", 
-        "T2_US_Caltech", 
-        "T2_US_Florida", 
-        "T2_US_Nebraska", 
-        "T2_US_UCSD", 
-        "T2_US_Wisconsin", 
-        "T2_CH_CERN", 
+        "T1_US_FNAL",
+        "T2_US_Purdue",
+        "T2_US_Caltech",
+        "T2_US_Florida",
+        "T2_US_Nebraska",
+        "T2_US_UCSD",
+        "T2_US_Wisconsin",
+        "T2_CH_CERN",
         "T2_CH_CERN_HLT",
         "T2_CH_CERN_P5"
       ]
-    }, 
-    "secondaries": {
-      "/MinBias_Hydjet_Drum5F_2018_5p02TeV/HINPbPbAutumn18GS-103X_upgrade2018_realistic_HI_v11-v1/GEN-SIM": {
-        "SiteWhitelist": [
-          "T1_RU_JINR_Disk", 
-          "T1_FR_CCIN2P3_Disk"
-        ]
-      }
-    }, 
+    },
+    "secondaries": {},
     "tune": true
-  }, 
+  },
   "HINPbPbAutumn18GS": {
-    "custodial": "T1_FR_CCIN2P3_MSS", 
-    "fractionpass": 0.95, 
-    "go": true, 
-    "lumisize": -1, 
-    "maxcopies": 1, 
+    "custodial": "T1_FR_CCIN2P3_MSS",
+    "fractionpass": 0.95,
+    "go": true,
+    "lumisize": -1,
+    "maxcopies": 1,
     "parameters": {
-      "MergedLFNBase": "/store/himc", 
+      "MergedLFNBase": "/store/himc",
       "SiteBlacklist": [
-        "T1_US_FNAL", 
-        "T2_US_Purdue", 
-        "T2_US_Caltech", 
-        "T2_US_Florida", 
-        "T2_US_Nebraska", 
-        "T2_US_UCSD", 
+        "T1_US_FNAL",
+        "T2_US_Purdue",
+        "T2_US_Caltech",
+        "T2_US_Florida",
+        "T2_US_Nebraska",
+        "T2_US_UCSD",
         "T2_US_Wisconsin"
       ]
-    }, 
+    },
     "tune": true
-  }, 
+  },
   "HINPbPbAutumn18GSHIMix": {
-    "MergedLFNBase": "/store/himc", 
+    "MergedLFNBase": "/store/himc",
     "SiteBlacklist": [
-      "T1_US_FNAL", 
-      "T2_US_Purdue", 
-      "T2_US_Caltech", 
-      "T2_US_Florida", 
-      "T2_US_Nebraska", 
-      "T2_US_UCSD", 
-      "T2_US_Wisconsin", 
+      "T1_US_FNAL",
+      "T2_US_Purdue",
+      "T2_US_Caltech",
+      "T2_US_Florida",
+      "T2_US_Nebraska",
+      "T2_US_UCSD",
+      "T2_US_Wisconsin",
       "T2_CH_CERN"
-    ], 
-    "custodial": "T1_FR_CCIN2P3_MSS", 
-    "fractionpass": 0.95, 
-    "go": true, 
-    "lumisize": -1, 
-    "maxcopies": 1, 
-    "secondaries": {
-      "/MinBias_Hydjet_Drum5F_2018_5p02TeV/HINPbPbAutumn18GS-103X_upgrade2018_realistic_HI_v11-v1/GEN-SIM": {
-        "SiteWhitelist": [
-          "T1_RU_JINR_Disk", 
-          "T1_FR_CCIN2P3_Disk"
-        ]
-      }
-    }, 
+    ],
+    "custodial": "T1_FR_CCIN2P3_MSS",
+    "fractionpass": 0.95,
+    "go": true,
+    "lumisize": -1,
+    "maxcopies": 1,
+    "secondaries": {},
     "tune": true
-  }, 
+  },
   "HINPbPbAutumn18pLHE": {
-    "custodial": "T1_FR_CCIN2P3_MSS", 
-    "fractionpass": 0.95, 
-    "go": true, 
-    "lumisize": -1, 
-    "maxcopies": 1, 
+    "custodial": "T1_FR_CCIN2P3_MSS",
+    "fractionpass": 0.95,
+    "go": true,
+    "lumisize": -1,
+    "maxcopies": 1,
     "parameters": {
-      "MergedLFNBase": "/store/himc", 
+      "MergedLFNBase": "/store/himc",
       "SiteBlacklist": [
-        "T1_US_FNAL", 
-        "T2_US_Purdue", 
-        "T2_US_Caltech", 
-        "T2_US_Florida", 
-        "T2_US_Nebraska", 
-        "T2_US_UCSD", 
+        "T1_US_FNAL",
+        "T2_US_Purdue",
+        "T2_US_Caltech",
+        "T2_US_Florida",
+        "T2_US_Nebraska",
+        "T2_US_UCSD",
         "T2_US_Wisconsin"
       ]
-    }, 
+    },
     "tune": true
-  }, 
+  },
   "HINPbPbAutumn18wmLHEGS": {
-    "custodial": "T1_FR_CCIN2P3_MSS", 
-    "fractionpass": 0.95, 
-    "go": true, 
-    "lumisize": -1, 
-    "maxcopies": 1, 
+    "custodial": "T1_FR_CCIN2P3_MSS",
+    "fractionpass": 0.95,
+    "go": true,
+    "lumisize": -1,
+    "maxcopies": 1,
     "parameters": {
-      "MergedLFNBase": "/store/himc", 
+      "MergedLFNBase": "/store/himc",
       "SiteBlacklist": [
-        "T1_US_FNAL", 
-        "T2_US_Purdue", 
-        "T2_US_Caltech", 
-        "T2_US_Florida", 
-        "T2_US_Nebraska", 
-        "T2_US_UCSD", 
-        "T2_US_Wisconsin", 
+        "T1_US_FNAL",
+        "T2_US_Purdue",
+        "T2_US_Caltech",
+        "T2_US_Florida",
+        "T2_US_Nebraska",
+        "T2_US_UCSD",
+        "T2_US_Wisconsin",
         "T2_CH_CERN"
       ]
-    }, 
+    },
     "tune": true
-  }, 
+  },
   "HINPbPbAutumn18wmLHEGSHIMix": {
-    "MergedLFNBase": "/store/himc", 
+    "MergedLFNBase": "/store/himc",
     "SiteBlacklist": [
-      "T1_US_FNAL", 
-      "T2_US_Purdue", 
-      "T2_US_Caltech", 
-      "T2_US_Florida", 
-      "T2_US_Nebraska", 
-      "T2_US_UCSD", 
-      "T2_US_Wisconsin", 
+      "T1_US_FNAL",
+      "T2_US_Purdue",
+      "T2_US_Caltech",
+      "T2_US_Florida",
+      "T2_US_Nebraska",
+      "T2_US_UCSD",
+      "T2_US_Wisconsin",
       "T2_CH_CERN"
-    ], 
-    "custodial": "T1_FR_CCIN2P3_MSS", 
-    "fractionpass": 0.95, 
-    "go": true, 
-    "lumisize": -1, 
-    "maxcopies": 1, 
-    "secondaries": {
-      "/MinBias_Hydjet_Drum5F_2018_5p02TeV/HINPbPbAutumn18GS-103X_upgrade2018_realistic_HI_v11-v1/GEN-SIM": {
-        "SiteWhitelist": [
-          "T1_RU_JINR_Disk", 
-          "T1_FR_CCIN2P3_Disk"
-        ]
-      }
-    }, 
+    ],
+    "custodial": "T1_FR_CCIN2P3_MSS",
+    "fractionpass": 0.95,
+    "go": true,
+    "lumisize": -1,
+    "maxcopies": 1,
+    "secondaries": {},
     "tune": true
-  }, 
+  },
   "HINPbPbWinter16DR": {
-    "custodial": "T1_FR_CCIN2P3_MSS", 
-    "fractionpass": 0.95, 
-    "go": true, 
+    "custodial": "T1_FR_CCIN2P3_MSS",
+    "fractionpass": 0.95,
+    "go": true,
     "parameters": {
-      "MergedLFNBase": "/store/himc", 
+      "MergedLFNBase": "/store/himc",
       "SiteBlacklist": [
-        "T1_US_FNAL", 
-        "T2_US_Purdue", 
-        "T2_US_Caltech", 
-        "T2_US_Florida", 
-        "T2_US_Nebraska", 
-        "T2_US_UCSD", 
+        "T1_US_FNAL",
+        "T2_US_Purdue",
+        "T2_US_Caltech",
+        "T2_US_Florida",
+        "T2_US_Nebraska",
+        "T2_US_UCSD",
         "T2_US_Wisconsin"
       ]
-    }, 
-    "secondaries": {
-      "/Hydjet_Quenched_Cymbal5Ev8_PbPbMinBias_5020GeV/HiFall15-75X_mcRun2_HeavyIon_v14_75X_mcRun2_HeavyIon_v14-v1/GEN-SIM": {
-        "SiteWhitelist": [
-          "T2_ES_CIEMAT",
-          "T1_RU_JINR_Disk"
-        ]
-      }
-    }
-  }, 
+    },
+    "secondaries": {}
+  },
   "HINPbPbWinter16pLHE": {
-    "custodial": "T1_FR_CCIN2P3_MSS", 
-    "fractionpass": 0.95, 
-    "go": true, 
-    "lumisize": -1, 
-    "maxcopies": 1, 
+    "custodial": "T1_FR_CCIN2P3_MSS",
+    "fractionpass": 0.95,
+    "go": true,
+    "lumisize": -1,
+    "maxcopies": 1,
     "parameters": {
-      "MergedLFNBase": "/store/himc", 
+      "MergedLFNBase": "/store/himc",
       "SiteBlacklist": [
-        "T1_US_FNAL", 
-        "T2_US_Purdue", 
-        "T2_US_Caltech", 
-        "T2_US_Florida", 
-        "T2_US_Nebraska", 
-        "T2_US_UCSD", 
-        "T2_US_Wisconsin", 
+        "T1_US_FNAL",
+        "T2_US_Purdue",
+        "T2_US_Caltech",
+        "T2_US_Florida",
+        "T2_US_Nebraska",
+        "T2_US_UCSD",
+        "T2_US_Wisconsin",
         "T2_CH_CERN"
       ]
-    }, 
+    },
     "tune": true
-  }, 
+  },
   "HINPbPbWinter16wmLHEGS": {
-    "custodial": "T1_FR_CCIN2P3_MSS", 
-    "fractionpass": 0.95, 
-    "go": true, 
-    "lumisize": -1, 
-    "maxcopies": 1, 
+    "custodial": "T1_FR_CCIN2P3_MSS",
+    "fractionpass": 0.95,
+    "go": true,
+    "lumisize": -1,
+    "maxcopies": 1,
     "parameters": {
-      "MergedLFNBase": "/store/himc", 
+      "MergedLFNBase": "/store/himc",
       "SiteBlacklist": [
-        "T1_US_FNAL", 
-        "T2_US_Purdue", 
-        "T2_US_Caltech", 
-        "T2_US_Florida", 
-        "T2_US_Nebraska", 
-        "T2_US_UCSD", 
-        "T2_US_Wisconsin", 
+        "T1_US_FNAL",
+        "T2_US_Purdue",
+        "T2_US_Caltech",
+        "T2_US_Florida",
+        "T2_US_Nebraska",
+        "T2_US_UCSD",
+        "T2_US_Wisconsin",
         "T2_CH_CERN"
       ]
-    }, 
+    },
     "tune": true
   },
   "HINPbPbWinter16wmLHEGSHIMix": {
-       "custodial": "T1_FR_CCIN2P3_MSS",
-       "fractionpass": 0.95,
-       "go": true,
-       "lumisize": -1,
-       "maxcopies": 1,
-       "parameters": {
-           "MergedLFNBase": "/store/himc",
-           "SiteBlacklist": [
-               "T1_US_FNAL",
-               "T2_US_Purdue",
-               "T2_US_Caltech",
-               "T2_US_Florida",
-               "T2_US_Nebraska", 
-               "T2_US_UCSD",
-               "T2_US_Wisconsin",
-               "T2_CH_CERN"
-                           ]
-                             },
-       "tune": true,
-       "secondaries": {
-         "/Hydjet_Quenched_Cymbal5Ev8_PbPbMinBias_5020GeV/HiFall15-75X_mcRun2_HeavyIon_v14_75X_mcRun2_HeavyIon_v14-v1/GEN-SIM": {
-          "SiteWhitelist": [
-                     "T2_ES_CIEMAT",
-                     "T1_RU_JINR_Disk"
-                           ]
-                 }
-        }
-         
-   },
-  "HINppWinter16wmLHEGS": {
-      "custodial": "T1_FR_CCIN2P3_MSS",
-      "fractionpass": 0.95,
-      "go": true,
-      "lumisize": -1,
-      "maxcopies": 1,
-      "parameters": {
-          "MergedLFNBase": "/store/himc",
-          "SiteBlacklist": [
-              "T1_US_FNAL",
-              "T2_US_Purdue",
-              "T2_US_Caltech",
-              "T2_US_Florida",
-              "T2_US_Nebraska",
-              "T2_US_UCSD",
-              "T2_US_Wisconsin",
-              "T2_CH_CERN" 
-                      ]
-      },
-      "tune": true
-  },      
-  "HINPbPbSpring21MiniAOD": {
-       "custodial": "T1_FR_CCIN2P3_MSS",
-       "fractionpass": 0.95,
-       "go": true,
-       "lumisize": -1,
-       "maxcopies": 1,
-       "parameters": {
-          "MergedLFNBase": "/store/himc",
-          "SiteBlacklist": [
-              "T1_US_FNAL",
-              "T2_US_Purdue",
-              "T2_US_Caltech",
-              "T2_US_Florida",
-              "T2_US_Nebraska",
-              "T2_US_UCSD",
-              "T2_US_Wisconsin",
-              "T3_US_NERSC"
-               ]
-       }
-  }, 
-  "HiFall15": {
-    "custodial": "T1_FR_CCIN2P3_MSS", 
-    "fractionpass": 0.95, 
-    "go": true, 
+    "custodial": "T1_FR_CCIN2P3_MSS",
+    "fractionpass": 0.95,
+    "go": true,
+    "lumisize": -1,
+    "maxcopies": 1,
     "parameters": {
-      "MergedLFNBase": "/store/himc", 
+      "MergedLFNBase": "/store/himc",
       "SiteBlacklist": [
-        "T1_US_FNAL", 
-        "T2_US_Purdue", 
-        "T2_US_Caltech", 
-        "T2_US_Florida", 
-        "T2_US_Nebraska", 
-        "T2_US_UCSD", 
+        "T1_US_FNAL",
+        "T2_US_Purdue",
+        "T2_US_Caltech",
+        "T2_US_Florida",
+        "T2_US_Nebraska",
+        "T2_US_UCSD",
+        "T2_US_Wisconsin",
+        "T2_CH_CERN"
+      ]
+    },
+    "tune": true,
+    "secondaries": {}
+  },
+  "HINppWinter16wmLHEGS": {
+    "custodial": "T1_FR_CCIN2P3_MSS",
+    "fractionpass": 0.95,
+    "go": true,
+    "lumisize": -1,
+    "maxcopies": 1,
+    "parameters": {
+      "MergedLFNBase": "/store/himc",
+      "SiteBlacklist": [
+        "T1_US_FNAL",
+        "T2_US_Purdue",
+        "T2_US_Caltech",
+        "T2_US_Florida",
+        "T2_US_Nebraska",
+        "T2_US_UCSD",
+        "T2_US_Wisconsin",
+        "T2_CH_CERN"
+      ]
+    },
+    "tune": true
+  },
+  "HINPbPbSpring21MiniAOD": {
+    "custodial": "T1_FR_CCIN2P3_MSS",
+    "fractionpass": 0.95,
+    "go": true,
+    "lumisize": -1,
+    "maxcopies": 1,
+    "parameters": {
+      "MergedLFNBase": "/store/himc",
+      "SiteBlacklist": [
+        "T1_US_FNAL",
+        "T2_US_Purdue",
+        "T2_US_Caltech",
+        "T2_US_Florida",
+        "T2_US_Nebraska",
+        "T2_US_UCSD",
+        "T2_US_Wisconsin",
+        "T3_US_NERSC"
+      ]
+    }
+  },
+  "HiFall15": {
+    "custodial": "T1_FR_CCIN2P3_MSS",
+    "fractionpass": 0.95,
+    "go": true,
+    "parameters": {
+      "MergedLFNBase": "/store/himc",
+      "SiteBlacklist": [
+        "T1_US_FNAL",
+        "T2_US_Purdue",
+        "T2_US_Caltech",
+        "T2_US_Florida",
+        "T2_US_Nebraska",
+        "T2_US_UCSD",
         "T2_US_Wisconsin"
       ]
     }
-  }, 
+  },
   "LowPU2010": {
-    "fractionpass": 0.95, 
-    "go": true, 
-    "lumisize": -1, 
-    "maxcopies": 1, 
-    "resize": "auto", 
+    "fractionpass": 0.95,
+    "go": true,
+    "lumisize": -1,
+    "maxcopies": 1,
+    "resize": "auto",
     "tune": true
-  }, 
+  },
   "LowPU2010DR42": {
-    "fractionpass": 0.95, 
-    "go": true, 
-    "lumisize": -1, 
-    "maxcopies": 1, 
+    "fractionpass": 0.95,
+    "go": true,
+    "lumisize": -1,
+    "maxcopies": 1,
     "tune": true
   },
   "MiniAODHI15Data": {
@@ -781,357 +740,331 @@
     "lumisize": -1,
     "resize": "auto",
     "parameters": {
-       "MergedLFNBase": "/store/himc",
-       "SiteBlacklist": [
-          "T1_US_FNAL",
-          "T2_US_Purdue",
-          "T2_US_Caltech",
-          "T2_US_Florida",
-          "T2_US_Nebraska",
-          "T2_US_UCSD",
-          "T2_US_Wisconsin"                         
-       ]
+      "MergedLFNBase": "/store/himc",
+      "SiteBlacklist": [
+        "T1_US_FNAL",
+        "T2_US_Purdue",
+        "T2_US_Caltech",
+        "T2_US_Florida",
+        "T2_US_Nebraska",
+        "T2_US_UCSD",
+        "T2_US_Wisconsin"
+      ]
     }
-  }, 
+  },
   "MiniAODHI18Data": {
     "SiteWhitelist": [
       "T2_US_Vanderbilt"
-    ], 
-    "fractionpass": 1.0, 
-    "go": true, 
-    "lumisize": -1, 
-    "maxcopies": 1, 
+    ],
+    "fractionpass": 1.0,
+    "go": true,
+    "lumisize": -1,
+    "maxcopies": 1,
     "resize": "auto"
-  }, 
+  },
   "MiniAODUL16Data": {
-    "go": true, 
-    "lumisize": -1, 
-    "maxcopies": 1, 
+    "go": true,
+    "lumisize": -1,
+    "maxcopies": 1,
     "resize": "auto"
-  }, 
+  },
   "MiniAODUL17Data": {
-    "go": true, 
-    "lumisize": -1, 
-    "maxcopies": 1, 
+    "go": true,
+    "lumisize": -1,
+    "maxcopies": 1,
     "resize": "auto"
-  }, 
+  },
   "MiniAODUL18Data": {
-    "go": true, 
-    "lumisize": -1, 
-    "maxcopies": 1, 
+    "go": true,
+    "lumisize": -1,
+    "maxcopies": 1,
     "resize": "auto"
-  }, 
+  },
   "MultiValidationUL17GS": {
-    "fractionpass": 0.95, 
-    "go": false, 
-    "lumisize": -1, 
-    "maxcopies": 1, 
+    "fractionpass": 0.95,
+    "go": false,
+    "lumisize": -1,
+    "maxcopies": 1,
     "overflow": {
       "PU": {
-        "force": false, 
-        "max": 0, 
+        "force": false,
+        "max": 0,
         "pending": 0
       }
-    }, 
-    "resize": "auto", 
+    },
+    "resize": "auto",
     "tune": true
-  }, 
+  },
   "MultiValidationUL17wmLHEGS": {
-    "fractionpass": 0.95, 
-    "go": false, 
-    "lumisize": -1, 
-    "maxcopies": 1, 
+    "fractionpass": 0.95,
+    "go": false,
+    "lumisize": -1,
+    "maxcopies": 1,
     "overflow": {
       "PU": {
-        "force": false, 
-        "max": 0, 
+        "force": false,
+        "max": 0,
         "pending": 0
       }
-    }, 
-    "resize": "auto", 
+    },
+    "resize": "auto",
     "tune": true
-  }, 
+  },
   "NANOAODRun2DataProd": {
-    "go": true, 
-    "lumisize": -1, 
+    "go": true,
+    "lumisize": -1,
     "maxcopies": 1
-  }, 
+  },
   "NANOAODULDataProd": {
-    "go": true, 
-    "lumisize": -1, 
+    "go": true,
+    "lumisize": -1,
     "maxcopies": 1
-  }, 
+  },
   "NanoAODUL16Data": {
-    "fractionpass": 1, 
-    "go": true, 
-    "lumisize": -1, 
-    "maxcopies": 1, 
+    "fractionpass": 1,
+    "go": true,
+    "lumisize": -1,
+    "maxcopies": 1,
     "overflow": {
       "PU": {
-        "force": false, 
-        "max": 0, 
+        "force": false,
+        "max": 0,
         "pending": 0
       }
-    }, 
-    "resize": "auto", 
+    },
+    "resize": "auto",
     "tune": true
-  }, 
+  },
   "NanoAODUL17Data": {
-    "fractionpass": 1, 
-    "go": true, 
-    "lumisize": -1, 
-    "maxcopies": 1, 
+    "fractionpass": 1,
+    "go": true,
+    "lumisize": -1,
+    "maxcopies": 1,
     "overflow": {
       "PU": {
-        "force": false, 
-        "max": 0, 
+        "force": false,
+        "max": 0,
         "pending": 0
       }
-    }, 
-    "resize": "auto", 
+    },
+    "resize": "auto",
     "tune": true
-  }, 
+  },
   "NanoAODUL18Data": {
-    "fractionpass": 1, 
-    "go": true, 
-    "lumisize": -1, 
-    "maxcopies": 1, 
+    "fractionpass": 1,
+    "go": true,
+    "lumisize": -1,
+    "maxcopies": 1,
     "overflow": {
       "PU": {
-        "force": false, 
-        "max": 0, 
+        "force": false,
+        "max": 0,
         "pending": 0
       }
-    }, 
-    "resize": "auto", 
+    },
+    "resize": "auto",
     "tune": true
   },
   "NanoAODv9UL16Data": {
-     "fractionpass": 1,
-     "go": true,
-     "lumisize": -1,
-     "maxcopies": 1,
-     "resize": "auto",
-     "tune": true
-    },
+    "fractionpass": 1,
+    "go": true,
+    "lumisize": -1,
+    "maxcopies": 1,
+    "resize": "auto",
+    "tune": true
+  },
   "NanoAODv9UL17Data": {
-     "fractionpass": 1,
-     "go": true,
-     "lumisize": -1,
-     "maxcopies": 1,
-     "resize": "auto",
-     "tune": true
-    },
+    "fractionpass": 1,
+    "go": true,
+    "lumisize": -1,
+    "maxcopies": 1,
+    "resize": "auto",
+    "tune": true
+  },
   "NanoAODv9UL18Data": {
-     "fractionpass": 1,
-     "go": true,
-     "lumisize": -1,
-     "maxcopies": 1,
-     "resize": "auto",
-     "tune": true
-    },
+    "fractionpass": 1,
+    "go": true,
+    "lumisize": -1,
+    "maxcopies": 1,
+    "resize": "auto",
+    "tune": true
+  },
   "Commissioning900wmLHEGS": {
-      "go": true,
-      "lumisize": -1,
-      "maxcopies": 1,
-      "fractionpass": 0.95
+    "go": true,
+    "lumisize": -1,
+    "maxcopies": 1,
+    "fractionpass": 0.95
   },
   "Commissioning900GS": {
-      "go": true,
-      "lumisize": -1,
-      "maxcopies": 1,
-      "fractionpass": 0.95
+    "go": true,
+    "lumisize": -1,
+    "maxcopies": 1,
+    "fractionpass": 0.95
   },
   "Commissioning900DR": {
-      "go": true,
-      "lumisize": -1,
-      "maxcopies": 1,
-      "fractionpass": 0.95
+    "go": true,
+    "lumisize": -1,
+    "maxcopies": 1,
+    "fractionpass": 0.95
   },
   "Commissioning900MiniAOD": {
-      "go": true,
-      "lumisize": -1,
-      "maxcopies": 1,
-      "fractionpass": 0.95
+    "go": true,
+    "lumisize": -1,
+    "maxcopies": 1,
+    "fractionpass": 0.95
   },
   "Phase2HLTTDRSummer20L1T": {
-    "fractionpass": 0.95, 
-    "go": true, 
-    "lumisize": -1, 
-    "maxcopies": 1, 
-    "resize": "auto", 
+    "fractionpass": 0.95,
+    "go": true,
+    "lumisize": -1,
+    "maxcopies": 1,
+    "resize": "auto",
     "tune": true
-  }, 
+  },
   "Phase2HLTTDRSummer20MiniAOD": {
-    "fractionpass": 0.95, 
-    "go": false, 
-    "lumisize": -1, 
-    "maxcopies": 1, 
+    "fractionpass": 0.95,
+    "go": false,
+    "lumisize": -1,
+    "maxcopies": 1,
     "resize": "auto"
-  }, 
+  },
   "Phase2HLTTDRSummer20ReRECO": {
-    "fractionpass": 0.95, 
-    "go": false, 
-    "lumisize": -1, 
-    "maxcopies": 1, 
+    "fractionpass": 0.95,
+    "go": false,
+    "lumisize": -1,
+    "maxcopies": 1,
     "resize": "auto"
-  }, 
+  },
   "Phase2HLTTDRSummer20ReRECOMiniAOD": {
-    "fractionpass": 0.95, 
-    "go": true, 
-    "lumisize": -1, 
+    "fractionpass": 0.95,
+    "go": true,
+    "lumisize": -1,
     "maxcopies": 1
-  }, 
+  },
   "Phase2HLTTDRWinter20DIGI": {
-    "fractionpass": 0.95, 
-    "go": true, 
-    "lumisize": -1, 
-    "maxcopies": 1, 
-    "partial_copy": 0.95, 
-    "resize": "auto", 
-    "secondaries": {
-      "/MinBias_TuneCP5_14TeV-pythia8/Phase2HLTTDRWinter20GS-110X_mcRun4_realistic_v3_ext1-v1/GEN-SIM": {
-        "SiteWhitelist": [
-          "T1_RU_JINR_Disk"
-        ]
-      }, 
-      "/RelValMinBias_14TeV/CMSSW_11_1_2_patch3-110X_mcRun4_realistic_v3_2026D49noPU_BSzpz35-v1/GEN-SIM": {
-        "SiteWhitelist": [
-          "T1_DE_KIT_Disk", 
-          "T2_US_Florida"
-        ]
-      },
-      "/MinBias_TuneCP5_14TeV-pythia8/Phase2HLTTDRWinter20GS-BSzpz35_110X_mcRun4_realistic_v3_ext4-v1/GEN-SIM":{
-           "SiteWhitelist": [
-                 "T1_ES_PIC_Disk",
-                 "T1_RU_JINR_Disk"
-                ]
-      }
-    }
-  }, 
-  "Phase2HLTTDRWinter20DR": {
-    "fractionpass": 0.95, 
-    "go": false, 
-    "lumisize": -1, 
-    "maxcopies": 1, 
-    "tune": true
-  }, 
-  "Phase2HLTTDRWinter20GS": {
-    "fractionpass": 0.95, 
-    "go": true, 
-    "lumisize": -1, 
-    "maxcopies": 1, 
-    "tune": true
-  }, 
-  "Phase2HLTTDRWinter20RECOMiniAOD": {
-    "fractionpass": 0.95, 
-    "go": true, 
-    "lumisize": -1, 
-    "maxcopies": 1, 
-    "resize": "auto"
-  }, 
-  "Phase2HLTTDRWinter20wmLHEGS": {
-    "fractionpass": 0.95, 
-    "go": true, 
-    "lumisize": -1, 
-    "maxcopies": 1, 
-    "tune": true
-  }, 
-  "Run2016F": {
-    "custodial_override": [
-      "DQMIO"
-    ], 
-    "fractionpass": {
-      "DQMIO": {
-        "/JetHT/": 0.95, 
-        "/SingleMuon/": 0.95, 
-        "/SinglePhoton": 0.95, 
-        "/ZeroBias/": 0.95, 
-        "all": 0.9
-      }, 
-      "all": 1.0
-    }, 
-    "go": true, 
-    "labels": [
-      "03Feb2017", 
-      "15Feb2017", 
-      "22Feb2017", 
-      "18Apr2017_ver2", 
-      "18Apr2017", 
-      "07Aug17", 
-      "07Dec2018", 
-      "28Feb2019", 
-      "TrkAPVStudies"
-    ], 
-    "maxcopies": 1, 
-    "overflow": {
-      "PRIM": {}
-    }, 
-    "resize": "auto"
-  }, 
-  "Run3Winter20CosmicDR": {
-    "fractionpass": 0.95, 
-    "go": true, 
-    "lumisize": -1, 
-    "maxcopies": 1, 
-    "tune": true
-  }, 
-  "Run3Winter20CosmicGS": {
-    "fractionpass": 0.95, 
-    "go": true, 
-    "lumisize": -1, 
-    "maxcopies": 1, 
-    "tune": true
-  }, 
-  "Run3Winter20DRMiniAOD": {
-    "fractionpass": 0.95, 
-    "go": true, 
-    "lumisize": -1, 
-    "maxcopies": 1, 
+    "fractionpass": 0.95,
+    "go": true,
+    "lumisize": -1,
+    "maxcopies": 1,
+    "partial_copy": 0.95,
     "resize": "auto",
     "secondaries": {
-      "/MinBias_TuneCP5_14TeV-pythia8/Run3Winter20GS-110X_mcRun3_2021_realistic_v6-v1/GEN-SIM": {
-        "SiteWhitelist": [
-          "T1_ES_PIC_Disk",
+      "/RelValMinBias_14TeV/CMSSW_11_1_2_patch3-110X_mcRun4_realistic_v3_2026D49noPU_BSzpz35-v1/GEN-SIM": {
+        "SecondaryLocation": [
           "T1_US_FNAL_Disk"
         ]
       }
     }
-  }, 
-  "Run3Winter20GS": {
-    "fractionpass": 0.95, 
-    "go": true, 
-    "lumisize": -1, 
-    "maxcopies": 1, 
-    "resize": "auto"
-  }, 
-  "Run3Winter21DRMiniAOD": {
-   "secondaries": { 
-    "/MinBias_TuneCP5_14TeV-pythia8/Run3Winter21GS-112X_mcRun3_2021_realistic_v15-v1/GEN-SIM": {
-      "SiteWhitelist": [
-        "T1_US_FNAL_Disk", 
-        "T1_UK_RAL_Disk"
-      ]
-     }
-    }, 
-    "fractionpass": 0.95, 
-    "go": true, 
-    "lumisize": -1, 
-    "maxcopies": 1, 
-    "resize": "auto"
-  }, 
-  "Run3Winter21GS": {
-    "fractionpass": 0.95, 
-    "go": true, 
-    "lumisize": -1, 
-    "maxcopies": 1, 
-    "resize": "auto"
-  }, 
-  "Run3Winter21wmLHEGS": {
-    "fractionpass": 0.95, 
+  },
+  "Phase2HLTTDRWinter20DR": {
+    "fractionpass": 0.95,
+    "go": false,
+    "lumisize": -1,
+    "maxcopies": 1,
+    "tune": true
+  },
+  "Phase2HLTTDRWinter20GS": {
+    "fractionpass": 0.95,
     "go": true,
-    "lumisize": -1, 
-    "maxcopies": 1, 
+    "lumisize": -1,
+    "maxcopies": 1,
+    "tune": true
+  },
+  "Phase2HLTTDRWinter20RECOMiniAOD": {
+    "fractionpass": 0.95,
+    "go": true,
+    "lumisize": -1,
+    "maxcopies": 1,
+    "resize": "auto"
+  },
+  "Phase2HLTTDRWinter20wmLHEGS": {
+    "fractionpass": 0.95,
+    "go": true,
+    "lumisize": -1,
+    "maxcopies": 1,
+    "tune": true
+  },
+  "Run2016F": {
+    "custodial_override": [
+      "DQMIO"
+    ],
+    "fractionpass": {
+      "DQMIO": {
+        "/JetHT/": 0.95,
+        "/SingleMuon/": 0.95,
+        "/SinglePhoton": 0.95,
+        "/ZeroBias/": 0.95,
+        "all": 0.9
+      },
+      "all": 1.0
+    },
+    "go": true,
+    "labels": [
+      "03Feb2017",
+      "15Feb2017",
+      "22Feb2017",
+      "18Apr2017_ver2",
+      "18Apr2017",
+      "07Aug17",
+      "07Dec2018",
+      "28Feb2019",
+      "TrkAPVStudies"
+    ],
+    "maxcopies": 1,
+    "overflow": {
+      "PRIM": {}
+    },
+    "resize": "auto"
+  },
+  "Run3Winter20CosmicDR": {
+    "fractionpass": 0.95,
+    "go": true,
+    "lumisize": -1,
+    "maxcopies": 1,
+    "tune": true
+  },
+  "Run3Winter20CosmicGS": {
+    "fractionpass": 0.95,
+    "go": true,
+    "lumisize": -1,
+    "maxcopies": 1,
+    "tune": true
+  },
+  "Run3Winter20DRMiniAOD": {
+    "fractionpass": 0.95,
+    "go": true,
+    "lumisize": -1,
+    "maxcopies": 1,
+    "resize": "auto",
+    "secondaries": {}
+  },
+  "Run3Winter20GS": {
+    "fractionpass": 0.95,
+    "go": true,
+    "lumisize": -1,
+    "maxcopies": 1,
+    "resize": "auto"
+  },
+  "Run3Winter21DRMiniAOD": {
+    "secondaries": {},
+    "fractionpass": 0.95,
+    "go": true,
+    "lumisize": -1,
+    "maxcopies": 1,
+    "resize": "auto"
+  },
+  "Run3Winter21GS": {
+    "fractionpass": 0.95,
+    "go": true,
+    "lumisize": -1,
+    "maxcopies": 1,
+    "resize": "auto"
+  },
+  "Run3Winter21wmLHEGS": {
+    "fractionpass": 0.95,
+    "go": true,
+    "lumisize": -1,
+    "maxcopies": 1,
     "resize": "auto"
   },
   "Run3Summer21PrePremix": {
@@ -1139,35 +1072,16 @@
     "go": true,
     "lumisize": -1,
     "SiteBlacklist": [
-        "T2_CH_CERN",
-        "T2_CH_CERN_HLT",
-        "T2_CH_CERN_P5"
+      "T2_CH_CERN",
+      "T2_CH_CERN_HLT",
+      "T2_CH_CERN_P5"
     ],
     "secondaries": {
-        "/MinBias_TuneCP5_14TeV-pythia8/Run3Summer21GS-120X_mcRun3_2021_realistic_v5-v1/GEN-SIM": {
-           "SiteWhitelist": [
-              "T1_US_FNAL_Disk",
-              "T1_DE_KIT_Disk"
-                ]
-        },        
-        "/MinBias_TuneCP5_13p6TeV-pythia8/Run3Winter22GS-122X_mcRun3_2021_realistic_v9-v1/GEN-SIM": {
-            "SiteWhitelist": [
-                "T1_US_FNAL_Disk",
-                "T1_ES_PIC_Disk"
-                    ]
-        },
-        "/MinBias_TuneCP5_13p6TeV-pythia8/Run3Summer22GS-124X_mcRun3_2022_realistic_v10-v1/GEN-SIM": {
-            "SiteWhitelist": [
-                "T2_CH_CERN",
-                "T1_US_FNAL_Disk"
-            ]
-        },
-        "/MinBias_TuneCP5_13p6TeV-pythia8/Run3Winter23GS-126X_mcRun3_2023_forPU65_v1-v1/GEN-SIM": {
-            "SiteWhitelist": [
-                "T1_US_FNAL_Disk", 
-                "T2_CH_CERN"
-            ]
-        }
+      "/MinBias_TuneCP5_13p6TeV-pythia8/Run3Winter22GS-122X_mcRun3_2021_realistic_v9-v1/GEN-SIM": {
+        "SecondaryLocation": [
+          "T1_US_FNAL_Disk"
+        ]
+      }
     },
     "maxcopies": 1
   },
@@ -1178,40 +1092,26 @@
     "maxcopies": 1
   },
   "Run3Summer21DR": {
-      "fractionpass": 0.95,
-      "go": true,
-      "lumisize": -1,
-      "SiteBlacklist": [
-        "T2_CH_CERN",
-        "T2_CH_CERN_HLT",
-        "T2_CH_CERN_P5"
-        ],      
-      "maxcopies": 1,
-      "secondaries": {
-          "/MinBias_TuneCP5_14TeV-pythia8/Run3Summer21GS-120X_mcRun3_2021_realistic_v5-v1/GEN-SIM": {
-              "SiteWhitelist": [
-                  "T1_US_FNAL_Disk",
-                  "T1_DE_KIT_Disk"
-                      ]
-          }
-      }
+    "fractionpass": 0.95,
+    "go": true,
+    "lumisize": -1,
+    "SiteBlacklist": [
+      "T2_CH_CERN",
+      "T2_CH_CERN_HLT",
+      "T2_CH_CERN_P5"
+    ],
+    "maxcopies": 1,
+    "secondaries": {}
   },
   "Run3Summer21DRPremix": {
     "fractionpass": 0.95,
     "SiteBlacklist": [
-        "T2_CH_CERN",
-        "T2_CH_CERN_HLT",
-        "T2_CH_CERN_P5"
-            ],
-    "secondary_AAA": true,        
-    "secondaries": {
-          "/Neutrino_E-10_gun/Run3Summer21PrePremix-120X_mcRun3_2021_realistic_v6-v2/PREMIX": { 
-              "SecondaryLocation": [
-                  "T1_US_FNAL_Disk",
-                  "T1_DE_KIT_Disk"
-                      ]
-          }
-    },
+      "T2_CH_CERN",
+      "T2_CH_CERN_HLT",
+      "T2_CH_CERN_P5"
+    ],
+    "secondary_AAA": true,
+    "secondaries": {},
     "go": true,
     "lumisize": -1,
     "maxcopies": 1
@@ -1223,7 +1123,7 @@
       "T2_CH_CERN",
       "T2_CH_CERN_HLT",
       "T2_CH_CERN_P5"
-        ],
+    ],
     "lumisize": -1,
     "maxcopies": 1
   },
@@ -1233,42 +1133,42 @@
       "T2_CH_CERN",
       "T2_CH_CERN_HLT",
       "T2_CH_CERN_P5"
-        ],
+    ],
     "go": true,
     "lumisize": -1,
     "maxcopies": 1
   },
   "Run3Summer21pLHE": {
-      "fractionpass": 0.95,
-      "go": true,
-      "lumisize": -1,
-      "tune": true
+    "fractionpass": 0.95,
+    "go": true,
+    "lumisize": -1,
+    "tune": true
   },
   "Run3Winter22PbPbpLHE": {
-      "fractionpass": 0.95,
-      "go": true,
-      "lumisize": -1,
-      "resize": "auto",
-      "tune": true,
-      "parameters": {
-          "MergedLFNBase": "/store/himc",
-          "SiteBlacklist": [
-            "T1_ES_PIC",
-            "T1_FR_CCIN2P3",
-            "T2_CN_Beijing",
-            "T2_DE_RWTH",
-            "T2_FR_IPHC",
-            "T2_KR_KISTI",
-            "T2_PT_NCG_Lisbon",
-            "T2_RU_IHEP",
-            "T2_UK_SGrid_RALPP",
-            "T2_TR_METU",
-            "T2_FI_HIP",
-            "T2_RU_INR"
-          ]
-        }
+    "fractionpass": 0.95,
+    "go": true,
+    "lumisize": -1,
+    "resize": "auto",
+    "tune": true,
+    "parameters": {
+      "MergedLFNBase": "/store/himc",
+      "SiteBlacklist": [
+        "T1_ES_PIC",
+        "T1_FR_CCIN2P3",
+        "T2_CN_Beijing",
+        "T2_DE_RWTH",
+        "T2_FR_IPHC",
+        "T2_KR_KISTI",
+        "T2_PT_NCG_Lisbon",
+        "T2_RU_IHEP",
+        "T2_UK_SGrid_RALPP",
+        "T2_TR_METU",
+        "T2_FI_HIP",
+        "T2_RU_INR"
+      ]
+    }
   },
-  "Run3Winter22PbPbNoMixRECOMiniAOD" : {
+  "Run3Winter22PbPbNoMixRECOMiniAOD": {
     "fractionpass": 0.95,
     "go": true,
     "lumisize": -1,
@@ -1289,9 +1189,9 @@
         "T2_FI_HIP",
         "T2_RU_INR"
       ]
-     } 
+    }
   },
-  "Run3Winter22PbPbRECOMiniAOD" : {
+  "Run3Winter22PbPbRECOMiniAOD": {
     "fractionpass": 0.95,
     "go": false,
     "lumisize": -1,
@@ -1314,7 +1214,7 @@
       ]
     }
   },
-  "Run3Winter22PbPbNoMixDIGI" : {
+  "Run3Winter22PbPbNoMixDIGI": {
     "fractionpass": 0.95,
     "go": true,
     "lumisize": -1,
@@ -1335,9 +1235,9 @@
         "T2_FI_HIP",
         "T2_RU_INR"
       ]
-     }
+    }
   },
-  "Run3Winter22PbPbDIGI" : {
+  "Run3Winter22PbPbDIGI": {
     "fractionpass": 0.95,
     "go": false,
     "lumisize": -1,
@@ -1358,17 +1258,10 @@
         "T2_FI_HIP",
         "T2_RU_INR"
       ]
-     },
-    "secondaries": {
-         "/MinBias_Hydjet_Drum5F_5p02TeV/Run3Winter22PbPbNoMixGS-122X_mcRun3_2021_realistic_HI_v10-v1/GEN-SIM": {
-                 "SiteWhitelist": [
-                      "T1_IT_CNAF_Disk",
-                      "T2_US_Florida"
-                                  ]
-                      }
-    }
-  },   
-  "Run3Winter22PbPbNoMixGS" : {
+    },
+    "secondaries": {}
+  },
+  "Run3Winter22PbPbNoMixGS": {
     "fractionpass": 0.95,
     "go": true,
     "lumisize": -1,
@@ -1390,14 +1283,14 @@
         "T2_RU_INR"
       ]
     }
-  }, 
-  "Run3Winter22PbPbGS" : {
+  },
+  "Run3Winter22PbPbGS": {
     "fractionpass": 0.95,
     "go": false,
     "lumisize": -1,
     "resize": "auto",
     "parameters": {
-       "MergedLFNBase": "/store/himc",
+      "MergedLFNBase": "/store/himc",
       "SiteBlacklist": [
         "T1_ES_PIC",
         "T1_FR_CCIN2P3",
@@ -1412,28 +1305,21 @@
         "T2_FI_HIP",
         "T2_RU_INR"
       ]
-     },
-    "secondaries": {
-         "/MinBias_Hydjet_Drum5F_5p02TeV/Run3Winter22PbPbNoMixGS-122X_mcRun3_2021_realistic_HI_v10-v1/GEN-SIM": {
-               "SiteWhitelist": [
-                     "T1_IT_CNAF_Disk",
-                     "T2_US_Florida"
-                              ]
-                      }
-    }
+    },
+    "secondaries": {}
   },
   "Run3Winter22pLHE": {
-     "fractionpass": 0.95,
-     "go": true
+    "fractionpass": 0.95,
+    "go": true
   },
   "Run3Winter22SIM": {
-      "fractionpass": 0.95,
-      "go": true
+    "fractionpass": 0.95,
+    "go": true
   },
   "Run3Winter22pLHEGEN": {
-     "fractionpass": 0.95,
-     "go": true
-  }, 
+    "fractionpass": 0.95,
+    "go": true
+  },
   "Run3Winter22GS": {
     "fractionpass": 0.95,
     "go": true,
@@ -1454,13 +1340,12 @@
     "lumisize": -1,
     "maxcopies": 1,
     "resize": "auto",
-    "secondaries": {        
-         "/MinBias_TuneCP5_13p6TeV-pythia8/Run3Winter22GS-122X_mcRun3_2021_realistic_v9-v1/GEN-SIM": {
-               "SiteWhitelist": [
-                   "T1_US_FNAL_Disk",
-                    "T1_ES_PIC_Disk"
-                     ]
-                }
+    "secondaries": {
+      "/MinBias_TuneCP5_13p6TeV-pythia8/Run3Winter22GS-122X_mcRun3_2021_realistic_v9-v1/GEN-SIM": {
+        "SecondaryLocation": [
+          "T1_US_FNAL_Disk"
+        ]
+      }
     }
   },
   "Run3Winter22DRPremix": {
@@ -1470,12 +1355,12 @@
     "maxcopies": 1,
     "resize": "auto",
     "secondaries": {
-        "/Neutrino_E-10_gun/Run3Summer21PrePremix-Winter22_122X_mcRun3_2021_realistic_v9-v1/PREMIX": {
-            "SecondaryLocation": [
-                      "T1_US_FNAL_Disk",
-                      "T2_CH_CERN"
-                                    ]
-        }
+      "/Neutrino_E-10_gun/Run3Summer21PrePremix-Winter22_122X_mcRun3_2021_realistic_v9-v1/PREMIX": {
+        "SecondaryLocation": [
+          "T1_US_FNAL_Disk",
+          "T2_CH_CERN"
+        ]
+      }
     },
     "secondary_AAA": true
   },
@@ -1487,470 +1372,414 @@
     "resize": "auto"
   },
   "Run3Winter22NanoAOD": {
-      "fractionpass": 0.95,
-      "go": true
+    "fractionpass": 0.95,
+    "go": true
   },
   "Run3Summer22wmLHEGS": {
-      "fractionpass": 0.95,
-      "go": true,
-      "SiteBlacklist": [
-        "T1_ES_PIC",
-        "T1_FR_CCIN2P3",
-        "T2_CN_Beijing",
-        "T2_DE_RWTH",
-        "T2_FR_IPHC",
-        "T2_KR_KISTI",
-        "T2_PT_NCG_Lisbon",
-        "T2_RU_IHEP",
-        "T2_UK_SGrid_RALPP",
-        "T2_TR_METU",
-        "T2_FI_HIP",
-        "T2_RU_INR",
-        "T2_US_Caltech"
-      ]
+    "fractionpass": 0.95,
+    "go": true,
+    "SiteBlacklist": [
+      "T1_ES_PIC",
+      "T1_FR_CCIN2P3",
+      "T2_CN_Beijing",
+      "T2_DE_RWTH",
+      "T2_FR_IPHC",
+      "T2_KR_KISTI",
+      "T2_PT_NCG_Lisbon",
+      "T2_RU_IHEP",
+      "T2_UK_SGrid_RALPP",
+      "T2_TR_METU",
+      "T2_FI_HIP",
+      "T2_RU_INR",
+      "T2_US_Caltech"
+    ]
   },
   "Run3Summer22EEwmLHEGS": {
-      "fractionpass": 0.95,
-      "go": true,
-      "SiteBlacklist": [
-        "T1_ES_PIC",
-        "T1_FR_CCIN2P3",
-        "T2_CN_Beijing",
-        "T2_DE_RWTH",
-        "T2_FR_IPHC",
-        "T2_KR_KISTI",
-        "T2_PT_NCG_Lisbon",
-        "T2_RU_IHEP",
-        "T2_UK_SGrid_RALPP",
-        "T2_TR_METU",
-        "T2_FI_HIP",
-        "T2_RU_INR",
-        "T2_US_Caltech"
-      ]
+    "fractionpass": 0.95,
+    "go": true,
+    "SiteBlacklist": [
+      "T1_ES_PIC",
+      "T1_FR_CCIN2P3",
+      "T2_CN_Beijing",
+      "T2_DE_RWTH",
+      "T2_FR_IPHC",
+      "T2_KR_KISTI",
+      "T2_PT_NCG_Lisbon",
+      "T2_RU_IHEP",
+      "T2_UK_SGrid_RALPP",
+      "T2_TR_METU",
+      "T2_FI_HIP",
+      "T2_RU_INR",
+      "T2_US_Caltech"
+    ]
   },
-  "Run3Summer22GS":{
-      "fractionpass": 0.95,
-      "go": true,
-      "SiteBlacklist": [
-        "T1_ES_PIC",
-        "T1_FR_CCIN2P3",
-        "T2_CN_Beijing",
-        "T2_DE_RWTH",
-        "T2_FR_IPHC",
-        "T2_KR_KISTI",
-        "T2_PT_NCG_Lisbon",
-        "T2_RU_IHEP",
-        "T2_UK_SGrid_RALPP",
-        "T2_TR_METU",
-        "T2_FI_HIP",
-        "T2_RU_INR"
-      ]
+  "Run3Summer22GS": {
+    "fractionpass": 0.95,
+    "go": true,
+    "SiteBlacklist": [
+      "T1_ES_PIC",
+      "T1_FR_CCIN2P3",
+      "T2_CN_Beijing",
+      "T2_DE_RWTH",
+      "T2_FR_IPHC",
+      "T2_KR_KISTI",
+      "T2_PT_NCG_Lisbon",
+      "T2_RU_IHEP",
+      "T2_UK_SGrid_RALPP",
+      "T2_TR_METU",
+      "T2_FI_HIP",
+      "T2_RU_INR"
+    ]
   },
-  "Run3Summer22EEGS":{
-      "fractionpass": 0.95,
-      "go": true,
-      "SiteBlacklist": [
-        "T1_ES_PIC",
-        "T1_FR_CCIN2P3",
-        "T2_CN_Beijing",
-        "T2_DE_RWTH",
-        "T2_FR_IPHC",
-        "T2_KR_KISTI",
-        "T2_PT_NCG_Lisbon",
-        "T2_RU_IHEP",
-        "T2_UK_SGrid_RALPP",
-        "T2_TR_METU",
-        "T2_FI_HIP",
-        "T2_RU_INR"
-      ]
+  "Run3Summer22EEGS": {
+    "fractionpass": 0.95,
+    "go": true,
+    "SiteBlacklist": [
+      "T1_ES_PIC",
+      "T1_FR_CCIN2P3",
+      "T2_CN_Beijing",
+      "T2_DE_RWTH",
+      "T2_FR_IPHC",
+      "T2_KR_KISTI",
+      "T2_PT_NCG_Lisbon",
+      "T2_RU_IHEP",
+      "T2_UK_SGrid_RALPP",
+      "T2_TR_METU",
+      "T2_FI_HIP",
+      "T2_RU_INR"
+    ]
   },
   "Run3Summer22DR": {
-      "fractionpass": 0.95,
-      "go": true,
-      "secondaries": {
-        "/MinBias_TuneCP5_13p6TeV-pythia8/Run3Summer22GS-124X_mcRun3_2022_realistic_v10-v1/GEN-SIM": {
-          "SiteWhitelist": [
-            "T1_US_FNAL_Disk",
-            "T2_CH_CERN"
-          ]
-        }
-      },
-      "secondary AAA": false,
-      "SiteBlacklist": [
-        "T1_ES_PIC",
-        "T1_FR_CCIN2P3",
-        "T2_CN_Beijing",
-        "T2_DE_RWTH",
-        "T2_FR_IPHC",
-        "T2_KR_KISTI",
-        "T2_PT_NCG_Lisbon",
-        "T2_RU_IHEP",
-        "T2_UK_SGrid_RALPP",
-        "T2_TR_METU",
-        "T2_FI_HIP",
-        "T2_RU_INR"
-      ]
-  },
-  "Run3Summer22EEDR": {
-      "fractionpass": 0.95,
-      "go": true,
-      "secondaries": {
-        "/MinBias_TuneCP5_13p6TeV-pythia8/Run3Summer22GS-124X_mcRun3_2022_realistic_v10-v1/GEN-SIM": {
-          "SiteWhitelist": [
-            "T1_US_FNAL_Disk",
-            "T2_CH_CERN"
-          ]
-        }
-      },
-      "secondary AAA": false,
-      "SiteBlacklist": [
-        "T1_ES_PIC",
-        "T1_FR_CCIN2P3",
-        "T2_CN_Beijing",
-        "T2_DE_RWTH",
-        "T2_FR_IPHC",
-        "T2_KR_KISTI",
-        "T2_PT_NCG_Lisbon",
-        "T2_RU_IHEP",
-        "T2_UK_SGrid_RALPP",
-        "T2_TR_METU",
-        "T2_FI_HIP",
-        "T2_RU_INR"
-      ]
-  },
-  "Run3Summer22DRPremix": {
-      "fractionpass": 0.95,
-      "go": true,
-      "secondaries": {
-        "/Neutrino_E-10_gun/Run3Summer21PrePremix-Summer22_124X_mcRun3_2022_realistic_v11-v2/PREMIX": {
-          "SecondaryLocation": [
-            "T1_US_FNAL_Disk",
-            "T2_CH_CERN"
-          ]
-        }
-      },
-      "secondary_AAA": true,
-      "SiteBlacklist": [
-        "T1_ES_PIC",
-        "T1_FR_CCIN2P3",
-        "T2_CN_Beijing",
-        "T2_DE_RWTH",
-        "T2_FR_IPHC",
-        "T2_KR_KISTI",
-        "T2_PT_NCG_Lisbon",
-        "T2_RU_IHEP",
-        "T2_UK_SGrid_RALPP",
-        "T2_TR_METU",
-        "T2_FI_HIP",
-        "T2_RU_INR"
-      ]
-  },
-  "Run3Summer22EEDRPremix": {
-      "fractionpass": 0.95,
-      "go": true,
-      "secondaries": {
-        "/Neutrino_E-10_gun/Run3Summer21PrePremix-Summer22_124X_mcRun3_2022_realistic_v11-v2/PREMIX": {
-          "SecondaryLocation": [
-            "T1_US_FNAL_Disk",
-            "T2_CH_CERN"
-          ]
-        }
-      },
-      "secondary_AAA": true,
-      "SiteBlacklist": [
-        "T1_ES_PIC",
-        "T1_FR_CCIN2P3",
-        "T2_CN_Beijing",
-        "T2_DE_RWTH",
-        "T2_FR_IPHC",
-        "T2_KR_KISTI",
-        "T2_PT_NCG_Lisbon",
-        "T2_RU_IHEP",
-        "T2_UK_SGrid_RALPP",
-        "T2_TR_METU",
-        "T2_FI_HIP",
-        "T2_RU_INR"
-      ]
-  },
-  "Run3Summer22EEMiniAODv3":{
-      "fractionpass": 0.95,
-      "go": true,
-      "SiteBlacklist": [
-        "T1_ES_PIC",
-        "T1_FR_CCIN2P3",
-        "T2_CN_Beijing",
-        "T2_DE_RWTH",
-        "T2_FR_IPHC",
-        "T2_KR_KISTI",
-        "T2_PT_NCG_Lisbon",
-        "T2_RU_IHEP",
-        "T2_UK_SGrid_RALPP",
-        "T2_TR_METU",
-        "T2_FI_HIP",
-        "T2_RU_INR"
-      ]
-  },
-  "Run3Summer22MiniAODv3":{
-      "fractionpass": 0.95,
-      "go": true,
-      "SiteBlacklist": [
-        "T1_ES_PIC",
-        "T1_FR_CCIN2P3",
-        "T2_CN_Beijing",
-        "T2_DE_RWTH",
-        "T2_FR_IPHC",
-        "T2_KR_KISTI",
-        "T2_PT_NCG_Lisbon",
-        "T2_RU_IHEP",
-        "T2_UK_SGrid_RALPP",
-        "T2_TR_METU",
-        "T2_FI_HIP",
-        "T2_RU_INR"
-      ]
-  },
-  "Run3Summer22NanoAODv10": {
-      "fractionpass": 0.95,
-       "go": true,
-      "SiteBlacklist": [
-        "T1_ES_PIC",
-        "T1_FR_CCIN2P3",
-        "T2_CN_Beijing",
-        "T2_DE_RWTH",
-        "T2_FR_IPHC",
-        "T2_KR_KISTI",
-        "T2_PT_NCG_Lisbon",
-        "T2_RU_IHEP",
-        "T2_UK_SGrid_RALPP",
-        "T2_TR_METU",
-        "T2_FI_HIP",
-        "T2_RU_INR"
-      ]
-  },
-  "Run3Summer22NanoAODv11": {
-      "fractionpass": 0.95,
-       "go": true,
-      "SiteBlacklist": [
-        "T1_ES_PIC",
-        "T1_FR_CCIN2P3",
-        "T2_CN_Beijing",
-        "T2_DE_RWTH",
-        "T2_FR_IPHC",
-        "T2_KR_KISTI",
-        "T2_PT_NCG_Lisbon",
-        "T2_RU_IHEP",
-        "T2_UK_SGrid_RALPP",
-        "T2_TR_METU",
-        "T2_FI_HIP",
-        "T2_RU_INR"
-      ]
-  },
-  "Run3Summer22EENanoAODv10": {
-      "fractionpass": 0.95,
-       "go": true,
-      "SiteBlacklist": [
-        "T1_ES_PIC",
-        "T1_FR_CCIN2P3",
-        "T2_CN_Beijing",
-        "T2_DE_RWTH",
-        "T2_FR_IPHC",
-        "T2_KR_KISTI",
-        "T2_PT_NCG_Lisbon",
-        "T2_RU_IHEP",
-        "T2_UK_SGrid_RALPP",
-        "T2_TR_METU",
-        "T2_FI_HIP",
-        "T2_RU_INR"
-      ]
-  },
-  "Run3Summer22EENanoAODv11": {
-      "fractionpass": 0.95,
-       "go": true,
-      "SiteBlacklist": [
-        "T1_ES_PIC",
-        "T1_FR_CCIN2P3",
-        "T2_CN_Beijing",
-        "T2_DE_RWTH",
-        "T2_FR_IPHC",
-        "T2_KR_KISTI",
-        "T2_PT_NCG_Lisbon",
-        "T2_RU_IHEP",
-        "T2_UK_SGrid_RALPP",
-        "T2_TR_METU",
-        "T2_FI_HIP",
-        "T2_RU_INR"
-      ]
-  },
-  "Run3Winter22CosmicGS":{
-      "fractionpass": 0.95,
-      "go": true
-  },
-  "Run3Winter22CosmicDR":{
-      "fractionpass": 0.95,
-      "go": true
-  },
-  "Run3Winter22NanoAODv10": {
-      "fractionpass": 0.95,
-      "go": false
-  },
-  "Run3Winter22wmLHEGEN": {
-      "fractionpass": 0.95,
-      "go": true
-  },
-  "Run3Winter22GEN": {
-      "fractionpass": 0.95,
-      "go": true
-  },
-  "PromptNanoAODv10": {
-      "fractionpass": 1,
-      "go" : true,
-      "partial_copy": 0.01,
-      "SiteBlacklist": [
-        "T1_ES_PIC",
-        "T1_FR_CCIN2P3",
-        "T1_IT_CNAF",
-        "T1_RU_JINR",
-        "T2_AT_Vienna",
-        "T2_BE_IIHE",
-        "T2_BE_UCL",
-        "T2_CH_CSCS",
-        "T2_CN_Beijing",
-        "T2_DE_RWTH",
-        "T2_EE_Estonia",
-        "T2_ES_CIEMAT",
-        "T2_FI_HIP",
-        "T2_FR_GRIF_LLR",
-        "T2_FR_IPHC",
-        "T2_GR_Ioannina",
-        "T2_HU_Budapest",
-        "T2_IT_Bari",
-        "T2_IT_Legnaro",
-        "T2_IT_Pisa",
-        "T2_IT_Rome",
-        "T2_KR_KISTI",
-        "T2_PK_NCP",
-        "T2_PL_Swierk",
-        "T2_PT_NCG_Lisbon",
-        "T2_RU_IHEP",
-        "T2_RU_INR",
-        "T2_RU_ITEP",
-        "T2_RU_JINR",
-        "T2_RU_SINP",
-        "T2_TR_METU",
-        "T2_UA_KIPT",
-        "T2_UK_London_IC",
-        "T2_UK_SGrid_RALPP",
-        "T2_US_Purdue",
-        "T2_US_Vanderbilt"
-      ]
-  },
-  "RunIIAutumn18DR": {
-    "fractionpass": 0.95, 
-    "go": true, 
-    "lumisize": -1, 
-    "maxcopies": 1, 
-    "resize": "auto", 
+    "fractionpass": 0.95,
+    "go": true,
     "secondaries": {
-      "/MinBias_TuneCP5_13TeV-pythia8/RunIIFall18GS-102X_upgrade2018_realistic_v9-v1/GEN-SIM": {
+      "/MinBias_TuneCP5_13p6TeV-pythia8/Run3Summer22GS-124X_mcRun3_2022_realistic_v10-v1/GEN-SIM": {
         "SiteWhitelist": [
-          "T2_US_MIT", 
-          "T2_DE_DESY"
-        ]
-      }, 
-      "/MinBias_TuneCP5_13TeV-pythia8/RunIIFall18GS-IdealGeometry_102X_upgrade2018_design_v9-v1/GEN-SIM": {
-        "SiteWhitelist": [
-          "T1_US_FNAL_Disk"
-        ]
-      }, 
-      "/MinBias_TuneCP5_13TeV-pythia8/RunIIFall18GS-newECALCrystalGeometryFor2016_102X_mcRun2_asymptotic_v5-v1/GEN-SIM": {
-        "SiteWhitelist": [
-          "T1_US_FNAL_Disk"
-        ]
-      }, 
-      "/MinBias_TuneCP5_13TeV-pythia8/RunIIFall18GS-newECALCrystalGeometryFor2017_102X_mc2017_realistic_v5-v1/GEN-SIM": {
-        "SiteWhitelist": [
-          "T1_DE_KIT_Disk"
-        ]
-      }, 
-      "/MinBias_TuneCP5_13TeV-pythia8_Fall18/RunIIFall18GS-102X_upgrade2018_realistic_v11-v1/GEN-SIM": {
-        "SiteWhitelist": [
-          "T1_IT_CNAF_Disk"
-        ]
-      }, 
-      "/MinBias_TuneCP5_13TeV_NeutronHP-pythia8/RunIIFall18GS-SNB_102X_upgrade2018_realistic_v17-v1/GEN-SIM": {
-        "SiteWhitelist": [
-          "T2_US_Nebraska"
-        ]
-      }, 
-      "/MinBias_TuneCP5_13TeV_NeutronXS-pythia8/RunIIFall18GS-SNB_102X_upgrade2018_realistic_v17-v1/GEN-SIM": {
-        "SiteWhitelist": [
-          "T1_ES_PIC_Disk"
+          "T1_US_FNAL_Disk",
+          "T2_CH_CERN"
         ]
       }
-    }, 
-    "tune": true
+    },
+    "secondary AAA": false,
+    "SiteBlacklist": [
+      "T1_ES_PIC",
+      "T1_FR_CCIN2P3",
+      "T2_CN_Beijing",
+      "T2_DE_RWTH",
+      "T2_FR_IPHC",
+      "T2_KR_KISTI",
+      "T2_PT_NCG_Lisbon",
+      "T2_RU_IHEP",
+      "T2_UK_SGrid_RALPP",
+      "T2_TR_METU",
+      "T2_FI_HIP",
+      "T2_RU_INR"
+    ]
   },
-  "Phase2Spring21DRMiniAOD":{
+  "Run3Summer22EEDR": {
+    "fractionpass": 0.95,
+    "go": true,
+    "secondaries": {
+      "/MinBias_TuneCP5_13p6TeV-pythia8/Run3Summer22GS-124X_mcRun3_2022_realistic_v10-v1/GEN-SIM": {
+        "SiteWhitelist": [
+          "T1_US_FNAL_Disk",
+          "T2_CH_CERN"
+        ]
+      }
+    },
+    "secondary AAA": false,
+    "SiteBlacklist": [
+      "T1_ES_PIC",
+      "T1_FR_CCIN2P3",
+      "T2_CN_Beijing",
+      "T2_DE_RWTH",
+      "T2_FR_IPHC",
+      "T2_KR_KISTI",
+      "T2_PT_NCG_Lisbon",
+      "T2_RU_IHEP",
+      "T2_UK_SGrid_RALPP",
+      "T2_TR_METU",
+      "T2_FI_HIP",
+      "T2_RU_INR"
+    ]
+  },
+  "Run3Summer22DRPremix": {
+    "fractionpass": 0.95,
+    "go": true,
+    "secondaries": {
+      "/Neutrino_E-10_gun/Run3Summer21PrePremix-Summer22_124X_mcRun3_2022_realistic_v11-v2/PREMIX": {
+        "SecondaryLocation": [
+          "T1_US_FNAL_Disk",
+          "T2_CH_CERN"
+        ]
+      }
+    },
+    "secondary_AAA": true,
+    "SiteBlacklist": [
+      "T1_ES_PIC",
+      "T1_FR_CCIN2P3",
+      "T2_CN_Beijing",
+      "T2_DE_RWTH",
+      "T2_FR_IPHC",
+      "T2_KR_KISTI",
+      "T2_PT_NCG_Lisbon",
+      "T2_RU_IHEP",
+      "T2_UK_SGrid_RALPP",
+      "T2_TR_METU",
+      "T2_FI_HIP",
+      "T2_RU_INR"
+    ]
+  },
+  "Run3Summer22EEDRPremix": {
+    "fractionpass": 0.95,
+    "go": true,
+    "secondaries": {
+      "/Neutrino_E-10_gun/Run3Summer21PrePremix-Summer22_124X_mcRun3_2022_realistic_v11-v2/PREMIX": {
+        "SecondaryLocation": [
+          "T1_US_FNAL_Disk",
+          "T2_CH_CERN"
+        ]
+      }
+    },
+    "secondary_AAA": true,
+    "SiteBlacklist": [
+      "T1_ES_PIC",
+      "T1_FR_CCIN2P3",
+      "T2_CN_Beijing",
+      "T2_DE_RWTH",
+      "T2_FR_IPHC",
+      "T2_KR_KISTI",
+      "T2_PT_NCG_Lisbon",
+      "T2_RU_IHEP",
+      "T2_UK_SGrid_RALPP",
+      "T2_TR_METU",
+      "T2_FI_HIP",
+      "T2_RU_INR"
+    ]
+  },
+  "Run3Summer22EEMiniAODv3": {
+    "fractionpass": 0.95,
+    "go": true,
+    "SiteBlacklist": [
+      "T1_ES_PIC",
+      "T1_FR_CCIN2P3",
+      "T2_CN_Beijing",
+      "T2_DE_RWTH",
+      "T2_FR_IPHC",
+      "T2_KR_KISTI",
+      "T2_PT_NCG_Lisbon",
+      "T2_RU_IHEP",
+      "T2_UK_SGrid_RALPP",
+      "T2_TR_METU",
+      "T2_FI_HIP",
+      "T2_RU_INR"
+    ]
+  },
+  "Run3Summer22MiniAODv3": {
+    "fractionpass": 0.95,
+    "go": true,
+    "SiteBlacklist": [
+      "T1_ES_PIC",
+      "T1_FR_CCIN2P3",
+      "T2_CN_Beijing",
+      "T2_DE_RWTH",
+      "T2_FR_IPHC",
+      "T2_KR_KISTI",
+      "T2_PT_NCG_Lisbon",
+      "T2_RU_IHEP",
+      "T2_UK_SGrid_RALPP",
+      "T2_TR_METU",
+      "T2_FI_HIP",
+      "T2_RU_INR"
+    ]
+  },
+  "Run3Summer22NanoAODv10": {
+    "fractionpass": 0.95,
+    "go": true,
+    "SiteBlacklist": [
+      "T1_ES_PIC",
+      "T1_FR_CCIN2P3",
+      "T2_CN_Beijing",
+      "T2_DE_RWTH",
+      "T2_FR_IPHC",
+      "T2_KR_KISTI",
+      "T2_PT_NCG_Lisbon",
+      "T2_RU_IHEP",
+      "T2_UK_SGrid_RALPP",
+      "T2_TR_METU",
+      "T2_FI_HIP",
+      "T2_RU_INR"
+    ]
+  },
+  "Run3Summer22NanoAODv11": {
+    "fractionpass": 0.95,
+    "go": true,
+    "SiteBlacklist": [
+      "T1_ES_PIC",
+      "T1_FR_CCIN2P3",
+      "T2_CN_Beijing",
+      "T2_DE_RWTH",
+      "T2_FR_IPHC",
+      "T2_KR_KISTI",
+      "T2_PT_NCG_Lisbon",
+      "T2_RU_IHEP",
+      "T2_UK_SGrid_RALPP",
+      "T2_TR_METU",
+      "T2_FI_HIP",
+      "T2_RU_INR"
+    ]
+  },
+  "Run3Summer22EENanoAODv10": {
+    "fractionpass": 0.95,
+    "go": true,
+    "SiteBlacklist": [
+      "T1_ES_PIC",
+      "T1_FR_CCIN2P3",
+      "T2_CN_Beijing",
+      "T2_DE_RWTH",
+      "T2_FR_IPHC",
+      "T2_KR_KISTI",
+      "T2_PT_NCG_Lisbon",
+      "T2_RU_IHEP",
+      "T2_UK_SGrid_RALPP",
+      "T2_TR_METU",
+      "T2_FI_HIP",
+      "T2_RU_INR"
+    ]
+  },
+  "Run3Summer22EENanoAODv11": {
+    "fractionpass": 0.95,
+    "go": true,
+    "SiteBlacklist": [
+      "T1_ES_PIC",
+      "T1_FR_CCIN2P3",
+      "T2_CN_Beijing",
+      "T2_DE_RWTH",
+      "T2_FR_IPHC",
+      "T2_KR_KISTI",
+      "T2_PT_NCG_Lisbon",
+      "T2_RU_IHEP",
+      "T2_UK_SGrid_RALPP",
+      "T2_TR_METU",
+      "T2_FI_HIP",
+      "T2_RU_INR"
+    ]
+  },
+  "Run3Winter22CosmicGS": {
+    "fractionpass": 0.95,
+    "go": true
+  },
+  "Run3Winter22CosmicDR": {
+    "fractionpass": 0.95,
+    "go": true
+  },
+  "Run3Winter22NanoAODv10": {
+    "fractionpass": 0.95,
+    "go": false
+  },
+  "Run3Winter22wmLHEGEN": {
+    "fractionpass": 0.95,
+    "go": true
+  },
+  "Run3Winter22GEN": {
+    "fractionpass": 0.95,
+    "go": true
+  },
+  "PromptNanoAODv10": {
+    "fractionpass": 1,
+    "go": true,
+    "partial_copy": 0.01,
+    "SiteBlacklist": [
+      "T1_ES_PIC",
+      "T1_FR_CCIN2P3",
+      "T1_IT_CNAF",
+      "T1_RU_JINR",
+      "T2_AT_Vienna",
+      "T2_BE_IIHE",
+      "T2_BE_UCL",
+      "T2_CH_CSCS",
+      "T2_CN_Beijing",
+      "T2_DE_RWTH",
+      "T2_EE_Estonia",
+      "T2_ES_CIEMAT",
+      "T2_FI_HIP",
+      "T2_FR_GRIF_LLR",
+      "T2_FR_IPHC",
+      "T2_GR_Ioannina",
+      "T2_HU_Budapest",
+      "T2_IT_Bari",
+      "T2_IT_Legnaro",
+      "T2_IT_Pisa",
+      "T2_IT_Rome",
+      "T2_KR_KISTI",
+      "T2_PK_NCP",
+      "T2_PL_Swierk",
+      "T2_PT_NCG_Lisbon",
+      "T2_RU_IHEP",
+      "T2_RU_INR",
+      "T2_RU_ITEP",
+      "T2_RU_JINR",
+      "T2_RU_SINP",
+      "T2_TR_METU",
+      "T2_UA_KIPT",
+      "T2_UK_London_IC",
+      "T2_UK_SGrid_RALPP",
+      "T2_US_Purdue",
+      "T2_US_Vanderbilt"
+    ]
+  },
+  "RunIIAutumn18DR": {
     "fractionpass": 0.95,
     "go": true,
     "lumisize": -1,
     "maxcopies": 1,
     "resize": "auto",
-    "secondaries": {
-        "/MinBias_TuneCP5_14TeV-pythia8/Phase2D76Spring21GS-113X_mcRun4_realistic_v7-v1/GEN-SIM": {
-            "SiteWhitelist": [
-                "T1_US_FNAL_Disk",
-                "T1_DE_KIT_Disk"
-                ]
-        },
-        "/MinBias_TuneCP5_14TeV-pythia8/Phase2D80Spring21GS-113X_mcRun4_realistic_T25_v1-v1/GEN-SIM": {
-            "SiteWhitelist": [
-                "T2_US_Nebraska",
-                "T2_IT_Pisa"
-                    ]
-        },
-        "/MinBias_TuneCP5_14TeV-pythia8/Phase2D81Spring21GS-113X_mcRun4_realistic_T26_v1-v1/GEN-SIM": {
-            "SiteWhitelist": [
-                "T1_DE_KIT_Disk",
-                "T2_US_Wisconsin"
-                    ]
-        }
-    }
+    "secondaries": {},
+    "tune": true
   },
-  "PhaseIISpring22GS" :{
-      "fractionpass": 0.95,
-      "go": true
+  "Phase2Spring21DRMiniAOD": {
+    "fractionpass": 0.95,
+    "go": true,
+    "lumisize": -1,
+    "maxcopies": 1,
+    "resize": "auto",
+    "secondaries": {}
+  },
+  "PhaseIISpring22GS": {
+    "fractionpass": 0.95,
+    "go": true
   },
   "PhaseIISpring22wmLHEGS": {
-      "fractionpass": 0.95,
-      "go": true
+    "fractionpass": 0.95,
+    "go": true
   },
-  "PhaseIISpring22DRMiniAOD" : {
-      "fractionpass": 0.95,
-      "go": true,
-      "secondaries": {
-         "/MinBias_TuneCP5_14TeV-pythia8/PhaseIISpring22GS-123X_mcRun4_realistic_v11-v1/GEN-SIM": {
-                 "SiteWhitelist": [
-                     "T1_US_FNAL_Disk",
-                     "T2_CH_CERN"
-                       ]
-              }
+  "PhaseIISpring22DRMiniAOD": {
+    "fractionpass": 0.95,
+    "go": true,
+    "secondaries": {
+      "/MinBias_TuneCP5_14TeV-pythia8/PhaseIISpring22GS-123X_mcRun4_realistic_v11-v1/GEN-SIM": {
+        "SiteWhitelist": [
+          "T1_US_FNAL_Disk",
+          "T2_CH_CERN"
+        ]
       }
+    }
   },
-  "Phase2D81Spring21GS":{
-      "fractionpass": 0.95,
-      "go": true,
-      "lumisize": -1,
-      "maxcopies": 1,
-      "resize": "auto"
-  },
-  "Phase2D80Spring21GS":{
+  "Phase2D81Spring21GS": {
     "fractionpass": 0.95,
     "go": true,
     "lumisize": -1,
     "maxcopies": 1,
     "resize": "auto"
   },
-  "Phase2D76Spring21GS":{
+  "Phase2D80Spring21GS": {
+    "fractionpass": 0.95,
+    "go": true,
+    "lumisize": -1,
+    "maxcopies": 1,
+    "resize": "auto"
+  },
+  "Phase2D76Spring21GS": {
     "fractionpass": 0.95,
     "go": true,
     "lumisize": -1,
@@ -1959,59 +1788,59 @@
   },
   "RunIIAutumn18DRPremix": {
     "SiteBlacklist": [
-      "T2_CH_CERN", 
+      "T2_CH_CERN",
       "T2_CH_CERN_HLT",
       "T2_CH_CERN_P5"
-    ], 
-    "fractionpass": 0.95, 
-    "go": true, 
-    "lumisize": -1, 
-    "maxcopies": 1, 
+    ],
+    "fractionpass": 0.95,
+    "go": true,
+    "lumisize": -1,
+    "maxcopies": 1,
     "overflow": {
       "PREMIX": {}
-    }, 
-    "resize": "auto", 
+    },
+    "resize": "auto",
     "secondaries": {
       "/Neutrino_E-10_gun/RunIISummer17PrePremix-PUAutumn18_102X_upgrade2018_realistic_v15-v1/GEN-SIM-DIGI-RAW": {
-          "SecondaryLocation": [
-                    "T1_US_FNAL_Disk"
-                        ]
+        "SecondaryLocation": [
+          "T1_US_FNAL_Disk"
+        ]
       }
-    }, 
-    "secondary_AAA": true, 
+    },
+    "secondary_AAA": true,
     "tune": true
-  }, 
+  },
   "RunIIAutumn18FSPremix": {
     "SiteBlacklist": [
       "T2_CH_CERN_HLT",
       "T2_CH_CERN_P5"
-    ], 
-    "fractionpass": 0.95, 
-    "go": true, 
-    "lumisize": -1, 
-    "maxcopies": 1, 
+    ],
+    "fractionpass": 0.95,
+    "go": true,
+    "lumisize": -1,
+    "maxcopies": 1,
     "overflow": {
       "PREMIX": {}
-    }, 
-    "resize": "auto", 
+    },
+    "resize": "auto",
     "secondaries": {
       "/Neutrino_E-10_gun/RunIIFall17FSPrePremix-PUMoriond18_102X_upgrade2018_realistic_v15-v2/GEN-SIM-DIGI-RAW": {
-          "SecondaryLocation": [
-                    "T1_US_FNAL_Disk",
-                    "T2_US_Nebraska",
-                    "T1_DE_KIT_Disk",
-                    "T1_RU_JINR_Disk"
-                                            ]
+        "SecondaryLocation": [
+          "T1_US_FNAL_Disk",
+          "T2_US_Nebraska",
+          "T1_DE_KIT_Disk",
+          "T1_RU_JINR_Disk"
+        ]
       }
-    }, 
-    "secondary_AAA": true, 
+    },
+    "secondary_AAA": true,
     "tune": true
-  }, 
+  },
   "RunIIAutumn18MiniAOD": {
-    "fractionpass": 0.95, 
-    "go": true, 
-    "lumisize": -1, 
-    "maxcopies": 1, 
+    "fractionpass": 0.95,
+    "go": true,
+    "lumisize": -1,
+    "maxcopies": 1,
     "resize": "auto"
   },
   "RunIIAutumn18NanoAODv6": {
@@ -2019,118 +1848,99 @@
     "go": true,
     "lumisize": -1,
     "maxcopies": 1
-  }, 
+  },
   "RunIIAutumn18NanoAODv7": {
-    "fractionpass": 0.99, 
-    "go": true, 
-    "lumisize": -1, 
+    "fractionpass": 0.99,
+    "go": true,
+    "lumisize": -1,
     "maxcopies": 1
-  }, 
+  },
   "RunIIAutumn18RECOBParking": {
-    "fractionpass": 0.95, 
-    "go": true, 
-    "lumisize": -1, 
-    "maxcopies": 1, 
-    "resize": "auto", 
+    "fractionpass": 0.95,
+    "go": true,
+    "lumisize": -1,
+    "maxcopies": 1,
+    "resize": "auto",
     "tune": true
-  }, 
+  },
   "RunIIFall17DRPremix": {
     "SiteBlacklist": [
-      "T2_CH_CERN", 
+      "T2_CH_CERN",
       "T2_CH_CERN_HLT",
       "T2_CH_CERN_P5"
-    ], 
-    "fractionpass": 0.95, 
-    "go": true, 
-    "lumisize": -1, 
-    "maxcopies": 1, 
+    ],
+    "fractionpass": 0.95,
+    "go": true,
+    "lumisize": -1,
+    "maxcopies": 1,
     "overflow": {
       "PREMIX": {}
-    }, 
-    "resize": "auto", 
+    },
+    "resize": "auto",
     "secondaries": {
       "/Neutrino_E-10_gun/RunIISummer17PrePremix-MCv2_correctPU_94X_mc2017_realistic_v9-v1/GEN-SIM-DIGI-RAW": {
-          "SecondaryLocation": [
-                    "T1_US_FNAL_Disk"
-                        ]
+        "SecondaryLocation": [
+          "T1_US_FNAL_Disk"
+        ]
       }
-    }, 
-    "secondary_AAA": true, 
+    },
+    "secondary_AAA": true,
     "tune": true
-  }, 
+  },
   "RunIIFall17DRStdmix": {
-    "fractionpass": 0.95, 
-    "go": true, 
-    "lumisize": -1, 
-    "maxcopies": 1, 
+    "fractionpass": 0.95,
+    "go": true,
+    "lumisize": -1,
+    "maxcopies": 1,
     "overflow": {
       "PU": {
-        "max": 20000, 
+        "max": 20000,
         "pending": 0
       }
-    }, 
-    "resize": "auto", 
-    "secondaries": {
-      "/MinBias_TuneCP1_13TeV-pythia8/RunIIFall17GS-93X_mc2017_realistic_v3-v1/GEN-SIM": {
-        "SiteWhitelist": [
-          "T1_DE_KIT_Disk", 
-          "T1_IT_CNAF_Disk"
-        ]
-      }, 
-      "/MinBias_TuneCP5_13TeV-pythia8_Fall17/RunIIFall17GS-93X_mc2017_realistic_v3-v1/GEN-SIM": {
-        "SiteWhitelist": [
-          "T1_IT_CNAF_Disk", 
-          "T1_DE_KIT_Disk"
-        ]
-      }, 
-      "/MinBias_TuneCP5_inelasticON_13TeV-pythia8/RunIIFall17GS-93X_mc2017_realistic_v3-v1/GEN-SIM": {
-        "SiteWhitelist": [
-          "T1_DE_KIT_Disk", 
-          "T1_FR_CCIN2P3_Disk"
-        ]
-      }
-    }, 
+    },
+    "resize": "auto",
+    "secondaries": {},
     "tune": false
-  }, 
+  },
   "RunIIFall17FSPremix": {
-    "fractionpass": 0.95, 
-    "go": true, 
-    "lumisize": -1, 
-    "maxcopies": 1, 
+    "fractionpass": 0.95,
+    "go": true,
+    "lumisize": -1,
+    "maxcopies": 1,
     "overflow": {
       "PREMIX": {}
-    }, 
-    "resize": "auto", 
+    },
+    "resize": "auto",
     "secondaries": {
       "/Neutrino_E-10_gun/RunIIFall17FSPrePremix-PUMoriond17_94X_mc2017_realistic_v15-v1/GEN-SIM-DIGI-RAW": {
-          "SecondaryLocation": [
-                    "T2_CH_CERN"
-                        ]
+        "SecondaryLocation": [
+          "T2_CH_CERN"
+        ]
       }
-    }, 
-    "secondary_AAA": true, 
+    },
+    "secondary_AAA": true,
     "tune": true
-  }, 
+  },
   "RunIIFall17GS": {
     "SiteBlacklist": [
-      "T2_CH_CERN", 
+      "T2_CH_CERN",
       "T2_CH_CERN_HLT",
       "T2_CH_CERN_P5",
       "T2_US_Caltech",
       "T2_CH_CSCS"
-    ], 
-    "force-complete": 0.99, 
-    "fractionpass": 0.95, 
-    "go": true, 
-    "lumisize": -1, 
-    "resize": "auto", 
+    ],
+    "force-complete": 0.99,
+    "fractionpass": 0.95,
+    "go": true,
+    "lumisize": -1,
+    "resize": "auto",
     "tune": true
-  }, 
+  },
   "RunIIFall17MiniAODv2": {
-    "fractionpass": 0.95, 
-    "go": true, 
-    "lumisize": -1, 
-    "maxcopies": 1, 
+    "fractionpass": 0.95,
+    "go": true,
+    "lumisize": -1,
+    "maxcopies": 1,
     "resize": "auto"
   },
   "RunIIFall17NanoAODv6": {
@@ -2138,250 +1948,213 @@
     "go": true,
     "lumisize": -1,
     "maxcopies": 1
-  }, 
+  },
   "RunIIFall17NanoAODv7": {
-    "fractionpass": 0.99, 
-    "go": true, 
-    "lumisize": -1, 
+    "fractionpass": 0.99,
+    "go": true,
+    "lumisize": -1,
     "maxcopies": 1
-  }, 
+  },
   "RunIIFall17pLHE": {
-    "fractionpass": 0.95, 
-    "go": true, 
-    "lumisize": -1, 
+    "fractionpass": 0.95,
+    "go": true,
+    "lumisize": -1,
     "tune": true
-  }, 
+  },
   "RunIIFall17wmLHEGS": {
     "SiteBlacklist": [
-      "T2_CH_CERN", 
+      "T2_CH_CERN",
       "T2_CH_CERN_HLT",
       "T2_CH_CERN_P5"
-    ], 
-    "force-complete": 0.99, 
-    "fractionpass": 0.95, 
-    "go": true, 
-    "lumisize": -1, 
+    ],
+    "force-complete": 0.99,
+    "fractionpass": 0.95,
+    "go": true,
+    "lumisize": -1,
     "overflow": {
       "LHE": {
         "site_list": "sites_AAA"
       }
-    }, 
+    },
     "tune": true
-  }, 
+  },
   "RunIIFall18GS": {
     "SiteBlacklist": [
       "T2_CH_CSCS",
-      "T2_US_Caltech", 
-      "T2_CH_CERN", 
+      "T2_US_Caltech",
+      "T2_CH_CERN",
       "T2_CH_CERN_HLT",
       "T2_CH_CERN_P5"
-    ], 
-    "fractionpass": 0.95, 
-    "go": true, 
-    "lumisize": -1, 
-    "resize": "auto", 
+    ],
+    "fractionpass": 0.95,
+    "go": true,
+    "lumisize": -1,
+    "resize": "auto",
     "tune": true
-  }, 
+  },
   "RunIIFall18pLHE": {
-    "fractionpass": 0.95, 
-    "go": true, 
-    "lumisize": -1, 
+    "fractionpass": 0.95,
+    "go": true,
+    "lumisize": -1,
     "tune": true
-  }, 
+  },
   "RunIIFall18wmLHEGS": {
     "SiteBlacklist": [
-      "T2_CH_CERN", 
+      "T2_CH_CERN",
       "T2_CH_CERN_HLT",
       "T2_CH_CERN_P5"
-    ], 
-    "fractionpass": 0.95, 
-    "go": true, 
-    "lumisize": -1, 
-    "overflow": {}, 
+    ],
+    "fractionpass": 0.95,
+    "go": true,
+    "lumisize": -1,
+    "overflow": {},
     "tune": true
-  }, 
+  },
   "RunIILowPUAutumn18DR": {
-    "fractionpass": 0.95, 
-    "go": true, 
-    "lumisize": -1, 
-    "maxcopies": 1, 
-    "resize": "auto", 
+    "fractionpass": 0.95,
+    "go": true,
+    "lumisize": -1,
+    "maxcopies": 1,
+    "resize": "auto",
     "tune": true
-  }, 
+  },
   "RunIILowPUAutumn18GS": {
     "SiteBlacklist": [
       "T3_US_NERSC"
-    ], 
-    "fractionpass": 0.95, 
-    "go": true, 
-    "lumisize": -1, 
-    "resize": "auto", 
+    ],
+    "fractionpass": 0.95,
+    "go": true,
+    "lumisize": -1,
+    "resize": "auto",
     "tune": true
-  }, 
+  },
   "RunIILowPUAutumn18MiniAOD": {
-    "fractionpass": 0.95, 
-    "go": true, 
-    "lumisize": -1, 
-    "maxcopies": 1, 
+    "fractionpass": 0.95,
+    "go": true,
+    "lumisize": -1,
+    "maxcopies": 1,
     "resize": "auto"
   },
   "RunIILowPUSpring18wmLHEGS": {
-    "lumisize": -1, 
-    "resize": "auto", 
-    "fractionpass": 0.95, 
+    "lumisize": -1,
+    "resize": "auto",
+    "fractionpass": 0.95,
     "SiteBlacklist": [
-       "T3_US_NERSC"
-    ], 
-    "go": true, 
+      "T3_US_NERSC"
+    ],
+    "go": true,
     "tune": true
   },
   "RunIILowPUSpring18DR": {
-    "maxcopies": 1, 
-    "lumisize": -1, 
-    "fractionpass": 0.95, 
-    "go": true, 
-    "tune": true, 
-    "secondaries": {
-      "/MinBias_TuneCP5_inelasticON_13TeV-pythia8/RunIIFall17GS-93X_mc2017_realistic_v3-v1/GEN-SIM": {
-        "SiteWhitelist": [
-          "T1_FR_CCIN2P3_Disk", 
-          "T1_DE_KIT_Disk" 
-        ]
-      }
-    }, 
+    "maxcopies": 1,
+    "lumisize": -1,
+    "fractionpass": 0.95,
+    "go": true,
+    "tune": true,
+    "secondaries": {},
     "resize": "auto"
-  },  
+  },
   "RunIISummer15GS": {
     "SiteBlacklist": [
-      "T2_US_Caltech", 
-      "T2_CH_CERN", 
+      "T2_US_Caltech",
+      "T2_CH_CERN",
       "T2_CH_CERN_HLT",
       "T2_CH_CERN_P5"
-    ], 
-    "force-complete": 0.99, 
-    "fractionpass": 0.95, 
-    "go": true, 
-    "lumisize": 1000, 
+    ],
+    "force-complete": 0.99,
+    "fractionpass": 0.95,
+    "go": true,
+    "lumisize": 1000,
     "overflow": {
       "LHE": {
         "site_list": "sites_AAA"
       }
-    }, 
+    },
     "parameters": {
       "EventsPerLumi": "x2"
-    }, 
-    "resize": "auto", 
+    },
+    "resize": "auto",
     "tune": true
-  }, 
+  },
   "RunIISummer15wmLHEGS": {
     "SiteBlacklist": [
-      "T2_CH_CERN", 
+      "T2_CH_CERN",
       "T2_CH_CERN_HLT",
       "T2_CH_CERN_P5"
-    ], 
-    "force-complete": 0.99, 
-    "fractionpass": 0.95, 
-    "go": true, 
-    "lumisize": -1, 
+    ],
+    "force-complete": 0.99,
+    "fractionpass": 0.95,
+    "go": true,
+    "lumisize": -1,
     "parameters": {
-      "EventsPerLumi": "x2", 
+      "EventsPerLumi": "x2",
       "MaxMergeEvents": 4000000
-    }, 
-    "resize": "auto", 
+    },
+    "resize": "auto",
     "tune": true
-  }, 
+  },
   "RunIISummer16DR80": {
-    "NONONO_force-complete": 0.99, 
-    "NONONO_force-timeout": 7, 
-    "NONONO_partial_copy": 0.98, 
-    "NO_tune": true, 
-    "fractionpass": 0.95, 
-    "go": true, 
-    "lumisize": -1, 
-    "maxcopies": 2, 
+    "NONONO_force-complete": 0.99,
+    "NONONO_force-timeout": 7,
+    "NONONO_partial_copy": 0.98,
+    "NO_tune": true,
+    "fractionpass": 0.95,
+    "go": true,
+    "lumisize": -1,
+    "maxcopies": 2,
     "overflow": {
       "PU": {
-        "force": false, 
-        "max": 20000, 
+        "force": false,
+        "max": 20000,
         "pending": 0
       }
-    }, 
-    "partial_copy": 0.95, 
-    "secondaries": {
-      "/MinBias_TuneCUETP8M1_13TeV-pythia8/RunIISummer15GS-MCRUN2_71_V1_ext1-v1/GEN-SIM": {
-        "SiteWhitelist": [
-          "T1_US_FNAL_Disk", 
-          "T2_US_Nebraska"
-        ]
-      }
-    }
-  }, 
+    },
+    "partial_copy": 0.95,
+    "secondaries": {}
+  },
   "RunIISummer16DR80Premix": {
     "NO_NO_fractionpass": {
       "90000": 0.9
-    }, 
+    },
     "SiteBlacklist": [
-      "T2_CH_CERN", 
+      "T2_CH_CERN",
       "T2_CH_CERN_HLT",
       "T2_CH_CERN_P5"
-    ], 
-    "force-complete": 0.99, 
-    "force-timeout": 7, 
-    "fractionpass": 0.95, 
-    "go": true, 
-    "lumisize": -1, 
-    "maxcopies": 1, 
+    ],
+    "force-complete": 0.99,
+    "force-timeout": 7,
+    "fractionpass": 0.95,
+    "go": true,
+    "lumisize": -1,
+    "maxcopies": 1,
     "overflow": {
       "PREMIX": {}
-    }, 
-    "partial_copy": 0.95, 
+    },
+    "partial_copy": 0.95,
     "resize": {
-      "maxCores": 10, 
-      "memoryPerThread": 500, 
+      "maxCores": 10,
+      "memoryPerThread": 500,
       "minCores": 3
-    }, 
+    },
     "secondaries": {
       "/Neutrino_E-10_gun/RunIISpring15PrePremix-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v2-v2/GEN-SIM-DIGI-RAW": {
-          "SecondaryLocation": [
-                    "T1_US_FNAL_Disk",
-                    "T1_RU_JINR_Disk"
-                                  ]
-      }
-    }, 
-    "secondary_AAA": true, 
-    "truncate-complete": 0.95, 
-    "tune": true
-  }, 
-  "RunIISummer16FSPremix": {
-    "fractionpass": 0.95, 
-    "go": true, 
-    "SiteBlacklist": [
-      "T2_CH_CERN",
-      "T2_CH_CERN_HLT",
-      "T2_CH_CERN_P5"
-      ],
-    "lumisize": -1, 
-    "parameters": {
-      "EventsPerLumi": "x2"
-    }, 
-    "secondaries": {
-      "/Neutrino_E-10_gun/RunIISummer16FSPremix-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v4-v1/GEN-SIM-DIGI-RAW": {
         "SecondaryLocation": [
-          "T2_US_Purdue", 
-          "T1_DE_KIT_Disk"
-        ], 
-        "secondary_AAA": true
+          "T1_US_FNAL_Disk"
+        ]
       }
-    }
+    },
+    "secondary_AAA": true,
+    "truncate-complete": 0.95,
+    "tune": true
   },
-  "RunIISpring16FSSIMDRPremix": {
+  "RunIISummer16FSPremix": {
     "fractionpass": 0.95,
-    "go": false,
+    "go": true,
     "SiteBlacklist": [
       "T2_CH_CERN",
       "T2_CH_CERN_HLT",
       "T2_CH_CERN_P5"
-      ],
+    ],
     "lumisize": -1,
     "parameters": {
       "EventsPerLumi": "x2"
@@ -2395,12 +2168,34 @@
         "secondary_AAA": true
       }
     }
-  }, 
+  },
+  "RunIISpring16FSSIMDRPremix": {
+    "fractionpass": 0.95,
+    "go": false,
+    "SiteBlacklist": [
+      "T2_CH_CERN",
+      "T2_CH_CERN_HLT",
+      "T2_CH_CERN_P5"
+    ],
+    "lumisize": -1,
+    "parameters": {
+      "EventsPerLumi": "x2"
+    },
+    "secondaries": {
+      "/Neutrino_E-10_gun/RunIISummer16FSPremix-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v4-v1/GEN-SIM-DIGI-RAW": {
+        "SecondaryLocation": [
+          "T2_US_Purdue",
+          "T1_DE_KIT_Disk"
+        ],
+        "secondary_AAA": true
+      }
+    }
+  },
   "RunIISummer16MiniAODv3": {
-    "force-complete": 0.99, 
-    "fractionpass": 0.95, 
-    "go": true, 
-    "lumisize": -1, 
+    "force-complete": 0.99,
+    "fractionpass": 0.95,
+    "go": true,
+    "lumisize": -1,
     "maxcopies": 1
   },
   "RunIISummer16NanoAODv6": {
@@ -2408,671 +2203,589 @@
     "go": true,
     "lumisize": -1,
     "maxcopies": 1
-  }, 
+  },
   "RunIISummer16NanoAODv7": {
-    "fractionpass": 0.99, 
-    "go": true, 
-    "lumisize": -1, 
+    "fractionpass": 0.99,
+    "go": true,
+    "lumisize": -1,
     "maxcopies": 1
-  }, 
+  },
   "RunIISummer17PrePremix": {
-    "fractionpass": 0.95, 
-    "go": true, 
-    "lumisize": -1, 
+    "fractionpass": 0.95,
+    "go": true,
+    "lumisize": -1,
     "parameters": {
       "NonCustodialSites": [
-        "T2_CH_CERN", 
+        "T2_CH_CERN",
         "T1_US_FNAL"
       ]
-    }, 
-    "partial_copy": 0.95, 
-    "secondaries": {
-      "/MinBias_TuneCP2_13TeV-pythia8/RunIIFall17FSPremix-PUMoriond17_94X_mc2017_realistic_v11-v1/GEN-SIM-RECO": {
-        "SiteWhitelist": [
-          "T2_US_MIT", 
-          "T2_DE_DESY"
-        ]
-      }, 
-      "/MinBias_TuneCP5_13TeV-pythia8/RunIIFall18GS-102X_upgrade2018_realistic_v9-v1/GEN-SIM": {
-        "SiteWhitelist": [
-          "T2_US_MIT", 
-          "T2_DE_DESY"
-        ]
-      }, 
-      "/MinBias_TuneCP5_13TeV-pythia8/RunIISpring18GS-100X_upgrade2018_realistic_v9-v1/GEN-SIM": {
-        "SiteWhitelist": [
-          "T2_DE_RWTH"
-        ]
-      }, 
-      "/MinBias_TuneCP5_13TeV-pythia8/RunIIWinter19PFCalib16GS-105X_mcRun2_asymptotic_v2-v1/GEN-SIM": {
-        "SiteWhitelist": [
-          "T1_FR_CCIN2P3_Disk", 
-          "T2_IT_Legnaro"
-        ]
-      }, 
-      "/MinBias_TuneCP5_13TeV-pythia8/RunIIWinter19PFCalib17GS-105X_mc2017_realistic_v5_ext1-v1/GEN-SIM": {
-        "SiteWhitelist": [
-          "T1_FR_CCIN2P3_Disk", 
-          "T1_IT_CNAF_Disk"
-        ]
-      }, 
-      "/MinBias_TuneCP5_13TeV-pythia8/RunIIWinter19PFCalib18GS-105X_upgrade2018_realistic_v4-v1/GEN-SIM": {
-        "SiteWhitelist": [
-          "T2_US_Florida"
-        ]
-      }, 
-      "/MinBias_TuneCP5_14TeV-pythia8/PhaseIITDRSpring19GS-106X_upgrade2023_realistic_v2_ext1-v1/GEN-SIM": {
-        "SiteWhitelist": [
-          "T2_US_Florida"
-        ]
-      }, 
-      "/MinBias_TuneCP5_14TeV-pythia8/Run3Winter20GS-110X_mcRun3_2021_realistic_v6-v1/GEN-SIM": {
-        "SiteWhitelist": [
-          "T1_ES_PIC_Disk", 
-          "T1_US_FNAL_Disk"
-        ]
-      }, 
-      "/MinBias_TuneCP5_inelasticON_13TeV-pythia8/RunIIFall17GS-93X_mc2017_realistic_v3-v1/GEN-SIM": {
-        "SiteWhitelist": [
-          "T1_FR_CCIN2P3_Disk", 
-          "T1_DE_KIT_Disk"
-        ]
-      }, 
-      "/MinBias_TuneCUETP8M1_13TeV-pythia8/RunIISummer17GS-92X_upgrade2017_realistic_v2-v1/GEN-SIM": {
-        "SiteWhitelist": [
-          "T1_IT_CNAF_Disk", 
-          "T2_US_MIT"
-        ]
-      }
-    }, 
+    },
+    "partial_copy": 0.95,
+    "secondaries": {},
     "tune": true
-  }, 
+  },
   "RunIISummer19CosmicDR": {
-    "fractionpass": 0.95, 
-    "go": true, 
-    "lumisize": -1, 
-    "maxcopies": 1, 
+    "fractionpass": 0.95,
+    "go": true,
+    "lumisize": -1,
+    "maxcopies": 1,
     "tune": true
-  }, 
+  },
   "RunIISummer19CosmicGS": {
     "SiteBlacklist": [
       "T3_US_NERSC"
-    ], 
-    "fractionpass": 0.95, 
-    "go": true, 
-    "lumisize": -1, 
+    ],
+    "fractionpass": 0.95,
+    "go": true,
+    "lumisize": -1,
     "tune": true
   },
   "RunIISummer19UL17DIGIPremix": {
     "SiteBlacklist": [
-        "T2_CH_CERN",
-        "T2_CH_CERN_HLT",
-        "T2_CH_CERN_P5"
+      "T2_CH_CERN",
+      "T2_CH_CERN_HLT",
+      "T2_CH_CERN_P5"
     ],
-    "fractionpass": 0.95, 
-    "go": true, 
-    "lumisize": -1, 
-    "maxcopies": 1, 
-    "partial_copy": 0.95, 
-    "resize": "auto", 
-    "secondaries": {
-      "/Neutrino_E-10_gun/RunIISummer19ULPrePremix-UL17_106X_mc2017_realistic_v6-v1/PREMIX": {
-          "SecondaryLocation": [
-                    "T1_US_FNAL_Disk"
-                        ]
-      }
-    }, 
-    "secondary_AAA": true, 
+    "fractionpass": 0.95,
+    "go": true,
+    "lumisize": -1,
+    "maxcopies": 1,
+    "partial_copy": 0.95,
+    "resize": "auto",
+    "secondaries": {},
+    "secondary_AAA": true,
     "tune": true
-  }, 
+  },
   "RunIISummer19UL16MiniAOD": {
-    "fractionpass": 0.95, 
-    "go": true, 
+    "fractionpass": 0.95,
+    "go": true,
     "SiteBlacklist": [
-              "T2_CH_CERN",
-              "T2_CH_CERN_HLT",
-              "T2_CH_CERN_P5"
-                  ],
-    "lumisize": -1, 
-    "maxcopies": 1, 
+      "T2_CH_CERN",
+      "T2_CH_CERN_HLT",
+      "T2_CH_CERN_P5"
+    ],
+    "lumisize": -1,
+    "maxcopies": 1,
     "resize": "auto"
-  }, 
+  },
   "RunIISummer19UL16MiniAODAPV": {
-    "fractionpass": 0.95, 
-    "go": true, 
+    "fractionpass": 0.95,
+    "go": true,
     "SiteBlacklist": [
-              "T2_CH_CERN",
-              "T2_CH_CERN_HLT",
-              "T2_CH_CERN_P5"
-                ],
-    "lumisize": -1, 
-    "maxcopies": 1, 
+      "T2_CH_CERN",
+      "T2_CH_CERN_HLT",
+      "T2_CH_CERN_P5"
+    ],
+    "lumisize": -1,
+    "maxcopies": 1,
     "overflow": {
       "PU": {
-        "force": false, 
-        "max": 0, 
+        "force": false,
+        "max": 0,
         "pending": 0
       }
-    }, 
-    "resize": "auto", 
+    },
+    "resize": "auto",
     "tune": true
-  }, 
+  },
   "RunIISummer19UL16MiniAODAPVv2": {
-    "fractionpass": 0.95, 
-    "go": false, 
-    "lumisize": -1, 
+    "fractionpass": 0.95,
+    "go": false,
+    "lumisize": -1,
     "maxcopies": 1,
     "SiteBlacklist": [
-             "T2_CH_CERN",
-             "T2_CH_CERN_HLT",
-             "T2_CH_CERN_P5"
-                ], 
+      "T2_CH_CERN",
+      "T2_CH_CERN_HLT",
+      "T2_CH_CERN_P5"
+    ],
     "overflow": {
       "PU": {
-        "force": false, 
-        "max": 0, 
+        "force": false,
+        "max": 0,
         "pending": 0
       }
-    }, 
-    "resize": "auto", 
+    },
+    "resize": "auto",
     "tune": true
   },
-  "RunIISummer19UL16SIM":
-  {
-    "fractionpass": 0.95, 
-    "go":true, 
-    "lumisize": -1, 
-    "resize": "auto", 
+  "RunIISummer19UL16SIM": {
+    "fractionpass": 0.95,
+    "go": true,
+    "lumisize": -1,
+    "resize": "auto",
     "tune": true
   },
-  "RunIISummer19UL16RECO":
-  {
-    "fractionpass": 0.95, 
-    "go": true, 
-    "lumisize": -1, 
-    "maxcopies": 1, 
-    "resize": "auto", 
-    "secondary_AAA": true, 
+  "RunIISummer19UL16RECO": {
+    "fractionpass": 0.95,
+    "go": true,
+    "lumisize": -1,
+    "maxcopies": 1,
+    "resize": "auto",
+    "secondary_AAA": true,
     "tune": true
   },
-  "RunIISummer19UL16DIGI":
-  {
-    "fractionpass": 0.95, 
-    "go": true, 
-    "lumisize": -1, 
-    "maxcopies": 1, 
+  "RunIISummer19UL16DIGI": {
+    "fractionpass": 0.95,
+    "go": true,
+    "lumisize": -1,
+    "maxcopies": 1,
     "overflow": {
       "PU": {
-        "force": false, 
-        "max": 0, 
+        "force": false,
+        "max": 0,
         "pending": 0
       }
-    }, 
-    "resize": "auto", 
-    "secondaries": {
-      "/MinBias_TuneCP1_13TeV-pythia8/RunIISummer19UL16SIM-106X_mcRun2_asymptotic_v10-v2/GEN-SIM": {
-        "SiteWhitelist": [
-          "T1_FR_CCIN2P3_Disk"
-        ]
-      }, 
-      "/MinBias_TuneCP5_13TeV-pythia8/RunIISummer19UL16SIM-106X_mcRun2_asymptotic_v3-v1/GEN-SIM": {
-       "SiteWhitelist": [
-         "T1_US_FNAL_Disk"
-        ]
-      }
-    }, 
+    },
+    "resize": "auto",
+    "secondaries": {},
     "tune": true
-  }, 
+  },
   "RunIISummer19UL16MiniAODv2": {
-    "fractionpass": 0.95, 
+    "fractionpass": 0.95,
     "go": false,
     "SiteBlacklist": [
-            "T2_CH_CERN",
-            "T2_CH_CERN_HLT",
-            "T2_CH_CERN_P5"
-                  ], 
-    "lumisize": -1, 
-    "maxcopies": 1, 
+      "T2_CH_CERN",
+      "T2_CH_CERN_HLT",
+      "T2_CH_CERN_P5"
+    ],
+    "lumisize": -1,
+    "maxcopies": 1,
     "resize": "auto"
-  }, 
+  },
   "RunIISummer19UL16NanoAOD": {
-    "fractionpass": 0.99, 
-    "go": true, 
+    "fractionpass": 0.99,
+    "go": true,
     "SiteBlacklist": [
-            "T2_CH_CERN",
-            "T2_CH_CERN_HLT",
-            "T2_CH_CERN_P5"
-               ],
-    "lumisize": -1, 
+      "T2_CH_CERN",
+      "T2_CH_CERN_HLT",
+      "T2_CH_CERN_P5"
+    ],
+    "lumisize": -1,
     "maxcopies": 1
-  }, 
+  },
   "RunIISummer19UL16NanoAODAPV": {
-    "fractionpass": 0.99, 
-    "go": true, 
-    "lumisize": -1, 
-    "SiteBlacklist": [
-                  "T2_CH_CERN",
-                  "T2_CH_CERN_HLT",
-                  "T2_CH_CERN_P5"
-                      ],
-    "maxcopies": 1, 
-    "overflow": {
-      "PU": {
-        "force": false, 
-        "max": 0, 
-        "pending": 0
-      }
-    }, 
-    "resize": "auto", 
-    "tune": true
-  }, 
-  "RunIISummer19UL16NanoAODAPVv2": {
-    "fractionpass": 0.99, 
-    "go": true, 
-    "SiteBlacklist": [
-                "T2_CH_CERN",
-                "T2_CH_CERN_HLT",
-                "T2_CH_CERN_P5"
-                    ],    
-    "lumisize": -1, 
-    "maxcopies": 1
-  }, 
-  "RunIISummer19UL16NanoAODv2": {
-    "fractionpass": 0.99, 
-    "go": true, 
-    "SiteBlacklist": [
-               "T2_CH_CERN",
-               "T2_CH_CERN_HLT",
-               "T2_CH_CERN_P5"
-                   ],    
-    "lumisize": -1, 
-    "maxcopies": 1
-  }, 
-  "RunIISummer19UL17MiniAOD": {
-    "fractionpass": 0.95, 
-    "go": true, 
-    "SiteBlacklist": [
-        "T2_CH_CERN",
-        "T2_CH_CERN_HLT",
-        "T2_CH_CERN_P5"
-            ],
-    "lumisize": -1, 
-    "maxcopies": 1, 
-    "resize": "auto"
-  }, 
-  "RunIISummer19UL17MiniAODv2": {
-    "fractionpass": 0.95, 
-    "go": true, 
-    "lumisize": -1, 
-    "SiteBlacklist": [
-        "T2_CH_CERN",
-        "T2_CH_CERN_HLT",
-        "T2_CH_CERN_P5"
-            ],
-    "maxcopies": 1, 
-    "resize": "auto"
-  }, 
-  "RunIISummer19UL17NanoAOD": {
-    "fractionpass": 0.99, 
-    "go": true, 
+    "fractionpass": 0.99,
+    "go": true,
     "lumisize": -1,
     "SiteBlacklist": [
       "T2_CH_CERN",
       "T2_CH_CERN_HLT",
       "T2_CH_CERN_P5"
-         ], 
-    "maxcopies": 1
-  }, 
-  "RunIISummer19UL17NanoAODv2": {
-    "fractionpass": 0.99, 
-    "go": true, 
-    "lumisize": -1, 
-    "SiteBlacklist": [
-        "T2_CH_CERN",
-        "T2_CH_CERN_HLT",
-        "T2_CH_CERN_P5"
-            ],
-    "maxcopies": 1
-  }, 
-  "RunIISummer19UL18MiniAOD": {
-    "fractionpass": 0.99, 
-    "go": true, 
-    "lumisize": -1, 
-    "maxcopies": 1, 
-    "resize": "auto"
-  }, 
-  "RunIISummer19UL18MiniAODv2": {
-    "fractionpass": 0.99, 
-    "go": true, 
-    "lumisize": -1, 
-    "maxcopies": 1, 
-    "resize": "auto"
-  }, 
-  "RunIISummer19UL18NanoAOD": {
-    "fractionpass": 0.99, 
-    "go": true, 
-    "lumisize": -1, 
-    "maxcopies": 1
-  }, 
-  "RunIISummer19UL18NanoAODv2": {
-    "fractionpass": 0.99, 
-    "go": true, 
-    "lumisize": -1, 
-    "maxcopies": 1
-  }, 
-  "RunIISummer20UL16DIGI": {
-    "fractionpass": 0.95, 
-    "go": true, 
-    "lumisize": -1, 
-    "maxcopies": 1, 
+    ],
+    "maxcopies": 1,
     "overflow": {
       "PU": {
-        "force": false, 
-        "max": 0, 
+        "force": false,
+        "max": 0,
         "pending": 0
       }
     },
-    "partial_copy": 0.95, 
-    "resize": "auto", 
+    "resize": "auto",
+    "tune": true
+  },
+  "RunIISummer19UL16NanoAODAPVv2": {
+    "fractionpass": 0.99,
+    "go": true,
+    "SiteBlacklist": [
+      "T2_CH_CERN",
+      "T2_CH_CERN_HLT",
+      "T2_CH_CERN_P5"
+    ],
+    "lumisize": -1,
+    "maxcopies": 1
+  },
+  "RunIISummer19UL16NanoAODv2": {
+    "fractionpass": 0.99,
+    "go": true,
+    "SiteBlacklist": [
+      "T2_CH_CERN",
+      "T2_CH_CERN_HLT",
+      "T2_CH_CERN_P5"
+    ],
+    "lumisize": -1,
+    "maxcopies": 1
+  },
+  "RunIISummer19UL17MiniAOD": {
+    "fractionpass": 0.95,
+    "go": true,
+    "SiteBlacklist": [
+      "T2_CH_CERN",
+      "T2_CH_CERN_HLT",
+      "T2_CH_CERN_P5"
+    ],
+    "lumisize": -1,
+    "maxcopies": 1,
+    "resize": "auto"
+  },
+  "RunIISummer19UL17MiniAODv2": {
+    "fractionpass": 0.95,
+    "go": true,
+    "lumisize": -1,
+    "SiteBlacklist": [
+      "T2_CH_CERN",
+      "T2_CH_CERN_HLT",
+      "T2_CH_CERN_P5"
+    ],
+    "maxcopies": 1,
+    "resize": "auto"
+  },
+  "RunIISummer19UL17NanoAOD": {
+    "fractionpass": 0.99,
+    "go": true,
+    "lumisize": -1,
+    "SiteBlacklist": [
+      "T2_CH_CERN",
+      "T2_CH_CERN_HLT",
+      "T2_CH_CERN_P5"
+    ],
+    "maxcopies": 1
+  },
+  "RunIISummer19UL17NanoAODv2": {
+    "fractionpass": 0.99,
+    "go": true,
+    "lumisize": -1,
+    "SiteBlacklist": [
+      "T2_CH_CERN",
+      "T2_CH_CERN_HLT",
+      "T2_CH_CERN_P5"
+    ],
+    "maxcopies": 1
+  },
+  "RunIISummer19UL18MiniAOD": {
+    "fractionpass": 0.99,
+    "go": true,
+    "lumisize": -1,
+    "maxcopies": 1,
+    "resize": "auto"
+  },
+  "RunIISummer19UL18MiniAODv2": {
+    "fractionpass": 0.99,
+    "go": true,
+    "lumisize": -1,
+    "maxcopies": 1,
+    "resize": "auto"
+  },
+  "RunIISummer19UL18NanoAOD": {
+    "fractionpass": 0.99,
+    "go": true,
+    "lumisize": -1,
+    "maxcopies": 1
+  },
+  "RunIISummer19UL18NanoAODv2": {
+    "fractionpass": 0.99,
+    "go": true,
+    "lumisize": -1,
+    "maxcopies": 1
+  },
+  "RunIISummer20UL16DIGI": {
+    "fractionpass": 0.95,
+    "go": true,
+    "lumisize": -1,
+    "maxcopies": 1,
+    "overflow": {
+      "PU": {
+        "force": false,
+        "max": 0,
+        "pending": 0
+      }
+    },
+    "partial_copy": 0.95,
+    "resize": "auto",
     "secondaries": {
       "/MinBias_TuneCP5_13TeV-pythia8/RunIISummer20UL16SIM-106X_mcRun2_asymptotic_v13-v2/GEN-SIM": {
-        "SiteWhitelist": [
-          "T1_US_FNAL_Disk",
-          "T1_IT_CNAF_Disk"
+        "SecondaryLocation": [
+          "T1_IT_CNAF_Disk",
+          "T2_US_Florida"
         ]
       }
-    }, 
+    },
     "tune": true
-  }, 
+  },
   "RunIISummer20UL16DIGIAPV": {
-    "fractionpass": 0.95, 
-    "go": true, 
-    "lumisize": -1, 
-    "maxcopies": 1, 
+    "fractionpass": 0.95,
+    "go": true,
+    "lumisize": -1,
+    "maxcopies": 1,
     "overflow": {
       "PU": {
-        "force": false, 
-        "max": 0, 
+        "force": false,
+        "max": 0,
         "pending": 0
       }
-    }, 
-    "partial_copy": 0.95, 
-    "resize": "auto", 
+    },
+    "partial_copy": 0.95,
+    "resize": "auto",
     "secondaries": {
       "/MinBias_TuneCP5_13TeV-pythia8/RunIISummer20UL16SIM-106X_mcRun2_asymptotic_v13-v2/GEN-SIM": {
-        "SiteWhitelist": [
-          "T1_US_FNAL_Disk",
-          "T1_IT_CNAF_Disk"
+        "SecondaryLocation": [
+          "T1_IT_CNAF_Disk",
+          "T2_US_Florida"
         ]
       }
-    }, 
+    },
     "tune": true
-  }, 
+  },
   "RunIISummer20UL16DIGIPremix": {
-    "fractionpass": 0.95, 
-    "go": true, 
-    "lumisize": -1, 
-    "maxcopies": 1, 
+    "fractionpass": 0.95,
+    "go": true,
+    "lumisize": -1,
+    "maxcopies": 1,
     "overflow": {
       "PU": {
-        "force": false, 
-        "max": 0, 
+        "force": false,
+        "max": 0,
         "pending": 0
       }
-    }, 
-    "partial_copy": 0.95, 
-    "resize": "auto", 
+    },
+    "partial_copy": 0.95,
+    "resize": "auto",
     "secondaries": {
       "/Neutrino_E-10_gun/RunIISummer20ULPrePremix-UL16_106X_mcRun2_asymptotic_v13-v1/PREMIX": {
         "SecondaryLocation": [
-          "T1_US_FNAL_Disk", 
           "T2_CH_CERN"
         ]
       }
-    }, 
-    "secondary_AAA": true, 
+    },
+    "secondary_AAA": true,
     "tune": true
   },
-  "RunIISummer19UL16GEN":
-  {
-    "fractionpass": 0.95, 
-    "go": true, 
-    "lumisize": -1, 
-    "resize": "auto", 
+  "RunIISummer19UL16GEN": {
+    "fractionpass": 0.95,
+    "go": true,
+    "lumisize": -1,
+    "resize": "auto",
     "tune": true
   },
   "RunIISummer20UL16DIGIPremixAPV": {
-    "fractionpass": 0.95, 
-    "go": true, 
-    "lumisize": -1, 
-    "maxcopies": 1, 
+    "fractionpass": 0.95,
+    "go": true,
+    "lumisize": -1,
+    "maxcopies": 1,
     "overflow": {
       "PU": {
-        "force": false, 
-        "max": 0, 
-        "pending": 0
-      }
-    }, 
-    "partial_copy": 0.95, 
-    "resize": "auto", 
-    "secondaries": {
-      "/Neutrino_E-10_gun/RunIISummer20ULPrePremix-UL16_106X_mcRun2_asymptotic_v13-v1/PREMIX": {
-        "SecondaryLocation": [
-          "T1_US_FNAL_Disk", 
-          "T2_CH_CERN"
-        ]
-      }
-    }, 
-    "secondary_AAA": true, 
-    "tune": true
-  },
-  "RunIISummer19UL16HLT":
-  {
-    "fractionpass": 0.95, 
-    "go": true, 
-    "lumisize": -1, 
-    "maxcopies": 1, 
-    "overflow": {
-      "PU": {
-        "force": false, 
-        "max": 0, 
-        "pending": 0
-      }
-    }, 
-    "resize": "auto", 
-    "secondary_AAA": true, 
-    "tune": true
-  },
-  "RunIISummer20UL16GENSIM": {
-     "fractionpass": 0.95,
-     "go": true,
-     "lumisize": -1,
-     "maxcopies": 1
-  },
-  "RunIISummer20UL16GEN": {
-    "fractionpass": 0.95, 
-    "go": true, 
-    "lumisize": -1, 
-    "maxcopies": 1, 
-    "overflow": {
-      "PU": {
-        "force": false, 
-        "max": 0, 
-        "pending": 0
-      }
-    }, 
-    "resize": "auto", 
-    "tune": true
-  },
-  "RunIISummer20UL16GENSIMAPV": {
-     "fractionpass": 0.95,
-     "go": true,
-     "lumisize": -1,
-     "maxcopies": 1
-  },
-  "RunIISummer20UL16GENAPV": {
-    "fractionpass": 0.95, 
-    "go": true, 
-    "lumisize": -1, 
-    "maxcopies": 1, 
-    "overflow": {
-      "PU": {
-        "force": false, 
-        "max": 0, 
-        "pending": 0
-      }
-    }, 
-    "resize": "auto", 
-    "tune": true
-  }, 
-  "RunIISummer20UL16HLT": {
-    "fractionpass": 0.95, 
-    "go": true, 
-    "lumisize": -1, 
-    "maxcopies": 1, 
-    "overflow": {
-      "PU": {
-        "force": false, 
-        "max": 0, 
+        "force": false,
+        "max": 0,
         "pending": 0
       }
     },
-    "resize": "auto", 
+    "partial_copy": 0.95,
+    "resize": "auto",
+    "secondaries": {
+      "/Neutrino_E-10_gun/RunIISummer20ULPrePremix-UL16_106X_mcRun2_asymptotic_v13-v1/PREMIX": {
+        "SecondaryLocation": [
+          "T2_CH_CERN"
+        ]
+      }
+    },
+    "secondary_AAA": true,
     "tune": true
-  }, 
+  },
+  "RunIISummer19UL16HLT": {
+    "fractionpass": 0.95,
+    "go": true,
+    "lumisize": -1,
+    "maxcopies": 1,
+    "overflow": {
+      "PU": {
+        "force": false,
+        "max": 0,
+        "pending": 0
+      }
+    },
+    "resize": "auto",
+    "secondary_AAA": true,
+    "tune": true
+  },
+  "RunIISummer20UL16GENSIM": {
+    "fractionpass": 0.95,
+    "go": true,
+    "lumisize": -1,
+    "maxcopies": 1
+  },
+  "RunIISummer20UL16GEN": {
+    "fractionpass": 0.95,
+    "go": true,
+    "lumisize": -1,
+    "maxcopies": 1,
+    "overflow": {
+      "PU": {
+        "force": false,
+        "max": 0,
+        "pending": 0
+      }
+    },
+    "resize": "auto",
+    "tune": true
+  },
+  "RunIISummer20UL16GENSIMAPV": {
+    "fractionpass": 0.95,
+    "go": true,
+    "lumisize": -1,
+    "maxcopies": 1
+  },
+  "RunIISummer20UL16GENAPV": {
+    "fractionpass": 0.95,
+    "go": true,
+    "lumisize": -1,
+    "maxcopies": 1,
+    "overflow": {
+      "PU": {
+        "force": false,
+        "max": 0,
+        "pending": 0
+      }
+    },
+    "resize": "auto",
+    "tune": true
+  },
+  "RunIISummer20UL16HLT": {
+    "fractionpass": 0.95,
+    "go": true,
+    "lumisize": -1,
+    "maxcopies": 1,
+    "overflow": {
+      "PU": {
+        "force": false,
+        "max": 0,
+        "pending": 0
+      }
+    },
+    "resize": "auto",
+    "tune": true
+  },
   "RunIISummer20UL16HLTAPV": {
-    "fractionpass": 0.95, 
-    "go": true, 
-    "lumisize": -1, 
-    "maxcopies": 1, 
+    "fractionpass": 0.95,
+    "go": true,
+    "lumisize": -1,
+    "maxcopies": 1,
     "overflow": {
       "PU": {
-        "force": false, 
-        "max": 0, 
+        "force": false,
+        "max": 0,
         "pending": 0
       }
-    }, 
-    "resize": "auto", 
+    },
+    "resize": "auto",
     "tune": true
-  }, 
+  },
   "RunIISummer20UL16MiniAOD": {
-    "fractionpass": 0.95, 
-    "go": true, 
-    "lumisize": -1, 
-    "maxcopies": 1, 
+    "fractionpass": 0.95,
+    "go": true,
+    "lumisize": -1,
+    "maxcopies": 1,
     "overflow": {
       "PU": {
-        "force": false, 
-        "max": 0, 
+        "force": false,
+        "max": 0,
         "pending": 0
       }
-    }, 
-    "resize": "auto", 
+    },
+    "resize": "auto",
     "tune": true
-  }, 
+  },
   "RunIISummer20UL16MiniAODAPV": {
-    "fractionpass": 0.95, 
-    "go": true, 
-    "lumisize": -1, 
-    "maxcopies": 1, 
+    "fractionpass": 0.95,
+    "go": true,
+    "lumisize": -1,
+    "maxcopies": 1,
     "overflow": {
       "PU": {
-        "force": false, 
-        "max": 0, 
+        "force": false,
+        "max": 0,
         "pending": 0
       }
-    }, 
-    "resize": "auto", 
+    },
+    "resize": "auto",
     "tune": true
-  }, 
+  },
   "RunIISummer20UL16MiniAODAPVv2": {
-    "fractionpass": 0.95, 
-    "go": true, 
-    "lumisize": -1, 
-    "maxcopies": 1, 
+    "fractionpass": 0.95,
+    "go": true,
+    "lumisize": -1,
+    "maxcopies": 1,
     "overflow": {
       "PU": {
-        "force": false, 
-        "max": 0, 
+        "force": false,
+        "max": 0,
         "pending": 0
       }
-    }, 
-    "resize": "auto", 
+    },
+    "resize": "auto",
     "tune": true
-  }, 
+  },
   "RunIISummer20UL16MiniAODv2": {
-    "fractionpass": 0.95, 
-    "go": true, 
-    "lumisize": -1, 
-    "maxcopies": 1, 
+    "fractionpass": 0.95,
+    "go": true,
+    "lumisize": -1,
+    "maxcopies": 1,
     "overflow": {
       "PU": {
-        "force": false, 
-        "max": 0, 
+        "force": false,
+        "max": 0,
         "pending": 0
       }
-    }, 
-    "resize": "auto", 
+    },
+    "resize": "auto",
     "tune": true
-  }, 
+  },
   "RunIISummer20UL16NanoAOD": {
-    "fractionpass": 0.99, 
-    "go": true, 
-    "lumisize": -1, 
-    "maxcopies": 1, 
+    "fractionpass": 0.99,
+    "go": true,
+    "lumisize": -1,
+    "maxcopies": 1,
     "overflow": {
       "PU": {
-        "force": false, 
-        "max": 0, 
+        "force": false,
+        "max": 0,
         "pending": 0
       }
-    }, 
-    "resize": "auto", 
+    },
+    "resize": "auto",
     "tune": true
-  }, 
+  },
   "RunIISummer20UL16NanoAODAPV": {
-    "fractionpass": 0.99, 
-    "go": true, 
-    "lumisize": -1, 
-    "maxcopies": 1, 
+    "fractionpass": 0.99,
+    "go": true,
+    "lumisize": -1,
+    "maxcopies": 1,
     "overflow": {
       "PU": {
-        "force": false, 
-        "max": 0, 
+        "force": false,
+        "max": 0,
         "pending": 0
       }
-    }, 
-    "resize": "auto", 
+    },
+    "resize": "auto",
     "tune": true
-  }, 
+  },
   "RunIISummer20UL16NanoAODAPVv2": {
-    "fractionpass": 0.99, 
-    "go": true, 
-    "lumisize": -1, 
-    "maxcopies": 1, 
+    "fractionpass": 0.99,
+    "go": true,
+    "lumisize": -1,
+    "maxcopies": 1,
     "overflow": {
       "PU": {
-        "force": false, 
-        "max": 0, 
+        "force": false,
+        "max": 0,
         "pending": 0
       }
-    }, 
-    "resize": "auto", 
+    },
+    "resize": "auto",
     "tune": true
-  }, 
+  },
   "RunIISummer20UL16NanoAODv2": {
-    "fractionpass": 0.99, 
-    "go": true, 
-    "lumisize": -1, 
-    "maxcopies": 1, 
+    "fractionpass": 0.99,
+    "go": true,
+    "lumisize": -1,
+    "maxcopies": 1,
     "overflow": {
       "PU": {
-        "force": false, 
-        "max": 0, 
+        "force": false,
+        "max": 0,
         "pending": 0
       }
-    }, 
-    "resize": "auto", 
+    },
+    "resize": "auto",
     "tune": true
   },
   "RunIISummer20UL16NanoAODv9": {
@@ -3104,140 +2817,140 @@
     },
     "resize": "auto",
     "tune": true
-  }, 
+  },
   "RunIISummer20UL16RECO": {
-    "fractionpass": 0.95, 
-    "go": true, 
-    "lumisize": -1, 
-    "maxcopies": 1, 
+    "fractionpass": 0.95,
+    "go": true,
+    "lumisize": -1,
+    "maxcopies": 1,
     "overflow": {
       "PU": {
-        "force": false, 
-        "max": 0, 
+        "force": false,
+        "max": 0,
         "pending": 0
       }
-    }, 
-    "resize": "auto", 
+    },
+    "resize": "auto",
     "tune": true
-  }, 
+  },
   "RunIISummer20UL16RECOAPV": {
-    "fractionpass": 0.95, 
-    "go": true, 
-    "lumisize": -1, 
-    "maxcopies": 1, 
+    "fractionpass": 0.95,
+    "go": true,
+    "lumisize": -1,
+    "maxcopies": 1,
     "overflow": {
       "PU": {
-        "force": false, 
-        "max": 0, 
+        "force": false,
+        "max": 0,
         "pending": 0
       }
-    }, 
-    "resize": "auto", 
+    },
+    "resize": "auto",
     "tune": true
-  }, 
+  },
   "RunIISummer20UL16SIM": {
-    "fractionpass": 0.95, 
-    "go": true, 
-    "lumisize": -1, 
-    "maxcopies": 1, 
+    "fractionpass": 0.95,
+    "go": true,
+    "lumisize": -1,
+    "maxcopies": 1,
     "overflow": {
       "PU": {
-        "force": false, 
-        "max": 0, 
+        "force": false,
+        "max": 0,
         "pending": 0
       }
-    }, 
-    "resize": "auto", 
+    },
+    "resize": "auto",
     "tune": true
-  }, 
+  },
   "RunIISummer20UL16SIMAPV": {
-    "fractionpass": 0.95, 
-    "go": true, 
-    "lumisize": -1, 
-    "maxcopies": 1, 
+    "fractionpass": 0.95,
+    "go": true,
+    "lumisize": -1,
+    "maxcopies": 1,
     "overflow": {
       "PU": {
-        "force": false, 
-        "max": 0, 
+        "force": false,
+        "max": 0,
         "pending": 0
       }
-    }, 
-    "resize": "auto", 
+    },
+    "resize": "auto",
     "tune": true
-  }, 
+  },
   "RunIISummer20UL16pLHEGEN": {
-    "fractionpass": 0.95, 
-    "go": true, 
-    "lumisize": -1, 
-    "maxcopies": 1, 
+    "fractionpass": 0.95,
+    "go": true,
+    "lumisize": -1,
+    "maxcopies": 1,
     "overflow": {
       "PU": {
-        "force": false, 
-        "max": 0, 
+        "force": false,
+        "max": 0,
         "pending": 0
       }
-    }, 
-    "resize": "auto", 
+    },
+    "resize": "auto",
     "tune": true
-  }, 
+  },
   "RunIISummer20UL16pLHEGENAPV": {
-    "fractionpass": 0.95, 
-    "go": true, 
-    "lumisize": -1, 
-    "maxcopies": 1, 
+    "fractionpass": 0.95,
+    "go": true,
+    "lumisize": -1,
+    "maxcopies": 1,
     "overflow": {
       "PU": {
-        "force": false, 
-        "max": 0, 
+        "force": false,
+        "max": 0,
         "pending": 0
       }
-    }, 
-    "resize": "auto", 
+    },
+    "resize": "auto",
     "tune": true
-  }, 
+  },
   "RunIISummer20UL16wmLHEGEN": {
-    "fractionpass": 0.95, 
-    "go": true, 
-    "lumisize": -1, 
-    "maxcopies": 1, 
+    "fractionpass": 0.95,
+    "go": true,
+    "lumisize": -1,
+    "maxcopies": 1,
     "overflow": {
       "PU": {
-        "force": false, 
-        "max": 0, 
+        "force": false,
+        "max": 0,
         "pending": 0
       }
-    }, 
-    "resize": "auto", 
+    },
+    "resize": "auto",
     "tune": true
-  }, 
+  },
   "RunIISummer20UL16wmLHEGENAPV": {
-    "fractionpass": 0.95, 
-    "go": true, 
-    "lumisize": -1, 
-    "maxcopies": 1, 
+    "fractionpass": 0.95,
+    "go": true,
+    "lumisize": -1,
+    "maxcopies": 1,
     "overflow": {
       "PU": {
-        "force": false, 
-        "max": 0, 
+        "force": false,
+        "max": 0,
         "pending": 0
       }
-    }, 
-    "resize": "auto", 
+    },
+    "resize": "auto",
     "tune": true
-  }, 
+  },
   "RunIISummer20UL16wmLHENanoGEN": {
-    "fractionpass": 0.95, 
-    "go": true, 
-    "lumisize": -1, 
-    "maxcopies": 1, 
+    "fractionpass": 0.95,
+    "go": true,
+    "lumisize": -1,
+    "maxcopies": 1,
     "overflow": {
       "PU": {
-        "force": false, 
-        "max": 0, 
+        "force": false,
+        "max": 0,
         "pending": 0
       }
-    }, 
-    "resize": "auto", 
+    },
+    "resize": "auto",
     "tune": true
   },
   "RunIISummer20UL17wmLHENanoGEN": {
@@ -3256,10 +2969,10 @@
     "tune": true
   },
   "RunIISummer20UL18GENSIM": {
-      "fractionpass": 0.95,
-      "go": true,
-      "lumisize": -1,
-      "maxcopies": 1
+    "fractionpass": 0.95,
+    "go": true,
+    "lumisize": -1,
+    "maxcopies": 1
   },
   "RunIISummer20UL18wmLHENanoGEN": {
     "fractionpass": 0.95,
@@ -3275,53 +2988,52 @@
     },
     "resize": "auto",
     "tune": true
-  }, 
+  },
   "RunIISummer20UL17DIGI": {
-    "fractionpass": 0.95, 
-    "go": true, 
-    "lumisize": -1, 
-    "maxcopies": 1, 
+    "fractionpass": 0.95,
+    "go": true,
+    "lumisize": -1,
+    "maxcopies": 1,
     "overflow": {
       "PU": {
-        "force": false, 
-        "max": 0, 
+        "force": false,
+        "max": 0,
         "pending": 0
       }
-    }, 
-    "partial_copy": 0.95, 
-    "resize": "auto", 
+    },
+    "partial_copy": 0.95,
+    "resize": "auto",
     "secondaries": {
       "/MinBias_TuneCP5_13TeV-pythia8/RunIISummer20UL17SIM-106X_mc2017_realistic_v6-v2/GEN-SIM": {
         "SiteWhitelist": [
           "T1_IT_CNAF_Disk"
         ]
       }
-    }, 
+    },
     "tune": true
-  }, 
+  },
   "RunIISummer20UL17DIGIPremix": {
-    "fractionpass": 0.95, 
-    "go": true, 
-    "lumisize": -1, 
-    "maxcopies": 1, 
+    "fractionpass": 0.95,
+    "go": true,
+    "lumisize": -1,
+    "maxcopies": 1,
     "overflow": {
       "PU": {
-        "force": false, 
-        "max": 0, 
+        "force": false,
+        "max": 0,
         "pending": 0
       }
-    }, 
-    "partial_copy": 0.95, 
-    "resize": "auto", 
+    },
+    "partial_copy": 0.95,
+    "resize": "auto",
     "secondaries": {
       "/Neutrino_E-10_gun/RunIISummer20ULPrePremix-UL17_106X_mc2017_realistic_v6-v3/PREMIX": {
-                  "SecondaryLocation": [
-                            "T2_CH_CERN",
-                            "T1_US_FNAL_Disk"
-                                          ]
+        "SecondaryLocation": [
+          "T2_CH_CERN"
+        ]
       }
-    }, 
-    "secondary_AAA": true, 
+    },
+    "secondary_AAA": true,
     "tune": true
   },
   "RunIISummer20UL17GENSIM": {
@@ -3329,95 +3041,95 @@
     "go": true,
     "lumisize": -1,
     "maxcopies": 1
-  },    
+  },
   "RunIISummer20UL17GEN": {
-    "fractionpass": 0.95, 
-    "go": true, 
-    "lumisize": -1, 
-    "maxcopies": 1, 
+    "fractionpass": 0.95,
+    "go": true,
+    "lumisize": -1,
+    "maxcopies": 1,
     "overflow": {
       "PU": {
-        "force": false, 
-        "max": 0, 
+        "force": false,
+        "max": 0,
         "pending": 0
       }
-    }, 
-    "resize": "auto", 
+    },
+    "resize": "auto",
     "tune": true
-  }, 
+  },
   "RunIISummer20UL17HLT": {
-    "fractionpass": 0.95, 
-    "go": true, 
-    "lumisize": -1, 
-    "maxcopies": 1, 
+    "fractionpass": 0.95,
+    "go": true,
+    "lumisize": -1,
+    "maxcopies": 1,
     "overflow": {
       "PU": {
-        "force": false, 
-        "max": 0, 
+        "force": false,
+        "max": 0,
         "pending": 0
       }
-    }, 
-    "resize": "auto", 
+    },
+    "resize": "auto",
     "tune": true
-  }, 
+  },
   "RunIISummer20UL17MiniAOD": {
-    "fractionpass": 0.95, 
-    "go": true, 
-    "lumisize": -1, 
-    "maxcopies": 1, 
+    "fractionpass": 0.95,
+    "go": true,
+    "lumisize": -1,
+    "maxcopies": 1,
     "overflow": {
       "PU": {
-        "force": false, 
-        "max": 0, 
+        "force": false,
+        "max": 0,
         "pending": 0
       }
-    }, 
-    "resize": "auto", 
+    },
+    "resize": "auto",
     "tune": true
-  }, 
+  },
   "RunIISummer20UL17MiniAODv2": {
-    "fractionpass": 0.95, 
-    "go": true, 
-    "lumisize": -1, 
-    "maxcopies": 1, 
+    "fractionpass": 0.95,
+    "go": true,
+    "lumisize": -1,
+    "maxcopies": 1,
     "overflow": {
       "PU": {
-        "force": false, 
-        "max": 0, 
+        "force": false,
+        "max": 0,
         "pending": 0
       }
-    }, 
-    "resize": "auto", 
+    },
+    "resize": "auto",
     "tune": true
-  }, 
+  },
   "RunIISummer20UL17NanoAOD": {
-    "fractionpass": 0.99, 
-    "go": true, 
-    "lumisize": -1, 
-    "maxcopies": 1, 
+    "fractionpass": 0.99,
+    "go": true,
+    "lumisize": -1,
+    "maxcopies": 1,
     "overflow": {
       "PU": {
-        "force": false, 
-        "max": 0, 
+        "force": false,
+        "max": 0,
         "pending": 0
       }
-    }, 
-    "resize": "auto", 
+    },
+    "resize": "auto",
     "tune": true
-  }, 
+  },
   "RunIISummer20UL17NanoAODv2": {
-    "fractionpass": 0.99, 
-    "go": true, 
-    "lumisize": -1, 
-    "maxcopies": 1, 
+    "fractionpass": 0.99,
+    "go": true,
+    "lumisize": -1,
+    "maxcopies": 1,
     "overflow": {
       "PU": {
-        "force": false, 
-        "max": 0, 
+        "force": false,
+        "max": 0,
         "pending": 0
       }
-    }, 
-    "resize": "auto", 
+    },
+    "resize": "auto",
     "tune": true
   },
   "RunIISummer20UL17NanoAODv9": {
@@ -3434,81 +3146,81 @@
     },
     "resize": "auto",
     "tune": true
-  }, 
+  },
   "RunIISummer20UL17RECO": {
-    "fractionpass": 0.95, 
-    "go": true, 
-    "lumisize": -1, 
-    "maxcopies": 1, 
+    "fractionpass": 0.95,
+    "go": true,
+    "lumisize": -1,
+    "maxcopies": 1,
     "overflow": {
       "PU": {
-        "force": false, 
-        "max": 0, 
+        "force": false,
+        "max": 0,
         "pending": 0
       }
-    }, 
-    "resize": "auto", 
+    },
+    "resize": "auto",
     "tune": true
-  }, 
+  },
   "RunIISummer20UL17SIM": {
-    "fractionpass": 0.95, 
-    "go": true, 
-    "lumisize": -1, 
-    "maxcopies": 1, 
+    "fractionpass": 0.95,
+    "go": true,
+    "lumisize": -1,
+    "maxcopies": 1,
     "overflow": {
       "PU": {
-        "force": false, 
-        "max": 0, 
+        "force": false,
+        "max": 0,
         "pending": 0
       }
-    }, 
-    "resize": "auto", 
+    },
+    "resize": "auto",
     "tune": true
-  }, 
+  },
   "RunIISummer20UL17pLHEGEN": {
-    "fractionpass": 0.95, 
-    "go": true, 
-    "lumisize": -1, 
-    "maxcopies": 1, 
+    "fractionpass": 0.95,
+    "go": true,
+    "lumisize": -1,
+    "maxcopies": 1,
     "overflow": {
       "PU": {
-        "force": false, 
-        "max": 0, 
+        "force": false,
+        "max": 0,
         "pending": 0
       }
-    }, 
-    "resize": "auto", 
+    },
+    "resize": "auto",
     "tune": true
-  }, 
+  },
   "RunIISummer20UL17wmLHEGEN": {
-    "fractionpass": 0.95, 
-    "go": true, 
-    "lumisize": -1, 
-    "maxcopies": 1, 
+    "fractionpass": 0.95,
+    "go": true,
+    "lumisize": -1,
+    "maxcopies": 1,
     "overflow": {
       "PU": {
-        "force": false, 
-        "max": 0, 
+        "force": false,
+        "max": 0,
         "pending": 0
       }
-    }, 
-    "resize": "auto", 
+    },
+    "resize": "auto",
     "tune": true
-  }, 
+  },
   "RunIISummer20UL18DIGI": {
-    "fractionpass": 0.95, 
-    "go": true, 
-    "lumisize": -1, 
-    "maxcopies": 1, 
+    "fractionpass": 0.95,
+    "go": true,
+    "lumisize": -1,
+    "maxcopies": 1,
     "overflow": {
       "PU": {
-        "force": false, 
-        "max": 0, 
+        "force": false,
+        "max": 0,
         "pending": 0
       }
-    }, 
-    "partial_copy": 0.95, 
-    "resize": "auto", 
+    },
+    "partial_copy": 0.95,
+    "resize": "auto",
     "secondaries": {
       "/MinBias_TuneCP5_13TeV-pythia8/RunIISummer20UL18SIM-106X_upgrade2018_realistic_v11_L1v1-v2/GEN-SIM": {
         "SiteWhitelist": [
@@ -3516,123 +3228,121 @@
           "T2_CH_CERN"
         ]
       }
-    }, 
+    },
     "tune": true
-  }, 
+  },
   "RunIISummer20UL18DIGIPremix": {
-    "fractionpass": 0.95, 
-    "go": true, 
-    "lumisize": -1, 
-    "maxcopies": 1, 
+    "fractionpass": 0.95,
+    "go": true,
+    "lumisize": -1,
+    "maxcopies": 1,
     "overflow": {
       "PU": {
-        "force": false, 
-        "max": 0, 
+        "force": false,
+        "max": 0,
         "pending": 0
       }
-    }, 
-    "partial_copy": 0.95, 
-    "resize": "auto", 
+    },
+    "partial_copy": 0.95,
+    "resize": "auto",
     "secondaries": {
       "/Neutrino_E-10_gun/RunIISummer20ULPrePremix-UL18_106X_upgrade2018_realistic_v11_L1v1-v2/PREMIX": {
-          "SecondaryLocation": [
-                    "T1_IT_CNAF_Disk",
-                    "T1_US_FNAL_Disk",
-                    "T2_CH_CERN"
-                                  ]
+        "SecondaryLocation": [
+          "T2_CH_CERN"
+        ]
       }
-    }, 
-    "secondary_AAA": true, 
+    },
+    "secondary_AAA": true,
     "tune": true
-  }, 
+  },
   "RunIISummer20UL18GEN": {
-    "fractionpass": 0.95, 
-    "go": true, 
-    "lumisize": -1, 
-    "maxcopies": 1, 
+    "fractionpass": 0.95,
+    "go": true,
+    "lumisize": -1,
+    "maxcopies": 1,
     "overflow": {
       "PU": {
-        "force": false, 
-        "max": 0, 
+        "force": false,
+        "max": 0,
         "pending": 0
       }
-    }, 
-    "resize": "auto", 
+    },
+    "resize": "auto",
     "tune": true
-  }, 
+  },
   "RunIISummer20UL18HLT": {
-    "fractionpass": 0.95, 
-    "go": true, 
-    "lumisize": -1, 
-    "maxcopies": 1, 
+    "fractionpass": 0.95,
+    "go": true,
+    "lumisize": -1,
+    "maxcopies": 1,
     "overflow": {
       "PU": {
-        "force": false, 
-        "max": 0, 
+        "force": false,
+        "max": 0,
         "pending": 0
       }
-    }, 
-    "resize": "auto", 
+    },
+    "resize": "auto",
     "tune": true
-  }, 
+  },
   "RunIISummer20UL18MiniAOD": {
-    "fractionpass": 0.95, 
-    "go": true, 
-    "lumisize": -1, 
-    "maxcopies": 1, 
+    "fractionpass": 0.95,
+    "go": true,
+    "lumisize": -1,
+    "maxcopies": 1,
     "overflow": {
       "PU": {
-        "force": false, 
-        "max": 0, 
+        "force": false,
+        "max": 0,
         "pending": 0
       }
-    }, 
-    "resize": "auto", 
+    },
+    "resize": "auto",
     "tune": true
-  }, 
+  },
   "RunIISummer20UL18MiniAODv2": {
-    "fractionpass": 0.95, 
-    "go": true, 
-    "lumisize": -1, 
-    "maxcopies": 1, 
+    "fractionpass": 0.95,
+    "go": true,
+    "lumisize": -1,
+    "maxcopies": 1,
     "overflow": {
       "PU": {
-        "force": false, 
-        "max": 0, 
+        "force": false,
+        "max": 0,
         "pending": 0
       }
-    }, 
-    "resize": "auto", 
+    },
+    "resize": "auto",
     "tune": true
-  }, 
+  },
   "RunIISummer20UL18NanoAOD": {
-    "fractionpass": 0.99, 
-    "go": true, 
-    "lumisize": -1, 
-    "maxcopies": 1, 
+    "fractionpass": 0.99,
+    "go": true,
+    "lumisize": -1,
+    "maxcopies": 1,
     "overflow": {
       "PU": {
-        "force": false, 
-        "max": 0, 
+        "force": false,
+        "max": 0,
         "pending": 0
       }
-    }, 
-    "resize": "auto", 
+    },
+    "resize": "auto",
     "tune": true
-  }, 
+  },
   "RunIISummer20UL18NanoAODv2": {
-    "fractionpass": 0.99, 
-    "go": true, 
-    "lumisize": -1, 
-    "maxcopies": 1, 
+    "fractionpass": 0.99,
+    "go": true,
+    "lumisize": -1,
+    "maxcopies": 1,
     "overflow": {
       "PU": {
-        "force": false, 
-        "max": 0, 
+        "force": false,
+        "max": 0,
         "pending": 0
       }
-    }, 
-    "resize": "auto", 
+    },
+    "resize": "auto",
     "tune": true
   },
   "RunIISummer20UL18NanoAODv9": {
@@ -3642,237 +3352,218 @@
     "maxcopies": 1,
     "resize": "auto",
     "tune": true
-  }, 
+  },
   "RunIISummer20UL18RECO": {
-    "fractionpass": 0.95, 
-    "go": true, 
-    "lumisize": -1, 
-    "maxcopies": 1, 
+    "fractionpass": 0.95,
+    "go": true,
+    "lumisize": -1,
+    "maxcopies": 1,
     "overflow": {
       "PU": {
-        "force": false, 
-        "max": 0, 
+        "force": false,
+        "max": 0,
         "pending": 0
       }
-    }, 
-    "resize": "auto", 
+    },
+    "resize": "auto",
     "tune": true
-  }, 
+  },
   "RunIISummer20UL18SIM": {
-    "fractionpass": 0.95, 
-    "go": true, 
-    "lumisize": -1, 
-    "maxcopies": 1, 
+    "fractionpass": 0.95,
+    "go": true,
+    "lumisize": -1,
+    "maxcopies": 1,
     "overflow": {
       "PU": {
-        "force": false, 
-        "max": 0, 
+        "force": false,
+        "max": 0,
         "pending": 0
       }
-    }, 
-    "resize": "auto", 
+    },
+    "resize": "auto",
     "tune": true
-  }, 
+  },
   "RunIISummer20UL18pLHEGEN": {
-    "fractionpass": 0.95, 
-    "go": true, 
-    "lumisize": -1, 
-    "maxcopies": 1, 
+    "fractionpass": 0.95,
+    "go": true,
+    "lumisize": -1,
+    "maxcopies": 1,
     "overflow": {
       "PU": {
-        "force": false, 
-        "max": 0, 
+        "force": false,
+        "max": 0,
         "pending": 0
       }
-    }, 
-    "resize": "auto", 
+    },
+    "resize": "auto",
     "tune": true
-  }, 
+  },
   "RunIISummer20UL18wmLHEGEN": {
-    "fractionpass": 0.95, 
-    "go": true, 
-    "lumisize": -1, 
-    "maxcopies": 1, 
+    "fractionpass": 0.95,
+    "go": true,
+    "lumisize": -1,
+    "maxcopies": 1,
     "overflow": {
       "PU": {
-        "force": false, 
-        "max": 0, 
+        "force": false,
+        "max": 0,
         "pending": 0
       }
-    }, 
-    "resize": "auto", 
+    },
+    "resize": "auto",
     "tune": true
-  }, 
+  },
   "RunIISummer20ULPrePremix": {
-    "fractionpass": 0.95, 
-    "go": true, 
-    "lumisize": -1, 
-    "maxcopies": 1, 
+    "fractionpass": 0.95,
+    "go": true,
+    "lumisize": -1,
+    "maxcopies": 1,
     "overflow": {
       "PU": {
-        "force": false, 
-        "max": 0, 
+        "force": false,
+        "max": 0,
         "pending": 0
       }
-    }, 
-    "partial_copy": 0.95, 
-    "resize": "auto", 
+    },
+    "partial_copy": 0.95,
+    "resize": "auto",
     "secondaries": {
       "/MinBias_TuneCP5_13TeV-pythia8/RunIISummer20UL16SIM-106X_mcRun2_asymptotic_v13-v2/GEN-SIM": {
-        "SiteWhitelist": [
-          "T1_US_FNAL_Disk",
-          "T1_IT_CNAF_Disk"
+        "SecondaryLocation": [
+          "T1_IT_CNAF_Disk",
+          "T2_US_Florida"
         ]
-      }, 
+      }
+    },
+    "tune": true
+  },
+  "RunIILowPUSummer20UL17GEN": {
+    "fractionpass": 0.95,
+    "go": true
+  },
+  "RunIILowPUSummer20UL17GS": {
+    "fractionpass": 0.95,
+    "go": true
+  },
+  "RunIILowPUSummer20UL17wmLHEGS": {
+    "fractionpass": 0.95,
+    "go": true
+  },
+  "RunIILowPUSummer20UL17DR": {
+    "fractionpass": 0.95,
+    "go": false,
+    "secondaries": {
       "/MinBias_TuneCP5_13TeV-pythia8/RunIISummer20UL17SIM-106X_mc2017_realistic_v6-v2/GEN-SIM": {
         "SiteWhitelist": [
           "T1_IT_CNAF_Disk"
         ]
-      }, 
-      "/MinBias_TuneCP5_13TeV-pythia8/RunIISummer20UL18SIM-106X_upgrade2018_realistic_v11_L1v1-v2/GEN-SIM": {
-        "SiteWhitelist": [
-          "T1_IT_CNAF_Disk",
-          "T2_CH_CERN"
-        ]
       }
-    }, 
-    "tune": true
-  },
-  "RunIILowPUSummer20UL17GEN":{
-      "fractionpass": 0.95,
-      "go": true
-  },
-  "RunIILowPUSummer20UL17GS": {
-     "fractionpass": 0.95,
-     "go": true
-  },
-  "RunIILowPUSummer20UL17wmLHEGS": {
-     "fractionpass": 0.95,
-     "go": true
-  },
-  "RunIILowPUSummer20UL17DR": {
-     "fractionpass": 0.95,
-     "go": false,
-     "secondaries": {
-               "/MinBias_TuneCP5_13TeV-pythia8/RunIISummer20UL17SIM-106X_mc2017_realistic_v6-v2/GEN-SIM": {
-                        "SiteWhitelist": [
-                               "T1_IT_CNAF_Disk"
-                                         ]
-                        }
-                   }
+    }
   },
   "RunIILowPUSummer20UL17SIM": {
-      "fractionpass": 0.95,
-      "go": false
-  },          
+    "fractionpass": 0.95,
+    "go": false
+  },
   "RunIILowPUSummer20UL17MiniAODv2": {
-     "fractionpass": 0.95,
-     "go": false
+    "fractionpass": 0.95,
+    "go": false
   },
   "RunIILowPUSummer20UL17NanoAODv9": {
-     "fractionpass": 0.95,
-     "go": false
-  }, 
+    "fractionpass": 0.95,
+    "go": false
+  },
   "RunIIWinter15pLHE": {
-    "fractionpass": 0.95, 
-    "go": true, 
+    "fractionpass": 0.95,
+    "go": true,
     "parameters": {
       "EventsPerLumi": 200
-    }, 
+    },
     "recover": false
-  }, 
+  },
   "RunIIpp5Spring18DR": {
-    "custodial": "T1_FR_CCIN2P3_MSS", 
-    "fractionpass": 0.95, 
-    "go": true, 
-    "lumisize": -1, 
-    "maxcopies": 1, 
+    "custodial": "T1_FR_CCIN2P3_MSS",
+    "fractionpass": 0.95,
+    "go": true,
+    "lumisize": -1,
+    "maxcopies": 1,
     "parameters": {
-      "MergedLFNBase": "/store/himc", 
+      "MergedLFNBase": "/store/himc",
       "SiteBlacklist": [
-        "T1_US_FNAL", 
-        "T2_US_Purdue", 
-        "T2_US_Caltech", 
-        "T2_US_Florida", 
-        "T2_US_Nebraska", 
-        "T2_US_UCSD", 
+        "T1_US_FNAL",
+        "T2_US_Purdue",
+        "T2_US_Caltech",
+        "T2_US_Florida",
+        "T2_US_Nebraska",
+        "T2_US_UCSD",
         "T2_US_Wisconsin"
       ]
-    }, 
-    "resize": "auto", 
+    },
+    "resize": "auto",
     "secondaries": {
       "/MinBias_TuneCUETP8M1_2017_5p02TeV-pythia8/RunIIpp5Spring18GS-94X_mc2017_realistic_v10For2017G_v3-v2/GEN-SIM": {
-        "SiteWhitelist": [
-          "T2_US_MIT",
-          "T2_CH_CERN"
-        ]
-      }, 
-      "/MinBias_TuneCUETP8M1_5p02TeV-pythia8/HINppWinter17GS-92X_upgrade2017_realistic_v11-v1/GEN-SIM": {
-        "SiteWhitelist": [
+        "SecondaryLocation": [
           "T2_US_MIT"
         ]
       }
-    }, 
+    },
     "tune": true
-  }, 
+  },
   "RunIIpp5Spring18GS": {
-    "custodial": "T1_FR_CCIN2P3_MSS", 
-    "fractionpass": 0.95, 
-    "go": true, 
-    "lumisize": -1, 
+    "custodial": "T1_FR_CCIN2P3_MSS",
+    "fractionpass": 0.95,
+    "go": true,
+    "lumisize": -1,
     "parameters": {
-      "MergedLFNBase": "/store/himc", 
+      "MergedLFNBase": "/store/himc",
       "SiteBlacklist": [
-        "T1_US_FNAL", 
-        "T2_US_Purdue", 
-        "T2_US_Caltech", 
-        "T2_US_Florida", 
-        "T2_US_Nebraska", 
-        "T2_US_UCSD", 
+        "T1_US_FNAL",
+        "T2_US_Purdue",
+        "T2_US_Caltech",
+        "T2_US_Florida",
+        "T2_US_Nebraska",
+        "T2_US_UCSD",
         "T2_US_Wisconsin"
       ]
-    }, 
-    "resize": "auto", 
+    },
+    "resize": "auto",
     "tune": true
-  }, 
+  },
   "RunIIpp5Spring18GSFixBeamspot": {
-    "custodial": "T1_FR_CCIN2P3_MSS", 
-    "fractionpass": 0.95, 
-    "go": true, 
-    "lumisize": -1, 
+    "custodial": "T1_FR_CCIN2P3_MSS",
+    "fractionpass": 0.95,
+    "go": true,
+    "lumisize": -1,
     "secondaries": {
-      "/MinBias_TuneCUETP8M1_2017_5p02TeV-pythia8/RunIIpp5Spring18GS-94X_mc2017_realistic_v10For2017G_v3-v2/GEN-SIM": 
-      {
+      "/MinBias_TuneCUETP8M1_2017_5p02TeV-pythia8/RunIIpp5Spring18GS-94X_mc2017_realistic_v10For2017G_v3-v2/GEN-SIM": {
         "SecondaryLocation": [
-          "T2_CH_CERN",
           "T2_US_MIT"
         ]
       }
     },
     "parameters": {
-      "MergedLFNBase": "/store/himc", 
+      "MergedLFNBase": "/store/himc",
       "SiteBlacklist": [
-        "T1_US_FNAL", 
-        "T2_US_Purdue", 
-        "T2_US_Caltech", 
-        "T2_US_Florida", 
-        "T2_US_Nebraska", 
-        "T2_US_UCSD", 
+        "T1_US_FNAL",
+        "T2_US_Purdue",
+        "T2_US_Caltech",
+        "T2_US_Florida",
+        "T2_US_Nebraska",
+        "T2_US_UCSD",
         "T2_US_Wisconsin"
       ]
-    }, 
-    "resize": "auto", 
+    },
+    "resize": "auto",
     "tune": true
-  }, 
+  },
   "RunIIpp5Spring18MiniAOD": {
-    "fractionpass": 0.95, 
-    "go": true, 
-    "lumisize": -1, 
+    "fractionpass": 0.95,
+    "go": true,
+    "lumisize": -1,
     "resize": "auto",
     "parameters": {
       "MergedLFNBase": "/store/himc",
       "SiteBlacklist": [
-        "T1_US_FNAL",        
+        "T1_US_FNAL",
         "T2_US_Purdue",
         "T2_US_Caltech",
         "T2_US_Florida",
@@ -3881,15 +3572,15 @@
         "T2_US_Wisconsin"
       ]
     }
-  }, 
+  },
   "RunIIpp5Spring18pLHE": {
-    "fractionpass": 0.95, 
-    "go": true, 
-    "lumisize": -1, 
+    "fractionpass": 0.95,
+    "go": true,
+    "lumisize": -1,
     "parameters": {
       "MergedLFNBase": "/store/himc",
       "SiteBlacklist": [
-        "T1_US_FNAL",        
+        "T1_US_FNAL",
         "T2_US_Purdue",
         "T2_US_Caltech",
         "T2_US_Florida",
@@ -3897,26 +3588,26 @@
         "T2_US_UCSD",
         "T2_US_Wisconsin"
       ]
-    } 
-  }, 
+    }
+  },
   "RunIIpp5Spring18wmLHEGS": {
-    "custodial": "T1_FR_CCIN2P3_MSS", 
-    "force-complete": 0.99, 
-    "fractionpass": 0.95, 
-    "go": true, 
-    "lumisize": -1, 
+    "custodial": "T1_FR_CCIN2P3_MSS",
+    "force-complete": 0.99,
+    "fractionpass": 0.95,
+    "go": true,
+    "lumisize": -1,
     "parameters": {
-      "MergedLFNBase": "/store/himc", 
+      "MergedLFNBase": "/store/himc",
       "SiteBlacklist": [
-        "T1_US_FNAL", 
-        "T2_US_Purdue", 
-        "T2_US_Caltech", 
-        "T2_US_Florida", 
-        "T2_US_Nebraska", 
-        "T2_US_UCSD", 
+        "T1_US_FNAL",
+        "T2_US_Purdue",
+        "T2_US_Caltech",
+        "T2_US_Florida",
+        "T2_US_Nebraska",
+        "T2_US_UCSD",
         "T2_US_Wisconsin"
       ]
-    }, 
+    },
     "tune": true
   },
   "RunIISummer20UL17pp5TeVpLHE": {
@@ -3925,17 +3616,17 @@
     "lumisize": -1,
     "resize": "auto",
     "parameters": {
-       "MergedLFNBase": "/store/himc",
-       "SiteBlacklist": [
-          "T1_US_FNAL",
-          "T2_US_Purdue",
-          "T2_US_Caltech",
-          "T2_US_Florida",
-          "T2_US_Nebraska",
-          "T2_US_UCSD",
-          "T2_US_Wisconsin"
-        ]
-     }
+      "MergedLFNBase": "/store/himc",
+      "SiteBlacklist": [
+        "T1_US_FNAL",
+        "T2_US_Purdue",
+        "T2_US_Caltech",
+        "T2_US_Florida",
+        "T2_US_Nebraska",
+        "T2_US_UCSD",
+        "T2_US_Wisconsin"
+      ]
+    }
   },
   "RunIISummer20UL17pp5TeVMiniAOD": {
     "fractionpass": 0.95,
@@ -3943,17 +3634,17 @@
     "lumisize": -1,
     "resize": "auto",
     "parameters": {
-       "MergedLFNBase": "/store/himc",
-       "SiteBlacklist": [
-          "T1_US_FNAL",
-          "T2_US_Purdue",
-          "T2_US_Caltech",
-          "T2_US_Florida",
-          "T2_US_Nebraska",
-          "T2_US_UCSD",
-          "T2_US_Wisconsin"
-        ]
-     }
+      "MergedLFNBase": "/store/himc",
+      "SiteBlacklist": [
+        "T1_US_FNAL",
+        "T2_US_Purdue",
+        "T2_US_Caltech",
+        "T2_US_Florida",
+        "T2_US_Nebraska",
+        "T2_US_UCSD",
+        "T2_US_Wisconsin"
+      ]
+    }
   },
   "RunIISummer20UL17pp5TeVMiniAODv2": {
     "fractionpass": 0.95,
@@ -3961,17 +3652,17 @@
     "lumisize": -1,
     "resize": "auto",
     "parameters": {
-       "MergedLFNBase": "/store/himc",
-       "SiteBlacklist": [
-          "T1_US_FNAL",
-          "T2_US_Purdue",
-          "T2_US_Caltech",
-          "T2_US_Florida",
-          "T2_US_Nebraska",
-          "T2_US_UCSD",
-          "T2_US_Wisconsin"
-        ]
-     }
+      "MergedLFNBase": "/store/himc",
+      "SiteBlacklist": [
+        "T1_US_FNAL",
+        "T2_US_Purdue",
+        "T2_US_Caltech",
+        "T2_US_Florida",
+        "T2_US_Nebraska",
+        "T2_US_UCSD",
+        "T2_US_Wisconsin"
+      ]
+    }
   },
   "RunIISummer20UL17pp5TeVNanoAODv9": {
     "fractionpass": 0.95,
@@ -3979,62 +3670,60 @@
     "lumisize": -1,
     "resize": "auto",
     "parameters": {
-       "MergedLFNBase": "/store/himc",
-       "SiteBlacklist": [
-          "T1_US_FNAL",
-          "T2_US_Purdue",
-          "T2_US_Caltech",
-          "T2_US_Florida",
-          "T2_US_Nebraska",
-          "T2_US_UCSD",
-          "T2_US_Wisconsin"
-        ]
-     }
-  }, 
+      "MergedLFNBase": "/store/himc",
+      "SiteBlacklist": [
+        "T1_US_FNAL",
+        "T2_US_Purdue",
+        "T2_US_Caltech",
+        "T2_US_Florida",
+        "T2_US_Nebraska",
+        "T2_US_UCSD",
+        "T2_US_Wisconsin"
+      ]
+    }
+  },
   "RunIISummer20UL17pp5TeVDR": {
     "fractionpass": 0.95,
     "go": true,
     "lumisize": -1,
     "resize": "auto",
     "parameters": {
-       "MergedLFNBase": "/store/himc",
-       "SiteBlacklist": [
-          "T1_US_FNAL",
-          "T2_US_Purdue",
-          "T2_US_Caltech",
-          "T2_US_Florida",
-          "T2_US_Nebraska",
-          "T2_US_UCSD",
-          "T2_US_Wisconsin"
-        ]
-     },
-    "secondaries": {
-       "/MinBias_TuneCP5_5TeV-pythia8/RunIISummer20UL17pp5TeVGS-106X_mc2017_realistic_forppRef5TeV_v3-v1/GEN-SIM": {
-          "SiteWhitelist": [
-             "T2_CH_CERN",
-             "T2_DE_DESY",
-             "T2_US_Nebraska"
-                      ]
-              }
-       }
+      "MergedLFNBase": "/store/himc",
+      "SiteBlacklist": [
+        "T1_US_FNAL",
+        "T2_US_Purdue",
+        "T2_US_Caltech",
+        "T2_US_Florida",
+        "T2_US_Nebraska",
+        "T2_US_UCSD",
+        "T2_US_Wisconsin"
+      ]
     },
+    "secondaries": {
+      "/MinBias_TuneCP5_5TeV-pythia8/RunIISummer20UL17pp5TeVGS-106X_mc2017_realistic_forppRef5TeV_v3-v1/GEN-SIM": {
+        "SecondaryLocation": [
+          "T2_DE_DESY"
+        ]
+      }
+    }
+  },
   "RunIISummer20UL17pp5TeVGS": {
     "fractionpass": 0.95,
     "go": true,
     "lumisize": -1,
     "resize": "auto",
     "parameters": {
-       "MergedLFNBase": "/store/himc",
-       "SiteBlacklist": [
-          "T1_US_FNAL",
-          "T2_US_Purdue",
-          "T2_US_Caltech",
-          "T2_US_Florida",
-          "T2_US_Nebraska",
-          "T2_US_UCSD",
-          "T2_US_Wisconsin"
-        ]
-     }
+      "MergedLFNBase": "/store/himc",
+      "SiteBlacklist": [
+        "T1_US_FNAL",
+        "T2_US_Purdue",
+        "T2_US_Caltech",
+        "T2_US_Florida",
+        "T2_US_Nebraska",
+        "T2_US_UCSD",
+        "T2_US_Wisconsin"
+      ]
+    }
   },
   "RunIISummer20UL17pp5TeVwmLHEGS": {
     "fractionpass": 0.95,
@@ -4114,61 +3803,59 @@
     "lumisize": -1,
     "resize": "auto",
     "parameters": {
-       "MergedLFNBase": "/store/himc",
-       "SiteBlacklist": [
-          "T1_US_FNAL",
-          "T2_US_Purdue",
-          "T2_US_Caltech",
-          "T2_US_Florida",
-          "T2_US_Nebraska",
-          "T2_US_UCSD",
-          "T2_US_Wisconsin"
-        ]
-     },
-    "secondaries": {
-       "/MinBias_TuneCP5_5TeV-pythia8/RunIISummer20UL17pp5TeVGS-106X_mc2017_realistic_forppRef5TeV_v3-v1/GEN-SIM": {
-          "SiteWhitelist": [
-             "T2_CH_CERN",
-             "T2_DE_DESY",
-             "T2_US_Nebraska"
-                      ]
-              }
-       }
+      "MergedLFNBase": "/store/himc",
+      "SiteBlacklist": [
+        "T1_US_FNAL",
+        "T2_US_Purdue",
+        "T2_US_Caltech",
+        "T2_US_Florida",
+        "T2_US_Nebraska",
+        "T2_US_UCSD",
+        "T2_US_Wisconsin"
+      ]
     },
+    "secondaries": {
+      "/MinBias_TuneCP5_5TeV-pythia8/RunIISummer20UL17pp5TeVGS-106X_mc2017_realistic_forppRef5TeV_v3-v1/GEN-SIM": {
+        "SecondaryLocation": [
+          "T2_DE_DESY"
+        ]
+      }
+    }
+  },
   "SnowmassWinter21GEN": {
-    "fractionpass": 0.95, 
-    "go": true, 
-    "lumisize": -1, 
-    "maxcopies": 1, 
+    "fractionpass": 0.95,
+    "go": true,
+    "lumisize": -1,
+    "maxcopies": 1,
     "resize": "auto"
-  }, 
+  },
   "SnowmassWinter21wmLHEGEN": {
-    "fractionpass": 0.95, 
-    "go": true, 
-    "lumisize": -1, 
-    "maxcopies": 1, 
+    "fractionpass": 0.95,
+    "go": true,
+    "lumisize": -1,
+    "maxcopies": 1,
     "resize": "auto"
-  }, 
+  },
   "UltraLegacy2016": {
     "custodial_override": [
       "DQMIO"
-    ], 
-    "fractionpass": 1, 
-    "go": true, 
-    "lumisize": -1, 
-    "maxcopies": 1, 
+    ],
+    "fractionpass": 1,
+    "go": true,
+    "lumisize": -1,
+    "maxcopies": 1,
     "overflow": {
       "PRIM": {}
     }
-  }, 
+  },
   "UltraLegacy2017": {
     "custodial_override": [
       "DQMIO"
-    ], 
-    "fractionpass": 1, 
-    "go": true, 
-    "lumisize": -1, 
-    "maxcopies": 1, 
+    ],
+    "fractionpass": 1,
+    "go": true,
+    "lumisize": -1,
+    "maxcopies": 1,
     "overflow": {
       "PRIM": {}
     }
@@ -4176,195 +3863,146 @@
   "UltraLegacy2018": {
     "custodial_override": [
       "DQMIO"
-    ], 
-    "fractionpass": 1, 
-    "go": true, 
-    "lumisize": -1, 
-    "maxcopies": 1, 
+    ],
+    "fractionpass": 1,
+    "go": true,
+    "lumisize": -1,
+    "maxcopies": 1,
     "overflow": {
       "PRIM": {}
     }
-  }, 
+  },
   "pPb816Spring16GS": {
-    "custodial": "T1_FR_CCIN2P3_MSS", 
-    "fractionpass": 0.95, 
-    "go": true, 
-    "lumisize": -1, 
+    "custodial": "T1_FR_CCIN2P3_MSS",
+    "fractionpass": 0.95,
+    "go": true,
+    "lumisize": -1,
     "parameters": {
-      "MergedLFNBase": "/store/himc", 
+      "MergedLFNBase": "/store/himc",
       "SiteBlacklist": [
-        "T1_US_FNAL", 
+        "T1_US_FNAL",
         "T2_US_Purdue",
-        "T2_US_Caltech", 
-        "T2_US_Florida", 
-        "T2_US_Nebraska", 
-        "T2_US_UCSD", 
-        "T2_US_Wisconsin", 
+        "T2_US_Caltech",
+        "T2_US_Florida",
+        "T2_US_Nebraska",
+        "T2_US_UCSD",
+        "T2_US_Wisconsin",
         "T3_US_NERSC"
       ]
-    }, 
-    "secondaries": {
-      "/ReggeGribovPartonMC_EposLHC_pPb_4080_4080/pPb816Spring16GS-80X_mcRun2_asymptotic_v17-v1/GEN-SIM": {
-        "SiteWhitelist": [
-          "T2_IT_Pisa",
-          "T1_IT_CNAF_Disk"
-        ]
-      },
-      "/ReggeGribovPartonMC_EposLHC_PbP_4080_4080_DataBS/pPb816Spring16GS-MB_80X_mcRun2_pA_v4-v2/GEN-SIM": {
-        "SiteWhitelist": [
-          "T1_IT_CNAF_Disk"
-        ]
-      },
-      "/ReggeGribovPartonMC_EposLHC_pPb_4080_4080_DataBS/pPb816Spring16GS-MB_80X_mcRun2_pA_v4-v2/GEN-SIM": {
-        "SiteWhitelist": [
-          "T1_FR_CCIN2P3_Disk",
-          "T2_US_MIT"
-        ]
-      }
-    }
-  }, 
+    },
+    "secondaries": {}
+  },
   "pPb816Spring16pLHE": {
-    "custodial": "T1_FR_CCIN2P3_MSS", 
-    "fractionpass": 0.95, 
-    "go": true, 
+    "custodial": "T1_FR_CCIN2P3_MSS",
+    "fractionpass": 0.95,
+    "go": true,
     "parameters": {
       "MergedLFNBase": "/store/himc"
-    }, 
+    },
     "tune": true
-  }, 
+  },
   "pPb816Summer16DR": {
-    "custodial": "T1_FR_CCIN2P3_MSS", 
-    "fractionpass": 0.95, 
-    "go": true, 
-    "lumisize": -1, 
+    "custodial": "T1_FR_CCIN2P3_MSS",
+    "fractionpass": 0.95,
+    "go": true,
+    "lumisize": -1,
     "parameters": {
-      "MergedLFNBase": "/store/himc", 
+      "MergedLFNBase": "/store/himc",
       "SiteBlacklist": [
-        "T1_US_FNAL", 
-        "T2_US_Purdue", 
-        "T2_US_Caltech", 
-        "T2_US_Florida", 
-        "T2_US_Nebraska", 
-        "T2_US_UCSD", 
+        "T1_US_FNAL",
+        "T2_US_Purdue",
+        "T2_US_Caltech",
+        "T2_US_Florida",
+        "T2_US_Nebraska",
+        "T2_US_UCSD",
         "T2_US_Wisconsin"
       ]
-    }, 
-    "secondaries": {
-      "/ReggeGribovPartonMC_EposLHC_PbP_4080_4080_DataBS/pPb816Spring16GS-MB_80X_mcRun2_pA_v4-v2/GEN-SIM": {
-        "SiteWhitelist": [
-          "T1_IT_CNAF_Disk"
-        ]
-      }, 
-      "/ReggeGribovPartonMC_EposLHC_pPb_4080_4080_DataBS/pPb816Spring16GS-MB_80X_mcRun2_pA_v4-v2/GEN-SIM": {
-        "SiteWhitelist": [
-          "T1_FR_CCIN2P3_Disk", 
-          "T2_US_MIT"
-        ]
-      }
-    }
-  }, 
+    },
+    "secondaries": {}
+  },
   "pp502Fall15": {
-    "custodial": "T1_FR_CCIN2P3_MSS", 
-    "fractionpass": 0.95, 
-    "go": true, 
+    "custodial": "T1_FR_CCIN2P3_MSS",
+    "fractionpass": 0.95,
+    "go": true,
     "parameters": {
-      "MergedLFNBase": "/store/himc", 
+      "MergedLFNBase": "/store/himc",
       "SiteBlacklist": [
-        "T1_US_FNAL", 
-        "T2_US_Purdue", 
-        "T2_US_Caltech", 
-        "T2_US_Florida", 
-        "T2_US_Nebraska", 
-        "T2_US_UCSD", 
-        "T2_US_Wisconsin", 
+        "T1_US_FNAL",
+        "T2_US_Purdue",
+        "T2_US_Caltech",
+        "T2_US_Florida",
+        "T2_US_Nebraska",
+        "T2_US_UCSD",
+        "T2_US_Wisconsin",
         "T2_CH_CERN"
       ]
     }
   },
   "RunIISpring21UL18FSGSDR": {
-      "fractionpass": 0.95,
-      "go": true,
-      "lumisize": -1,
-      "maxcopies": 1,
-      "SiteBlacklist": [
-          "T2_CH_CERN",
-          "T2_CH_CERN_HLT",
-          "T2_CH_CERN_P5"
-              ],
-      "secondaries": {
-          "/MinBias_TuneCP5_13TeV-pythia8/RunIISpring21UL18FSGSPremix-PUFSUL18CP5_106X_upgrade2018_realistic_v16-v1/GEN-SIM-RECO" :
-          {
-              "SiteWhitelist": [
-                  "T1_RU_JINR_Disk",
-                  "T1_US_FNAL_Disk"
-                      ]
-          }
+    "fractionpass": 0.95,
+    "go": true,
+    "lumisize": -1,
+    "maxcopies": 1,
+    "SiteBlacklist": [
+      "T2_CH_CERN",
+      "T2_CH_CERN_HLT",
+      "T2_CH_CERN_P5"
+    ],
+    "secondaries": {
+      "/MinBias_TuneCP5_13TeV-pythia8/RunIISpring21UL18FSGSPremix-PUFSUL18CP5_106X_upgrade2018_realistic_v16-v1/GEN-SIM-RECO": {
+        "SecondaryLocation": [
+          "T1_RU_JINR_Disk"
+        ]
       }
+    }
   },
   "RunIISpring21UL18FSwmLHEGSDR": {
-      "fractionpass": 0.95,
-      "go": true,
-      "lumisize": -1,
-      "maxcopies": 1,
-      "SiteBlacklist": [
-         "T2_CH_CERN",
-         "T2_CH_CERN_HLT",
-         "T2_CH_CERN_P5"
-              ],
-      "secondaries": {
-          "/MinBias_TuneCP5_13TeV-pythia8/RunIISpring21UL18FSGSPremix-PUFSUL18CP5_106X_upgrade2018_realistic_v16-v1/GEN-SIM-RECO" : {
-               "SiteWhitelist": [
-                                "T1_RU_JINR_Disk",
-                                "T1_US_FNAL_Disk"                                                            
-               ]
-            }
-        }
+    "fractionpass": 0.95,
+    "go": true,
+    "lumisize": -1,
+    "maxcopies": 1,
+    "SiteBlacklist": [
+      "T2_CH_CERN",
+      "T2_CH_CERN_HLT",
+      "T2_CH_CERN_P5"
+    ],
+    "secondaries": {
+      "/MinBias_TuneCP5_13TeV-pythia8/RunIISpring21UL18FSGSPremix-PUFSUL18CP5_106X_upgrade2018_realistic_v16-v1/GEN-SIM-RECO": {
+        "SecondaryLocation": [
+          "T1_RU_JINR_Disk"
+        ]
+      }
+    }
   },
   "RunIISpring21UL18FSSIMDR": {
-      "fractionpass": 0.95,
-      "go": true,
-      "lumisize": -1,
-      "maxcopies": 1,
-      "SiteBlacklist": [
-         "T2_CH_CERN",
-         "T2_CH_CERN_HLT",
-         "T2_CH_CERN_P5"
-              ],
-      "secondaries": {
-          "/MinBias_TuneCP5_13TeV-pythia8/RunIISpring21UL18FSGSPremix-PUFSUL18CP5_106X_upgrade2018_realistic_v16-v1/GEN-SIM-RECO" : {
-               "SiteWhitelist": [
-                                "T1_RU_JINR_Disk",
-                                "T1_US_FNAL_Disk"
-               ]
-            }
-        }
-  }, 
+    "fractionpass": 0.95,
+    "go": true,
+    "lumisize": -1,
+    "maxcopies": 1,
+    "SiteBlacklist": [
+      "T2_CH_CERN",
+      "T2_CH_CERN_HLT",
+      "T2_CH_CERN_P5"
+    ],
+    "secondaries": {
+      "/MinBias_TuneCP5_13TeV-pythia8/RunIISpring21UL18FSGSPremix-PUFSUL18CP5_106X_upgrade2018_realistic_v16-v1/GEN-SIM-RECO": {
+        "SecondaryLocation": [
+          "T1_RU_JINR_Disk"
+        ]
+      }
+    }
+  },
   "RunIISpring21UL18FSGSPremix": {
     "fractionpass": 0.95,
     "go": true,
     "lumisize": -1,
     "maxcopies": 1,
     "SiteBlacklist": [
-       "T2_CH_CERN",
-       "T2_CH_CERN_HLT",
-       "T2_CH_CERN_P5"
+      "T2_CH_CERN",
+      "T2_CH_CERN_HLT",
+      "T2_CH_CERN_P5"
     ],
-    "secondaries": {
-      "/Neutrino_E-10_gun/RunIIFall17FSPrePremix-PUFSUL18_106X_upgrade2018_realistic_v16-v1/PREMIX": 
-      {
-              "SecondaryLocation": [
-                 "T1_IT_CNAF_Disk",
-                 "T1_US_FNAL_Disk"
-               ]
-      },
-      "/Neutrino_E-10_gun/RunIIFall17FSPrePremix-PUFSUL18CP5_106X_upgrade2018_realistic_v16-v1/PREMIX":
-      {
-          "SecondaryLocation": [
-              "T1_US_FNAL_Disk",
-              "T1_FR_CCIN2P3_Disk"
-           ]
-      }
-    },
+    "secondaries": {},
     "secondary_AAA": true
   },
   "RunIISpring21UL18FSwmLHEGSPremix": {
@@ -4373,170 +4011,99 @@
     "lumisize": -1,
     "maxcopies": 1,
     "SiteBlacklist": [
-       "T2_CH_CERN",
-       "T2_CH_CERN_HLT",
-       "T2_CH_CERN_P5"
+      "T2_CH_CERN",
+      "T2_CH_CERN_HLT",
+      "T2_CH_CERN_P5"
     ],
-    "secondaries": {
-      "/Neutrino_E-10_gun/RunIIFall17FSPrePremix-PUFSUL18_106X_upgrade2018_realistic_v16-v1/PREMIX":
-      {
-             "SecondaryLocation": [
-                "T1_IT_CNAF_Disk",
-                "T1_US_FNAL_Disk"
-             ]
-      },
-      "/Neutrino_E-10_gun/RunIIFall17FSPrePremix-PUFSUL18CP5_106X_upgrade2018_realistic_v16-v1/PREMIX":
-      {
-             "SecondaryLocation": [
-                 "T1_US_FNAL_Disk",
-                 "T1_FR_CCIN2P3_Disk"
-              ]
-      }    
-    },
+    "secondaries": {},
     "secondary_AAA": true
   },
   "RunIISpring22UL18FSwmLHEGSPremix": {
-      "fractionpass": 0.95,
-      "go": true,
-      "lumisize": -1,
-      "maxcopies": 1,
-      "SiteBlacklist": [
-          "T2_CH_CERN",
-          "T2_CH_CERN_HLT",
-          "T2_CH_CERN_P5"
-       ],
-       "secondaries": {
-           "/Neutrino_E-10_gun/RunIIFall17FSPrePremix-PUFSUL18CP5_106X_upgrade2018_realistic_v16-v1/PREMIX":
-           {
-               "SecondaryLocation": [
-                   "T1_US_FNAL_Disk",
-                   "T1_FR_CCIN2P3_Disk"
-               ]
-           }
-       },
-       "secondary_AAA": true
+    "fractionpass": 0.95,
+    "go": true,
+    "lumisize": -1,
+    "maxcopies": 1,
+    "SiteBlacklist": [
+      "T2_CH_CERN",
+      "T2_CH_CERN_HLT",
+      "T2_CH_CERN_P5"
+    ],
+    "secondaries": {},
+    "secondary_AAA": true
   },
   "RunIISpring21UL18FSGSPremixLLPBugFix": {
-      "fractionpass": 0.95,
-      "go": true,
-      "lumisize": -1,
-      "maxcopies": 1,
-      "SiteBlacklist": [
-          "T2_CH_CERN",
-          "T2_CH_CERN_HLT",
-          "T2_CH_CERN_P5"
-      ],
-      "secondaries": {
-          "/Neutrino_E-10_gun/RunIIFall17FSPrePremix-PUFSUL18CP5_106X_upgrade2018_realistic_v16-v1/PREMIX":
-          {
-              "SecondaryLocation": [
-                  "T1_US_FNAL_Disk",
-                  "T1_FR_CCIN2P3_Disk"
-              ]
-          }
-      },
-      "secondary_AAA": true
-  },    
+    "fractionpass": 0.95,
+    "go": true,
+    "lumisize": -1,
+    "maxcopies": 1,
+    "SiteBlacklist": [
+      "T2_CH_CERN",
+      "T2_CH_CERN_HLT",
+      "T2_CH_CERN_P5"
+    ],
+    "secondaries": {},
+    "secondary_AAA": true
+  },
   "RunIISpring21UL18FSSIMDRPremix": {
     "fractionpass": 0.95,
     "go": true,
     "lumisize": -1,
     "maxcopies": 1,
     "SiteBlacklist": [
-       "T2_CH_CERN",
-       "T2_CH_CERN_HLT",
-       "T2_CH_CERN_P5"
+      "T2_CH_CERN",
+      "T2_CH_CERN_HLT",
+      "T2_CH_CERN_P5"
     ],
-    "secondaries": {
-      "/Neutrino_E-10_gun/RunIIFall17FSPrePremix-PUFSUL18CP5_106X_upgrade2018_realistic_v16-v1/PREMIX":
-      {
-             "SecondaryLocation": [
-                 "T1_US_FNAL_Disk",
-                 "T1_FR_CCIN2P3_Disk"
-              ]
-      }
-    },
+    "secondaries": {},
     "secondary_AAA": true
   },
   "RunIISpring21UL17FSGSDR": {
-      "fractionpass": 0.95,
-      "go": true,
-      "lumisize": -1,
-      "maxcopies": 1,
-      "SiteBlacklist": [
-          "T2_CH_CERN",
-          "T2_CH_CERN_HLT",
-          "T2_CH_CERN_P5"
-              ],
-      "secondaries": {
-          "/MinBias_TuneCP5_13TeV-pythia8/RunIISpring21UL17FSGSPremix-PUFSUL17CP5_106X_mc2017_realistic_v9-v1/GEN-SIM-RECO":
-          {
-              "SiteWhitelist": [
-                  "T1_DE_KIT_Disk",
-                  "T1_RU_JINR_Disk"
-                      ]
-          }
-      }
+    "fractionpass": 0.95,
+    "go": true,
+    "lumisize": -1,
+    "maxcopies": 1,
+    "SiteBlacklist": [
+      "T2_CH_CERN",
+      "T2_CH_CERN_HLT",
+      "T2_CH_CERN_P5"
+    ],
+    "secondaries": {}
   },
   "RunIISpring21UL17FSwmLHEGSDR": {
-      "fractionpass": 0.95,
-      "go": true,
-      "lumisize": -1,
-      "maxcopies": 1,
-      "SiteBlacklist": [
-          "T2_CH_CERN",
-          "T2_CH_CERN_HLT",
-          "T2_CH_CERN_P5"
-              ],
-      "secondaries": {
-          "/MinBias_TuneCP5_13TeV-pythia8/RunIISpring21UL17FSGSPremix-PUFSUL17CP5_106X_mc2017_realistic_v9-v1/GEN-SIM-RECO":
-          {
-              "SiteWhitelist": [
-                  "T1_DE_KIT_Disk",
-                  "T1_RU_JINR_Disk"
-                      ]
-          }
-      }
+    "fractionpass": 0.95,
+    "go": true,
+    "lumisize": -1,
+    "maxcopies": 1,
+    "SiteBlacklist": [
+      "T2_CH_CERN",
+      "T2_CH_CERN_HLT",
+      "T2_CH_CERN_P5"
+    ],
+    "secondaries": {}
   },
   "RunIISpring21UL17FSSIMDR": {
-      "fractionpass": 0.95,
-      "go": true,
-      "lumisize": -1,
-      "maxcopies": 1,
-      "SiteBlacklist": [
-          "T2_CH_CERN",
-          "T2_CH_CERN_HLT",
-          "T2_CH_CERN_P5"
-              ],
-      "secondaries": {
-          "/MinBias_TuneCP5_13TeV-pythia8/RunIISpring21UL17FSGSPremix-PUFSUL17CP5_106X_mc2017_realistic_v9-v1/GEN-SIM-RECO":
-          {
-              "SiteWhitelist": [
-                  "T1_DE_KIT_Disk",
-                  "T1_RU_JINR_Disk"
-                      ]
-          }
-      }
+    "fractionpass": 0.95,
+    "go": true,
+    "lumisize": -1,
+    "maxcopies": 1,
+    "SiteBlacklist": [
+      "T2_CH_CERN",
+      "T2_CH_CERN_HLT",
+      "T2_CH_CERN_P5"
+    ],
+    "secondaries": {}
   },
   "RunIISpring21UL17FSGSPremix": {
     "fractionpass": 0.95,
     "go": true,
     "lumisize": -1,
     "maxcopies": 1,
-     "SiteBlacklist": [
-        "T2_CH_CERN",
-        "T2_CH_CERN_HLT",
-        "T2_CH_CERN_P5"
+    "SiteBlacklist": [
+      "T2_CH_CERN",
+      "T2_CH_CERN_HLT",
+      "T2_CH_CERN_P5"
     ],
-    "secondaries": {
-      "/Neutrino_E-10_gun/RunIIFall17FSPrePremix-PUFSUL17CP5_106X_mc2017_realistic_v9-v2/PREMIX" :
-      {
-              "SecondaryLocation": [
-                 "T1_DE_KIT_Disk",
-                 "T1_US_FNAL_Disk"
-                  ]
-      }
-    },
+    "secondaries": {},
     "secondary_AAA": true
   },
   "RunIISpring21UL17FSwmLHEGSPremix": {
@@ -4545,61 +4112,37 @@
     "lumisize": -1,
     "maxcopies": 1,
     "SiteBlacklist": [
-       "T2_CH_CERN",
-       "T2_CH_CERN_HLT",
-       "T2_CH_CERN_P5"
-     ],
-    "secondaries": {
-          "/Neutrino_E-10_gun/RunIIFall17FSPrePremix-PUFSUL17CP5_106X_mc2017_realistic_v9-v2/PREMIX" :
-          { 
-                 "SecondaryLocation": [
-                    "T1_US_FNAL_Disk",
-                    "T1_DE_KIT_Disk"
-                     ]
-         }
-    },
+      "T2_CH_CERN",
+      "T2_CH_CERN_HLT",
+      "T2_CH_CERN_P5"
+    ],
+    "secondaries": {},
     "secondary_AAA": true
   },
   "RunIISpring22UL17FSwmLHEGSPremix": {
-      "fractionpass": 0.95,
-      "go": true,
-      "lumisize": -1,
-      "maxcopies": 1,
-      "SiteBlacklist": [
-          "T2_CH_CERN",
-          "T2_CH_CERN_HLT",
-          "T2_CH_CERN_P5"
-       ],
-       "secondaries": {
-           "/Neutrino_E-10_gun/RunIIFall17FSPrePremix-PUFSUL17CP5_106X_mc2017_realistic_v9-v2/PREMIX" :
-           {
-               "SecondaryLocation": [
-                   "T1_US_FNAL_Disk",
-                   "T1_DE_KIT_Disk"
-                    ]
-           }
-       },
-       "secondary_AAA": true
-  },       
+    "fractionpass": 0.95,
+    "go": true,
+    "lumisize": -1,
+    "maxcopies": 1,
+    "SiteBlacklist": [
+      "T2_CH_CERN",
+      "T2_CH_CERN_HLT",
+      "T2_CH_CERN_P5"
+    ],
+    "secondaries": {},
+    "secondary_AAA": true
+  },
   "RunIISpring21UL17FSGSPremixLLPBugFix": {
     "fractionpass": 0.95,
     "go": true,
     "lumisize": -1,
     "maxcopies": 1,
     "SiteBlacklist": [
-       "T2_CH_CERN",
-       "T2_CH_CERN_HLT",
-       "T2_CH_CERN_P5"
-     ],
-     "secondaries": {
-          "/Neutrino_E-10_gun/RunIIFall17FSPrePremix-PUFSUL17CP5_106X_mc2017_realistic_v9-v2/PREMIX" :
-          {
-                 "SecondaryLocation": [
-                    "T1_US_FNAL_Disk",
-                    "T1_DE_KIT_Disk"
-                     ]
-          }
-    },
+      "T2_CH_CERN",
+      "T2_CH_CERN_HLT",
+      "T2_CH_CERN_P5"
+    ],
+    "secondaries": {},
     "secondary_AAA": true
   },
   "RunIISpring21UL17FSSIMDRPremix": {
@@ -4607,99 +4150,62 @@
     "go": true,
     "lumisize": -1,
     "maxcopies": 1,
-     "SiteBlacklist": [
-        "T2_CH_CERN",
-        "T2_CH_CERN_HLT",
-        "T2_CH_CERN_P5"
+    "SiteBlacklist": [
+      "T2_CH_CERN",
+      "T2_CH_CERN_HLT",
+      "T2_CH_CERN_P5"
     ],
-    "secondaries": {
-      "/Neutrino_E-10_gun/RunIIFall17FSPrePremix-PUFSUL17CP5_106X_mc2017_realistic_v9-v2/PREMIX" :
-      {
-              "SecondaryLocation": [
-                 "T1_DE_KIT_Disk",
-                 "T1_US_FNAL_Disk"
-                  ]
-      }
-    },
+    "secondaries": {},
     "secondary_AAA": true
   },
-  "RunIISpring21UL16FSSIMDR": { 
-      "fractionpass": 0.95,
-      "go": true,
-      "lumisize": -1,
-      "maxcopies": 1,
-      "SiteBlacklist": [
-          "T2_CH_CERN",
-          "T2_CH_CERN_HLT",
-          "T2_CH_CERN_P5"
-              ],
-      "secondaries": {
-        "/MinBias_TuneCP5_13TeV-pythia8/RunIISpring21UL16FSGSPremix-PUFSUL16CP5_106X_mcRun2_asymptotic_v16-v1/GEN-SIM-RECO" :
-        {
-            "SiteWhitelist": [
-                "T1_RU_JINR_Disk"
-                ]
-        }
-      }
-  },
-  "RunIISpring21UL16FSSIMDRPremix": {     
-      "fractionpass": 0.95,
-      "go": true,
-      "lumisize": -1,
-      "maxcopies": 1, 
-      "SiteBlacklist": [
-       "T2_CH_CERN",
-       "T2_CH_CERN_HLT",
-       "T2_CH_CERN_P5"
+  "RunIISpring21UL16FSSIMDR": {
+    "fractionpass": 0.95,
+    "go": true,
+    "lumisize": -1,
+    "maxcopies": 1,
+    "SiteBlacklist": [
+      "T2_CH_CERN",
+      "T2_CH_CERN_HLT",
+      "T2_CH_CERN_P5"
     ],
-    "secondaries": {
-       "/Neutrino_E-10_gun/RunIIFall17FSPrePremix-PUFSUL16CP5_106X_mcRun2_asymptotic_v16-v1/PREMIX" :
-                {
-                  "SecondaryLocation": [
-                     "T1_RU_JINR_Disk",
-                     "T1_US_FNAL_Disk"
-                       ]
-                 }
-    },
+    "secondaries": {}
+  },
+  "RunIISpring21UL16FSSIMDRPremix": {
+    "fractionpass": 0.95,
+    "go": true,
+    "lumisize": -1,
+    "maxcopies": 1,
+    "SiteBlacklist": [
+      "T2_CH_CERN",
+      "T2_CH_CERN_HLT",
+      "T2_CH_CERN_P5"
+    ],
+    "secondaries": {},
     "secondary_AAA": true
-  },        
+  },
   "RunIISpring21UL16FSGSDR": {
-      "fractionpass": 0.95,
-      "go": true,
-      "lumisize": -1,
-      "maxcopies": 1,
-      "SiteBlacklist": [
-          "T2_CH_CERN",
-          "T2_CH_CERN_HLT",
-          "T2_CH_CERN_P5"
-              ],
-      "secondaries": {
-        "/MinBias_TuneCP5_13TeV-pythia8/RunIISpring21UL16FSGSPremix-PUFSUL16CP5_106X_mcRun2_asymptotic_v16-v1/GEN-SIM-RECO" :
-        {
-            "SiteWhitelist": [
-                "T1_RU_JINR_Disk"
-                ]
-        }
-      }
+    "fractionpass": 0.95,
+    "go": true,
+    "lumisize": -1,
+    "maxcopies": 1,
+    "SiteBlacklist": [
+      "T2_CH_CERN",
+      "T2_CH_CERN_HLT",
+      "T2_CH_CERN_P5"
+    ],
+    "secondaries": {}
   },
   "RunIISpring21UL16FSwmLHEGSDR": {
-      "fractionpass": 0.95,
-      "go": true,
-      "lumisize": -1,
-      "maxcopies": 1,
-      "SiteBlacklist": [
-          "T2_CH_CERN",
-          "T2_CH_CERN_HLT",
-          "T2_CH_CERN_P5"
-              ],
-      "secondaries": {
-        "/MinBias_TuneCP5_13TeV-pythia8/RunIISpring21UL16FSGSPremix-PUFSUL16CP5_106X_mcRun2_asymptotic_v16-v1/GEN-SIM-RECO" :
-        {
-            "SiteWhitelist": [
-                "T1_RU_JINR_Disk"
-                ]
-        }
-      }
+    "fractionpass": 0.95,
+    "go": true,
+    "lumisize": -1,
+    "maxcopies": 1,
+    "SiteBlacklist": [
+      "T2_CH_CERN",
+      "T2_CH_CERN_HLT",
+      "T2_CH_CERN_P5"
+    ],
+    "secondaries": {}
   },
   "RunIISpring21UL16FSGSPremix": {
     "fractionpass": 0.95,
@@ -4711,22 +4217,7 @@
       "T2_CH_CERN_HLT",
       "T2_CH_CERN_P5"
     ],
-    "secondaries": {    
-      "/Neutrino_E-10_gun/RunIIFall17FSPrePremix-PUFSUL16_106X_mcRun2_asymptotic_v16-v1/PREMIX" :
-                {
-                  "SecondaryLocation": [
-                     "T1_ES_PIC_Disk",
-                     "T1_US_FNAL_Disk"
-                       ]
-                 },
-       "/Neutrino_E-10_gun/RunIIFall17FSPrePremix-PUFSUL16CP5_106X_mcRun2_asymptotic_v16-v1/PREMIX" :
-                {
-                  "SecondaryLocation": [
-                     "T1_RU_JINR_Disk",
-                     "T1_US_FNAL_Disk"
-                       ]
-                 }
-    },
+    "secondaries": {},
     "secondary_AAA": true
   },
   "RunIISpring21UL16FSwmLHEGSPremix": {
@@ -4739,44 +4230,21 @@
       "T2_CH_CERN_HLT",
       "T2_CH_CERN_P5"
     ],
-    "secondaries": {
-      "/Neutrino_E-10_gun/RunIIFall17FSPrePremix-PUFSUL16_106X_mcRun2_asymptotic_v16-v1/PREMIX" : 
-      {
-              "SecondaryLocation": [
-                 "T1_ES_PIC_Disk",
-                 "T1_US_FNAL_Disk"
-                   ]
-      },
-      "/Neutrino_E-10_gun/RunIIFall17FSPrePremix-PUFSUL16CP5_106X_mcRun2_asymptotic_v16-v1/PREMIX" : 
-      {
-              "SecondaryLocation": [
-                 "T1_RU_JINR_Disk",
-                 "T1_US_FNAL_Disk"
-                   ]
-      }
-    },
+    "secondaries": {},
     "secondary_AAA": true
   },
   "RunIISpring22UL16FSwmLHEGSPremix": {
-      "fractionpass": 0.95,
-      "go": true,
-      "lumisize": -1,
-      "maxcopies": 1,
-      "SiteBlacklist": [
-          "T2_CH_CERN",
-          "T2_CH_CERN_HLT",
-          "T2_CH_CERN_P5"
-      ],
-      "secondaries": {
-          "/Neutrino_E-10_gun/RunIIFall17FSPrePremix-PUFSUL16CP5_106X_mcRun2_asymptotic_v16-v1/PREMIX" :
-          {
-              "SecondaryLocation": [
-                   "T1_RU_JINR_Disk",
-                   "T1_US_FNAL_Disk"
-                       ]
-          }
-      },
-      "secondary_AAA": true
+    "fractionpass": 0.95,
+    "go": true,
+    "lumisize": -1,
+    "maxcopies": 1,
+    "SiteBlacklist": [
+      "T2_CH_CERN",
+      "T2_CH_CERN_HLT",
+      "T2_CH_CERN_P5"
+    ],
+    "secondaries": {},
+    "secondary_AAA": true
   },
   "RunIISpring21UL16FSGSPremixLLPBugFix": {
     "fractionpass": 0.95,
@@ -4788,15 +4256,7 @@
       "T2_CH_CERN_HLT",
       "T2_CH_CERN_P5"
     ],
-    "secondaries": {
-      "/Neutrino_E-10_gun/RunIIFall17FSPrePremix-PUFSUL16CP5_106X_mcRun2_asymptotic_v16-v1/PREMIX" :
-      {
-              "SecondaryLocation": [
-                 "T1_RU_JINR_Disk",
-                 "T1_US_FNAL_Disk"
-                   ]
-      }
-    },
+    "secondaries": {},
     "secondary_AAA": true
   },
   "RunIIFall17FSPrePremix": {
@@ -4805,60 +4265,26 @@
     "lumisize": -1,
     "maxcopies": 1,
     "secondaries": {
-        "/MinBias_TuneCP2_13TeV-pythia8/RunIISpring21UL18FSGSPremix-PUFSUL18_106X_upgrade2018_realistic_v16-v1/GEN-SIM-RECO":
-        {
-            "SiteWhitelist": [
-                "T1_FR_CCIN2P3_Disk"
-            ]
-        },
-        "/MinBias_TuneCP2_13TeV-pythia8/RunIISpring21UL16FSGSPremix-PUFSUL16_106X_mcRun2_asymptotic_v16-v1/GEN-SIM-RECO":
-        {
-            "SiteWhitelist":[
-                "T2_US_Purdue"
-            ]
-        },
-        "/MinBias_TuneCP2_13TeV-pythia8/RunIISpring21UL17FSGSPremix-PUFSUL17_106X_mc2017_realistic_v9-v1/GEN-SIM-RECO":
-        {
-            "SiteWhitelist":[
-                "T1_ES_PIC_Disk"
-                ]
-        },
-        "/MinBias_TuneCP5_13TeV-pythia8/RunIISpring21UL16FSGSPremix-PUFSUL16CP5_106X_mcRun2_asymptotic_v16-v1/GEN-SIM-RECO": 
-        {
-            "SiteWhitelist":[
-                "T1_RU_JINR_Disk"
-            ]
-        },
-        "/MinBias_TuneCP5_13TeV-pythia8/RunIISpring21UL18FSGSPremix-PUFSUL18CP5_106X_upgrade2018_realistic_v16-v1/GEN-SIM-RECO":
-        {
-            "SiteWhitelist":[
-                "T1_US_FNAL_Disk",
-                "T1_RU_JINR_Disk"
-            ]
-        },
-        "/MinBias_TuneCP5_13TeV-pythia8/RunIISpring21UL17FSGSPremix-PUFSUL17CP5_106X_mc2017_realistic_v9-v1/GEN-SIM-RECO":
-        {
-            "SiteWhitelist":[
-                "T1_DE_KIT_Disk",
-                "T1_RU_JINR_Disk"
-             ]
-        }
-
-     }
+      "/MinBias_TuneCP5_13TeV-pythia8/RunIISpring21UL18FSGSPremix-PUFSUL18CP5_106X_upgrade2018_realistic_v16-v1/GEN-SIM-RECO": {
+        "SecondaryLocation": [
+          "T1_RU_JINR_Disk"
+        ]
+      }
+    }
   },
   "Run3DataHLTGPU": {
     "SiteWhitelist": [
       "T2_US_Wisconsin"
-    ], 
-    "fractionpass": 0.0, 
-    "go": true 
+    ],
+    "fractionpass": 0.0,
+    "go": true
   },
   "Run3DataHLTCPU": {
     "SiteWhitelist": [
       "T2_US_Wisconsin"
-    ], 
+    ],
     "fractionpass": 0.0,
-    "go": true  
+    "go": true
   },
   "PhaseIISpring22pLHEGEN": {
     "fractionpass": 0.95,
@@ -4869,7 +4295,7 @@
     "go": true
   },
   "HINPbPbAutumn22GS": {
-    "fractionpass" : 0.95,
+    "fractionpass": 0.95,
     "go": false,
     "SiteBlacklist": [
       "T1_ES_PIC",
@@ -4887,7 +4313,7 @@
     ]
   },
   "HINPbPbAutumn22DR": {
-    "fractionpass" : 0.95,
+    "fractionpass": 0.95,
     "go": false,
     "SiteBlacklist": [
       "T1_ES_PIC",
@@ -4905,7 +4331,7 @@
     ]
   },
   "HINPbPbAutumnMiniAOD": {
-    "fractionpass" : 0.95,
+    "fractionpass": 0.95,
     "go": false,
     "SiteBlacklist": [
       "T1_ES_PIC",
@@ -4923,4 +4349,3 @@
     ]
   }
 }
-


### PR DESCRIPTION
Fixes #1159

This PR updates `campaigns.json` pileup configurations according to the following logic:

For a given pileup,
&nbsp;&nbsp;&nbsp;&nbsp;If there is no `wmcore_transferor` rule protecting it:
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;remove the pileup from the campaigns.json
&nbsp;&nbsp;&nbsp;&nbsp;If there is at least one `wmcore_transferor` rule, but the RSEs at which the pileup is protected at don't match the RSEs specified in the campaign config:
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Update the RSEs in the campaign config according to RSEs of `wmcore_transferor` rules.

Here is the list of taken actions:
```
1. Inconsistency between campaigns.json and wmcore_transferor rules for campaign HINPbPbAutumn18DR
/MinBias_Hydjet_Drum5F_2018_5p02TeV/HINPbPbAutumn18GS-103X_upgrade2018_realistic_HI_v11-v1/GEN-SIM
On campaign config: ['T1_RU_JINR_Disk', 'T1_FR_CCIN2P3_Disk']
On Rucio by wmcore_transferor: []
ACTION: The pileup is not protected by any wmcore_transferor rules, removing it

2. Inconsistency between campaigns.json and wmcore_transferor rules for campaign HINPbPbAutumn18GSHIMix
/MinBias_Hydjet_Drum5F_2018_5p02TeV/HINPbPbAutumn18GS-103X_upgrade2018_realistic_HI_v11-v1/GEN-SIM
On campaign config: ['T1_RU_JINR_Disk', 'T1_FR_CCIN2P3_Disk']
On Rucio by wmcore_transferor: []
ACTION: The pileup is not protected by any wmcore_transferor rules, removing it

3. Inconsistency between campaigns.json and wmcore_transferor rules for campaign HINPbPbAutumn18wmLHEGSHIMix
/MinBias_Hydjet_Drum5F_2018_5p02TeV/HINPbPbAutumn18GS-103X_upgrade2018_realistic_HI_v11-v1/GEN-SIM
On campaign config: ['T1_RU_JINR_Disk', 'T1_FR_CCIN2P3_Disk']
On Rucio by wmcore_transferor: []
ACTION: The pileup is not protected by any wmcore_transferor rules, removing it

4. Inconsistency between campaigns.json and wmcore_transferor rules for campaign HINPbPbWinter16DR
/Hydjet_Quenched_Cymbal5Ev8_PbPbMinBias_5020GeV/HiFall15-75X_mcRun2_HeavyIon_v14_75X_mcRun2_HeavyIon_v14-v1/GEN-SIM
On campaign config: ['T2_ES_CIEMAT', 'T1_RU_JINR_Disk']
On Rucio by wmcore_transferor: []
ACTION: The pileup is not protected by any wmcore_transferor rules, removing it

5. Inconsistency between campaigns.json and wmcore_transferor rules for campaign HINPbPbWinter16wmLHEGSHIMix
/Hydjet_Quenched_Cymbal5Ev8_PbPbMinBias_5020GeV/HiFall15-75X_mcRun2_HeavyIon_v14_75X_mcRun2_HeavyIon_v14-v1/GEN-SIM
On campaign config: ['T2_ES_CIEMAT', 'T1_RU_JINR_Disk']
On Rucio by wmcore_transferor: []
ACTION: The pileup is not protected by any wmcore_transferor rules, removing it

6. Inconsistency between campaigns.json and wmcore_transferor rules for campaign Phase2HLTTDRWinter20DIGI
/MinBias_TuneCP5_14TeV-pythia8/Phase2HLTTDRWinter20GS-110X_mcRun4_realistic_v3_ext1-v1/GEN-SIM
On campaign config: ['T1_RU_JINR_Disk']
On Rucio by wmcore_transferor: []
ACTION: The pileup is not protected by any wmcore_transferor rules, removing it

7. Inconsistency between campaigns.json and wmcore_transferor rules for campaign Phase2HLTTDRWinter20DIGI
/RelValMinBias_14TeV/CMSSW_11_1_2_patch3-110X_mcRun4_realistic_v3_2026D49noPU_BSzpz35-v1/GEN-SIM
On campaign config: ['T1_DE_KIT_Disk', 'T2_US_Florida']
On Rucio by wmcore_transferor: ['T1_US_FNAL_Disk']
ACTION: The pileup is protected by at least onE wmcore_transferor rule, but it doesn't match that of the campaign config. Updating the campaign config

8. Inconsistency between campaigns.json and wmcore_transferor rules for campaign Phase2HLTTDRWinter20DIGI
/MinBias_TuneCP5_14TeV-pythia8/Phase2HLTTDRWinter20GS-BSzpz35_110X_mcRun4_realistic_v3_ext4-v1/GEN-SIM
On campaign config: ['T1_ES_PIC_Disk', 'T1_RU_JINR_Disk']
On Rucio by wmcore_transferor: []
ACTION: The pileup is not protected by any wmcore_transferor rules, removing it

9. Inconsistency between campaigns.json and wmcore_transferor rules for campaign Run3Winter20DRMiniAOD
/MinBias_TuneCP5_14TeV-pythia8/Run3Winter20GS-110X_mcRun3_2021_realistic_v6-v1/GEN-SIM
On campaign config: ['T1_ES_PIC_Disk', 'T1_US_FNAL_Disk']
On Rucio by wmcore_transferor: []
ACTION: The pileup is not protected by any wmcore_transferor rules, removing it

10. Inconsistency between campaigns.json and wmcore_transferor rules for campaign Run3Winter21DRMiniAOD
/MinBias_TuneCP5_14TeV-pythia8/Run3Winter21GS-112X_mcRun3_2021_realistic_v15-v1/GEN-SIM
On campaign config: ['T1_US_FNAL_Disk', 'T1_UK_RAL_Disk']
On Rucio by wmcore_transferor: []
ACTION: The pileup is not protected by any wmcore_transferor rules, removing it

11. Inconsistency between campaigns.json and wmcore_transferor rules for campaign Run3Summer21PrePremix
/MinBias_TuneCP5_14TeV-pythia8/Run3Summer21GS-120X_mcRun3_2021_realistic_v5-v1/GEN-SIM
On campaign config: ['T1_US_FNAL_Disk', 'T1_DE_KIT_Disk']
On Rucio by wmcore_transferor: []
ACTION: The pileup is not protected by any wmcore_transferor rules, removing it

12. Inconsistency between campaigns.json and wmcore_transferor rules for campaign Run3Summer21PrePremix
/MinBias_TuneCP5_13p6TeV-pythia8/Run3Winter22GS-122X_mcRun3_2021_realistic_v9-v1/GEN-SIM
On campaign config: ['T1_US_FNAL_Disk', 'T1_ES_PIC_Disk']
On Rucio by wmcore_transferor: ['T1_US_FNAL_Disk']
ACTION: The pileup is protected by at least onE wmcore_transferor rule, but it doesn't match that of the campaign config. Updating the campaign config



13. Inconsistency between campaigns.json and wmcore_transferor rules for campaign Run3Summer21DR
/MinBias_TuneCP5_14TeV-pythia8/Run3Summer21GS-120X_mcRun3_2021_realistic_v5-v1/GEN-SIM
On campaign config: ['T1_US_FNAL_Disk', 'T1_DE_KIT_Disk']
On Rucio by wmcore_transferor: []
ACTION: The pileup is not protected by any wmcore_transferor rules, removing it

14. Inconsistency between campaigns.json and wmcore_transferor rules for campaign Run3Summer21DRPremix
/Neutrino_E-10_gun/Run3Summer21PrePremix-120X_mcRun3_2021_realistic_v6-v2/PREMIX
On campaign config: ['T1_US_FNAL_Disk', 'T1_DE_KIT_Disk']
On Rucio by wmcore_transferor: []
ACTION: The pileup is not protected by any wmcore_transferor rules, removing it

15. Inconsistency between campaigns.json and wmcore_transferor rules for campaign Run3Winter22PbPbDIGI
/MinBias_Hydjet_Drum5F_5p02TeV/Run3Winter22PbPbNoMixGS-122X_mcRun3_2021_realistic_HI_v10-v1/GEN-SIM
On campaign config: ['T1_IT_CNAF_Disk', 'T2_US_Florida']
On Rucio by wmcore_transferor: []
ACTION: The pileup is not protected by any wmcore_transferor rules, removing it

16. Inconsistency between campaigns.json and wmcore_transferor rules for campaign Run3Winter22PbPbGS
/MinBias_Hydjet_Drum5F_5p02TeV/Run3Winter22PbPbNoMixGS-122X_mcRun3_2021_realistic_HI_v10-v1/GEN-SIM
On campaign config: ['T1_IT_CNAF_Disk', 'T2_US_Florida']
On Rucio by wmcore_transferor: []
ACTION: The pileup is not protected by any wmcore_transferor rules, removing it

17. Inconsistency between campaigns.json and wmcore_transferor rules for campaign Run3Winter22DR
/MinBias_TuneCP5_13p6TeV-pythia8/Run3Winter22GS-122X_mcRun3_2021_realistic_v9-v1/GEN-SIM
On campaign config: ['T1_US_FNAL_Disk', 'T1_ES_PIC_Disk']
On Rucio by wmcore_transferor: ['T1_US_FNAL_Disk']
ACTION: The pileup is protected by at least onE wmcore_transferor rule, but it doesn't match that of the campaign config. Updating the campaign config






18. Inconsistency between campaigns.json and wmcore_transferor rules for campaign RunIIAutumn18DR
/MinBias_TuneCP5_13TeV-pythia8/RunIIFall18GS-102X_upgrade2018_realistic_v9-v1/GEN-SIM
On campaign config: ['T2_US_MIT', 'T2_DE_DESY']
On Rucio by wmcore_transferor: []
ACTION: The pileup is not protected by any wmcore_transferor rules, removing it

19. Inconsistency between campaigns.json and wmcore_transferor rules for campaign RunIIAutumn18DR
/MinBias_TuneCP5_13TeV-pythia8/RunIIFall18GS-IdealGeometry_102X_upgrade2018_design_v9-v1/GEN-SIM
On campaign config: ['T1_US_FNAL_Disk']
On Rucio by wmcore_transferor: []
ACTION: The pileup is not protected by any wmcore_transferor rules, removing it

20. Inconsistency between campaigns.json and wmcore_transferor rules for campaign RunIIAutumn18DR
/MinBias_TuneCP5_13TeV-pythia8/RunIIFall18GS-newECALCrystalGeometryFor2016_102X_mcRun2_asymptotic_v5-v1/GEN-SIM
On campaign config: ['T1_US_FNAL_Disk']
On Rucio by wmcore_transferor: []
ACTION: The pileup is not protected by any wmcore_transferor rules, removing it

21. Inconsistency between campaigns.json and wmcore_transferor rules for campaign RunIIAutumn18DR
/MinBias_TuneCP5_13TeV-pythia8/RunIIFall18GS-newECALCrystalGeometryFor2017_102X_mc2017_realistic_v5-v1/GEN-SIM
On campaign config: ['T1_DE_KIT_Disk']
On Rucio by wmcore_transferor: []
ACTION: The pileup is not protected by any wmcore_transferor rules, removing it

22. Inconsistency between campaigns.json and wmcore_transferor rules for campaign RunIIAutumn18DR
/MinBias_TuneCP5_13TeV-pythia8_Fall18/RunIIFall18GS-102X_upgrade2018_realistic_v11-v1/GEN-SIM
On campaign config: ['T1_IT_CNAF_Disk']
On Rucio by wmcore_transferor: []
ACTION: The pileup is not protected by any wmcore_transferor rules, removing it

23. Inconsistency between campaigns.json and wmcore_transferor rules for campaign RunIIAutumn18DR
/MinBias_TuneCP5_13TeV_NeutronHP-pythia8/RunIIFall18GS-SNB_102X_upgrade2018_realistic_v17-v1/GEN-SIM
On campaign config: ['T2_US_Nebraska']
On Rucio by wmcore_transferor: []
ACTION: The pileup is not protected by any wmcore_transferor rules, removing it

24. Inconsistency between campaigns.json and wmcore_transferor rules for campaign RunIIAutumn18DR
/MinBias_TuneCP5_13TeV_NeutronXS-pythia8/RunIIFall18GS-SNB_102X_upgrade2018_realistic_v17-v1/GEN-SIM
On campaign config: ['T1_ES_PIC_Disk']
On Rucio by wmcore_transferor: []
ACTION: The pileup is not protected by any wmcore_transferor rules, removing it

25. Inconsistency between campaigns.json and wmcore_transferor rules for campaign Phase2Spring21DRMiniAOD
/MinBias_TuneCP5_14TeV-pythia8/Phase2D76Spring21GS-113X_mcRun4_realistic_v7-v1/GEN-SIM
On campaign config: ['T1_US_FNAL_Disk', 'T1_DE_KIT_Disk']
On Rucio by wmcore_transferor: []
ACTION: The pileup is not protected by any wmcore_transferor rules, removing it

26. Inconsistency between campaigns.json and wmcore_transferor rules for campaign Phase2Spring21DRMiniAOD
/MinBias_TuneCP5_14TeV-pythia8/Phase2D80Spring21GS-113X_mcRun4_realistic_T25_v1-v1/GEN-SIM
On campaign config: ['T2_US_Nebraska', 'T2_IT_Pisa']
On Rucio by wmcore_transferor: []
ACTION: The pileup is not protected by any wmcore_transferor rules, removing it

27. Inconsistency between campaigns.json and wmcore_transferor rules for campaign Phase2Spring21DRMiniAOD
/MinBias_TuneCP5_14TeV-pythia8/Phase2D81Spring21GS-113X_mcRun4_realistic_T26_v1-v1/GEN-SIM
On campaign config: ['T1_DE_KIT_Disk', 'T2_US_Wisconsin']
On Rucio by wmcore_transferor: []
ACTION: The pileup is not protected by any wmcore_transferor rules, removing it





28. Inconsistency between campaigns.json and wmcore_transferor rules for campaign RunIIFall17DRStdmix
/MinBias_TuneCP1_13TeV-pythia8/RunIIFall17GS-93X_mc2017_realistic_v3-v1/GEN-SIM
On campaign config: ['T1_DE_KIT_Disk', 'T1_IT_CNAF_Disk']
On Rucio by wmcore_transferor: []
ACTION: The pileup is not protected by any wmcore_transferor rules, removing it

29. Inconsistency between campaigns.json and wmcore_transferor rules for campaign RunIIFall17DRStdmix
/MinBias_TuneCP5_13TeV-pythia8_Fall17/RunIIFall17GS-93X_mc2017_realistic_v3-v1/GEN-SIM
On campaign config: ['T1_IT_CNAF_Disk', 'T1_DE_KIT_Disk']
On Rucio by wmcore_transferor: []
ACTION: The pileup is not protected by any wmcore_transferor rules, removing it

30. Inconsistency between campaigns.json and wmcore_transferor rules for campaign RunIIFall17DRStdmix
/MinBias_TuneCP5_inelasticON_13TeV-pythia8/RunIIFall17GS-93X_mc2017_realistic_v3-v1/GEN-SIM
On campaign config: ['T1_DE_KIT_Disk', 'T1_FR_CCIN2P3_Disk']
On Rucio by wmcore_transferor: []
ACTION: The pileup is not protected by any wmcore_transferor rules, removing it


31. Inconsistency between campaigns.json and wmcore_transferor rules for campaign RunIILowPUSpring18DR
/MinBias_TuneCP5_inelasticON_13TeV-pythia8/RunIIFall17GS-93X_mc2017_realistic_v3-v1/GEN-SIM
On campaign config: ['T1_FR_CCIN2P3_Disk', 'T1_DE_KIT_Disk']
On Rucio by wmcore_transferor: []
ACTION: The pileup is not protected by any wmcore_transferor rules, removing it

32. Inconsistency between campaigns.json and wmcore_transferor rules for campaign RunIISummer16DR80
/MinBias_TuneCUETP8M1_13TeV-pythia8/RunIISummer15GS-MCRUN2_71_V1_ext1-v1/GEN-SIM
On campaign config: ['T1_US_FNAL_Disk', 'T2_US_Nebraska']
On Rucio by wmcore_transferor: []
ACTION: The pileup is not protected by any wmcore_transferor rules, removing it

33. Inconsistency between campaigns.json and wmcore_transferor rules for campaign RunIISummer16DR80Premix
/Neutrino_E-10_gun/RunIISpring15PrePremix-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v2-v2/GEN-SIM-DIGI-RAW
On campaign config: ['T1_US_FNAL_Disk', 'T1_RU_JINR_Disk']
On Rucio by wmcore_transferor: ['T1_US_FNAL_Disk']
ACTION: The pileup is protected by at least onE wmcore_transferor rule, but it doesn't match that of the campaign config. Updating the campaign config



34. Inconsistency between campaigns.json and wmcore_transferor rules for campaign RunIISummer17PrePremix
/MinBias_TuneCP2_13TeV-pythia8/RunIIFall17FSPremix-PUMoriond17_94X_mc2017_realistic_v11-v1/GEN-SIM-RECO
On campaign config: ['T2_US_MIT', 'T2_DE_DESY']
On Rucio by wmcore_transferor: []
ACTION: The pileup is not protected by any wmcore_transferor rules, removing it

35. Inconsistency between campaigns.json and wmcore_transferor rules for campaign RunIISummer17PrePremix
/MinBias_TuneCP5_13TeV-pythia8/RunIIFall18GS-102X_upgrade2018_realistic_v9-v1/GEN-SIM
On campaign config: ['T2_US_MIT', 'T2_DE_DESY']
On Rucio by wmcore_transferor: []
ACTION: The pileup is not protected by any wmcore_transferor rules, removing it

36. Inconsistency between campaigns.json and wmcore_transferor rules for campaign RunIISummer17PrePremix
/MinBias_TuneCP5_13TeV-pythia8/RunIISpring18GS-100X_upgrade2018_realistic_v9-v1/GEN-SIM
On campaign config: ['T2_DE_RWTH']
On Rucio by wmcore_transferor: []
ACTION: The pileup is not protected by any wmcore_transferor rules, removing it

37. Inconsistency between campaigns.json and wmcore_transferor rules for campaign RunIISummer17PrePremix
/MinBias_TuneCP5_13TeV-pythia8/RunIIWinter19PFCalib16GS-105X_mcRun2_asymptotic_v2-v1/GEN-SIM
On campaign config: ['T1_FR_CCIN2P3_Disk', 'T2_IT_Legnaro']
On Rucio by wmcore_transferor: []
ACTION: The pileup is not protected by any wmcore_transferor rules, removing it

38. Inconsistency between campaigns.json and wmcore_transferor rules for campaign RunIISummer17PrePremix
/MinBias_TuneCP5_13TeV-pythia8/RunIIWinter19PFCalib17GS-105X_mc2017_realistic_v5_ext1-v1/GEN-SIM
On campaign config: ['T1_FR_CCIN2P3_Disk', 'T1_IT_CNAF_Disk']
On Rucio by wmcore_transferor: []
ACTION: The pileup is not protected by any wmcore_transferor rules, removing it

39. Inconsistency between campaigns.json and wmcore_transferor rules for campaign RunIISummer17PrePremix
/MinBias_TuneCP5_13TeV-pythia8/RunIIWinter19PFCalib18GS-105X_upgrade2018_realistic_v4-v1/GEN-SIM
On campaign config: ['T2_US_Florida']
On Rucio by wmcore_transferor: []
ACTION: The pileup is not protected by any wmcore_transferor rules, removing it

40. Inconsistency between campaigns.json and wmcore_transferor rules for campaign RunIISummer17PrePremix
/MinBias_TuneCP5_14TeV-pythia8/PhaseIITDRSpring19GS-106X_upgrade2023_realistic_v2_ext1-v1/GEN-SIM
On campaign config: ['T2_US_Florida']
On Rucio by wmcore_transferor: []
ACTION: The pileup is not protected by any wmcore_transferor rules, removing it

41. Inconsistency between campaigns.json and wmcore_transferor rules for campaign RunIISummer17PrePremix
/MinBias_TuneCP5_14TeV-pythia8/Run3Winter20GS-110X_mcRun3_2021_realistic_v6-v1/GEN-SIM
On campaign config: ['T1_ES_PIC_Disk', 'T1_US_FNAL_Disk']
On Rucio by wmcore_transferor: []
ACTION: The pileup is not protected by any wmcore_transferor rules, removing it

42. Inconsistency between campaigns.json and wmcore_transferor rules for campaign RunIISummer17PrePremix
/MinBias_TuneCP5_inelasticON_13TeV-pythia8/RunIIFall17GS-93X_mc2017_realistic_v3-v1/GEN-SIM
On campaign config: ['T1_FR_CCIN2P3_Disk', 'T1_DE_KIT_Disk']
On Rucio by wmcore_transferor: []
ACTION: The pileup is not protected by any wmcore_transferor rules, removing it

43. Inconsistency between campaigns.json and wmcore_transferor rules for campaign RunIISummer17PrePremix
/MinBias_TuneCUETP8M1_13TeV-pythia8/RunIISummer17GS-92X_upgrade2017_realistic_v2-v1/GEN-SIM
On campaign config: ['T1_IT_CNAF_Disk', 'T2_US_MIT']
On Rucio by wmcore_transferor: []
ACTION: The pileup is not protected by any wmcore_transferor rules, removing it

44. Inconsistency between campaigns.json and wmcore_transferor rules for campaign RunIISummer19UL17DIGIPremix
/Neutrino_E-10_gun/RunIISummer19ULPrePremix-UL17_106X_mc2017_realistic_v6-v1/PREMIX
On campaign config: ['T1_US_FNAL_Disk']
On Rucio by wmcore_transferor: []
ACTION: The pileup is not protected by any wmcore_transferor rules, removing it

45. Inconsistency between campaigns.json and wmcore_transferor rules for campaign RunIISummer19UL16DIGI
/MinBias_TuneCP1_13TeV-pythia8/RunIISummer19UL16SIM-106X_mcRun2_asymptotic_v10-v2/GEN-SIM
On campaign config: ['T1_FR_CCIN2P3_Disk']
On Rucio by wmcore_transferor: []
ACTION: The pileup is not protected by any wmcore_transferor rules, removing it

46. Inconsistency between campaigns.json and wmcore_transferor rules for campaign RunIISummer19UL16DIGI
/MinBias_TuneCP5_13TeV-pythia8/RunIISummer19UL16SIM-106X_mcRun2_asymptotic_v3-v1/GEN-SIM
On campaign config: ['T1_US_FNAL_Disk']
On Rucio by wmcore_transferor: []
ACTION: The pileup is not protected by any wmcore_transferor rules, removing it

47. Inconsistency between campaigns.json and wmcore_transferor rules for campaign RunIISummer20UL16DIGI
/MinBias_TuneCP5_13TeV-pythia8/RunIISummer20UL16SIM-106X_mcRun2_asymptotic_v13-v2/GEN-SIM
On campaign config: ['T1_US_FNAL_Disk', 'T1_IT_CNAF_Disk']
On Rucio by wmcore_transferor: ['T1_IT_CNAF_Disk', 'T2_US_Florida']
ACTION: The pileup is protected by at least onE wmcore_transferor rule, but it doesn't match that of the campaign config. Updating the campaign config

48. Inconsistency between campaigns.json and wmcore_transferor rules for campaign RunIISummer20UL16DIGIAPV
/MinBias_TuneCP5_13TeV-pythia8/RunIISummer20UL16SIM-106X_mcRun2_asymptotic_v13-v2/GEN-SIM
On campaign config: ['T1_US_FNAL_Disk', 'T1_IT_CNAF_Disk']
On Rucio by wmcore_transferor: ['T1_IT_CNAF_Disk', 'T2_US_Florida']
ACTION: The pileup is protected by at least onE wmcore_transferor rule, but it doesn't match that of the campaign config. Updating the campaign config

49. Inconsistency between campaigns.json and wmcore_transferor rules for campaign RunIISummer20UL16DIGIPremix
/Neutrino_E-10_gun/RunIISummer20ULPrePremix-UL16_106X_mcRun2_asymptotic_v13-v1/PREMIX
On campaign config: ['T1_US_FNAL_Disk', 'T2_CH_CERN']
On Rucio by wmcore_transferor: ['T2_CH_CERN']
ACTION: The pileup is protected by at least onE wmcore_transferor rule, but it doesn't match that of the campaign config. Updating the campaign config

50. Inconsistency between campaigns.json and wmcore_transferor rules for campaign RunIISummer20UL16DIGIPremixAPV
/Neutrino_E-10_gun/RunIISummer20ULPrePremix-UL16_106X_mcRun2_asymptotic_v13-v1/PREMIX
On campaign config: ['T1_US_FNAL_Disk', 'T2_CH_CERN']
On Rucio by wmcore_transferor: ['T2_CH_CERN']
ACTION: The pileup is protected by at least onE wmcore_transferor rule, but it doesn't match that of the campaign config. Updating the campaign config


51. Inconsistency between campaigns.json and wmcore_transferor rules for campaign RunIISummer20UL17DIGIPremix
/Neutrino_E-10_gun/RunIISummer20ULPrePremix-UL17_106X_mc2017_realistic_v6-v3/PREMIX
On campaign config: ['T2_CH_CERN', 'T1_US_FNAL_Disk']
On Rucio by wmcore_transferor: ['T2_CH_CERN']
ACTION: The pileup is protected by at least onE wmcore_transferor rule, but it doesn't match that of the campaign config. Updating the campaign config


52. Inconsistency between campaigns.json and wmcore_transferor rules for campaign RunIISummer20UL18DIGIPremix
/Neutrino_E-10_gun/RunIISummer20ULPrePremix-UL18_106X_upgrade2018_realistic_v11_L1v1-v2/PREMIX
On campaign config: ['T1_IT_CNAF_Disk', 'T1_US_FNAL_Disk', 'T2_CH_CERN']
On Rucio by wmcore_transferor: ['T2_CH_CERN']
ACTION: The pileup is protected by at least onE wmcore_transferor rule, but it doesn't match that of the campaign config. Updating the campaign config

53. Inconsistency between campaigns.json and wmcore_transferor rules for campaign RunIISummer20ULPrePremix
/MinBias_TuneCP5_13TeV-pythia8/RunIISummer20UL16SIM-106X_mcRun2_asymptotic_v13-v2/GEN-SIM
On campaign config: ['T1_US_FNAL_Disk', 'T1_IT_CNAF_Disk']
On Rucio by wmcore_transferor: ['T1_IT_CNAF_Disk', 'T2_US_Florida']
ACTION: The pileup is protected by at least onE wmcore_transferor rule, but it doesn't match that of the campaign config. Updating the campaign config




54. Inconsistency between campaigns.json and wmcore_transferor rules for campaign RunIIpp5Spring18DR
/MinBias_TuneCUETP8M1_2017_5p02TeV-pythia8/RunIIpp5Spring18GS-94X_mc2017_realistic_v10For2017G_v3-v2/GEN-SIM
On campaign config: ['T2_US_MIT', 'T2_CH_CERN']
On Rucio by wmcore_transferor: ['T2_US_MIT']
ACTION: The pileup is protected by at least onE wmcore_transferor rule, but it doesn't match that of the campaign config. Updating the campaign config

55. Inconsistency between campaigns.json and wmcore_transferor rules for campaign RunIIpp5Spring18DR
/MinBias_TuneCUETP8M1_5p02TeV-pythia8/HINppWinter17GS-92X_upgrade2017_realistic_v11-v1/GEN-SIM
On campaign config: ['T2_US_MIT']
On Rucio by wmcore_transferor: []
ACTION: The pileup is not protected by any wmcore_transferor rules, removing it

56. Inconsistency between campaigns.json and wmcore_transferor rules for campaign RunIIpp5Spring18GSFixBeamspot
/MinBias_TuneCUETP8M1_2017_5p02TeV-pythia8/RunIIpp5Spring18GS-94X_mc2017_realistic_v10For2017G_v3-v2/GEN-SIM
On campaign config: ['T2_CH_CERN', 'T2_US_MIT']
On Rucio by wmcore_transferor: ['T2_US_MIT']
ACTION: The pileup is protected by at least onE wmcore_transferor rule, but it doesn't match that of the campaign config. Updating the campaign config

57. Inconsistency between campaigns.json and wmcore_transferor rules for campaign RunIISummer20UL17pp5TeVDR
/MinBias_TuneCP5_5TeV-pythia8/RunIISummer20UL17pp5TeVGS-106X_mc2017_realistic_forppRef5TeV_v3-v1/GEN-SIM
On campaign config: ['T2_CH_CERN', 'T2_DE_DESY', 'T2_US_Nebraska']
On Rucio by wmcore_transferor: ['T2_DE_DESY']
ACTION: The pileup is protected by at least onE wmcore_transferor rule, but it doesn't match that of the campaign config. Updating the campaign config

58. Inconsistency between campaigns.json and wmcore_transferor rules for campaign RunIISummer20UL17pp5TeVDIGI
/MinBias_TuneCP5_5TeV-pythia8/RunIISummer20UL17pp5TeVGS-106X_mc2017_realistic_forppRef5TeV_v3-v1/GEN-SIM
On campaign config: ['T2_CH_CERN', 'T2_DE_DESY', 'T2_US_Nebraska']
On Rucio by wmcore_transferor: ['T2_DE_DESY']
ACTION: The pileup is protected by at least onE wmcore_transferor rule, but it doesn't match that of the campaign config. Updating the campaign config

59. Inconsistency between campaigns.json and wmcore_transferor rules for campaign pPb816Spring16GS
/ReggeGribovPartonMC_EposLHC_pPb_4080_4080/pPb816Spring16GS-80X_mcRun2_asymptotic_v17-v1/GEN-SIM
On campaign config: ['T2_IT_Pisa', 'T1_IT_CNAF_Disk']
On Rucio by wmcore_transferor: []
ACTION: The pileup is not protected by any wmcore_transferor rules, removing it

60. Inconsistency between campaigns.json and wmcore_transferor rules for campaign pPb816Spring16GS
/ReggeGribovPartonMC_EposLHC_PbP_4080_4080_DataBS/pPb816Spring16GS-MB_80X_mcRun2_pA_v4-v2/GEN-SIM
On campaign config: ['T1_IT_CNAF_Disk']
On Rucio by wmcore_transferor: []
ACTION: The pileup is not protected by any wmcore_transferor rules, removing it

61. Inconsistency between campaigns.json and wmcore_transferor rules for campaign pPb816Spring16GS
/ReggeGribovPartonMC_EposLHC_pPb_4080_4080_DataBS/pPb816Spring16GS-MB_80X_mcRun2_pA_v4-v2/GEN-SIM
On campaign config: ['T1_FR_CCIN2P3_Disk', 'T2_US_MIT']
On Rucio by wmcore_transferor: []
ACTION: The pileup is not protected by any wmcore_transferor rules, removing it

62. Inconsistency between campaigns.json and wmcore_transferor rules for campaign pPb816Summer16DR
/ReggeGribovPartonMC_EposLHC_PbP_4080_4080_DataBS/pPb816Spring16GS-MB_80X_mcRun2_pA_v4-v2/GEN-SIM
On campaign config: ['T1_IT_CNAF_Disk']
On Rucio by wmcore_transferor: []
ACTION: The pileup is not protected by any wmcore_transferor rules, removing it

63. Inconsistency between campaigns.json and wmcore_transferor rules for campaign pPb816Summer16DR
/ReggeGribovPartonMC_EposLHC_pPb_4080_4080_DataBS/pPb816Spring16GS-MB_80X_mcRun2_pA_v4-v2/GEN-SIM
On campaign config: ['T1_FR_CCIN2P3_Disk', 'T2_US_MIT']
On Rucio by wmcore_transferor: []
ACTION: The pileup is not protected by any wmcore_transferor rules, removing it

64. Inconsistency between campaigns.json and wmcore_transferor rules for campaign RunIISpring21UL18FSGSDR
/MinBias_TuneCP5_13TeV-pythia8/RunIISpring21UL18FSGSPremix-PUFSUL18CP5_106X_upgrade2018_realistic_v16-v1/GEN-SIM-RECO
On campaign config: ['T1_RU_JINR_Disk', 'T1_US_FNAL_Disk']
On Rucio by wmcore_transferor: ['T1_RU_JINR_Disk']
ACTION: The pileup is protected by at least onE wmcore_transferor rule, but it doesn't match that of the campaign config. Updating the campaign config

65. Inconsistency between campaigns.json and wmcore_transferor rules for campaign RunIISpring21UL18FSwmLHEGSDR
/MinBias_TuneCP5_13TeV-pythia8/RunIISpring21UL18FSGSPremix-PUFSUL18CP5_106X_upgrade2018_realistic_v16-v1/GEN-SIM-RECO
On campaign config: ['T1_RU_JINR_Disk', 'T1_US_FNAL_Disk']
On Rucio by wmcore_transferor: ['T1_RU_JINR_Disk']
ACTION: The pileup is protected by at least onE wmcore_transferor rule, but it doesn't match that of the campaign config. Updating the campaign config

66. Inconsistency between campaigns.json and wmcore_transferor rules for campaign RunIISpring21UL18FSSIMDR
/MinBias_TuneCP5_13TeV-pythia8/RunIISpring21UL18FSGSPremix-PUFSUL18CP5_106X_upgrade2018_realistic_v16-v1/GEN-SIM-RECO
On campaign config: ['T1_RU_JINR_Disk', 'T1_US_FNAL_Disk']
On Rucio by wmcore_transferor: ['T1_RU_JINR_Disk']
ACTION: The pileup is protected by at least onE wmcore_transferor rule, but it doesn't match that of the campaign config. Updating the campaign config

67. Inconsistency between campaigns.json and wmcore_transferor rules for campaign RunIISpring21UL18FSGSPremix
/Neutrino_E-10_gun/RunIIFall17FSPrePremix-PUFSUL18_106X_upgrade2018_realistic_v16-v1/PREMIX
On campaign config: ['T1_IT_CNAF_Disk', 'T1_US_FNAL_Disk']
On Rucio by wmcore_transferor: []
ACTION: The pileup is not protected by any wmcore_transferor rules, removing it

68. Inconsistency between campaigns.json and wmcore_transferor rules for campaign RunIISpring21UL18FSGSPremix
/Neutrino_E-10_gun/RunIIFall17FSPrePremix-PUFSUL18CP5_106X_upgrade2018_realistic_v16-v1/PREMIX
On campaign config: ['T1_US_FNAL_Disk', 'T1_FR_CCIN2P3_Disk']
On Rucio by wmcore_transferor: []
ACTION: The pileup is not protected by any wmcore_transferor rules, removing it

69. Inconsistency between campaigns.json and wmcore_transferor rules for campaign RunIISpring21UL18FSwmLHEGSPremix
/Neutrino_E-10_gun/RunIIFall17FSPrePremix-PUFSUL18_106X_upgrade2018_realistic_v16-v1/PREMIX
On campaign config: ['T1_IT_CNAF_Disk', 'T1_US_FNAL_Disk']
On Rucio by wmcore_transferor: []
ACTION: The pileup is not protected by any wmcore_transferor rules, removing it

70. Inconsistency between campaigns.json and wmcore_transferor rules for campaign RunIISpring21UL18FSwmLHEGSPremix
/Neutrino_E-10_gun/RunIIFall17FSPrePremix-PUFSUL18CP5_106X_upgrade2018_realistic_v16-v1/PREMIX
On campaign config: ['T1_US_FNAL_Disk', 'T1_FR_CCIN2P3_Disk']
On Rucio by wmcore_transferor: []
ACTION: The pileup is not protected by any wmcore_transferor rules, removing it

71. Inconsistency between campaigns.json and wmcore_transferor rules for campaign RunIISpring22UL18FSwmLHEGSPremix
/Neutrino_E-10_gun/RunIIFall17FSPrePremix-PUFSUL18CP5_106X_upgrade2018_realistic_v16-v1/PREMIX
On campaign config: ['T1_US_FNAL_Disk', 'T1_FR_CCIN2P3_Disk']
On Rucio by wmcore_transferor: []
ACTION: The pileup is not protected by any wmcore_transferor rules, removing it

72. Inconsistency between campaigns.json and wmcore_transferor rules for campaign RunIISpring21UL18FSGSPremixLLPBugFix
/Neutrino_E-10_gun/RunIIFall17FSPrePremix-PUFSUL18CP5_106X_upgrade2018_realistic_v16-v1/PREMIX
On campaign config: ['T1_US_FNAL_Disk', 'T1_FR_CCIN2P3_Disk']
On Rucio by wmcore_transferor: []
ACTION: The pileup is not protected by any wmcore_transferor rules, removing it

73. Inconsistency between campaigns.json and wmcore_transferor rules for campaign RunIISpring21UL18FSSIMDRPremix
/Neutrino_E-10_gun/RunIIFall17FSPrePremix-PUFSUL18CP5_106X_upgrade2018_realistic_v16-v1/PREMIX
On campaign config: ['T1_US_FNAL_Disk', 'T1_FR_CCIN2P3_Disk']
On Rucio by wmcore_transferor: []
ACTION: The pileup is not protected by any wmcore_transferor rules, removing it

74. Inconsistency between campaigns.json and wmcore_transferor rules for campaign RunIISpring21UL17FSGSDR
/MinBias_TuneCP5_13TeV-pythia8/RunIISpring21UL17FSGSPremix-PUFSUL17CP5_106X_mc2017_realistic_v9-v1/GEN-SIM-RECO
On campaign config: ['T1_DE_KIT_Disk', 'T1_RU_JINR_Disk']
On Rucio by wmcore_transferor: []
ACTION: The pileup is not protected by any wmcore_transferor rules, removing it

75. Inconsistency between campaigns.json and wmcore_transferor rules for campaign RunIISpring21UL17FSwmLHEGSDR
/MinBias_TuneCP5_13TeV-pythia8/RunIISpring21UL17FSGSPremix-PUFSUL17CP5_106X_mc2017_realistic_v9-v1/GEN-SIM-RECO
On campaign config: ['T1_DE_KIT_Disk', 'T1_RU_JINR_Disk']
On Rucio by wmcore_transferor: []
ACTION: The pileup is not protected by any wmcore_transferor rules, removing it

76. Inconsistency between campaigns.json and wmcore_transferor rules for campaign RunIISpring21UL17FSSIMDR
/MinBias_TuneCP5_13TeV-pythia8/RunIISpring21UL17FSGSPremix-PUFSUL17CP5_106X_mc2017_realistic_v9-v1/GEN-SIM-RECO
On campaign config: ['T1_DE_KIT_Disk', 'T1_RU_JINR_Disk']
On Rucio by wmcore_transferor: []
ACTION: The pileup is not protected by any wmcore_transferor rules, removing it

77. Inconsistency between campaigns.json and wmcore_transferor rules for campaign RunIISpring21UL17FSGSPremix
/Neutrino_E-10_gun/RunIIFall17FSPrePremix-PUFSUL17CP5_106X_mc2017_realistic_v9-v2/PREMIX
On campaign config: ['T1_DE_KIT_Disk', 'T1_US_FNAL_Disk']
On Rucio by wmcore_transferor: []
ACTION: The pileup is not protected by any wmcore_transferor rules, removing it

78. Inconsistency between campaigns.json and wmcore_transferor rules for campaign RunIISpring21UL17FSwmLHEGSPremix
/Neutrino_E-10_gun/RunIIFall17FSPrePremix-PUFSUL17CP5_106X_mc2017_realistic_v9-v2/PREMIX
On campaign config: ['T1_US_FNAL_Disk', 'T1_DE_KIT_Disk']
On Rucio by wmcore_transferor: []
ACTION: The pileup is not protected by any wmcore_transferor rules, removing it

79. Inconsistency between campaigns.json and wmcore_transferor rules for campaign RunIISpring22UL17FSwmLHEGSPremix
/Neutrino_E-10_gun/RunIIFall17FSPrePremix-PUFSUL17CP5_106X_mc2017_realistic_v9-v2/PREMIX
On campaign config: ['T1_US_FNAL_Disk', 'T1_DE_KIT_Disk']
On Rucio by wmcore_transferor: []
ACTION: The pileup is not protected by any wmcore_transferor rules, removing it

80. Inconsistency between campaigns.json and wmcore_transferor rules for campaign RunIISpring21UL17FSGSPremixLLPBugFix
/Neutrino_E-10_gun/RunIIFall17FSPrePremix-PUFSUL17CP5_106X_mc2017_realistic_v9-v2/PREMIX
On campaign config: ['T1_US_FNAL_Disk', 'T1_DE_KIT_Disk']
On Rucio by wmcore_transferor: []
ACTION: The pileup is not protected by any wmcore_transferor rules, removing it

81. Inconsistency between campaigns.json and wmcore_transferor rules for campaign RunIISpring21UL17FSSIMDRPremix
/Neutrino_E-10_gun/RunIIFall17FSPrePremix-PUFSUL17CP5_106X_mc2017_realistic_v9-v2/PREMIX
On campaign config: ['T1_DE_KIT_Disk', 'T1_US_FNAL_Disk']
On Rucio by wmcore_transferor: []
ACTION: The pileup is not protected by any wmcore_transferor rules, removing it

82. Inconsistency between campaigns.json and wmcore_transferor rules for campaign RunIISpring21UL16FSSIMDR
/MinBias_TuneCP5_13TeV-pythia8/RunIISpring21UL16FSGSPremix-PUFSUL16CP5_106X_mcRun2_asymptotic_v16-v1/GEN-SIM-RECO
On campaign config: ['T1_RU_JINR_Disk']
On Rucio by wmcore_transferor: []
ACTION: The pileup is not protected by any wmcore_transferor rules, removing it

83. Inconsistency between campaigns.json and wmcore_transferor rules for campaign RunIISpring21UL16FSSIMDRPremix
/Neutrino_E-10_gun/RunIIFall17FSPrePremix-PUFSUL16CP5_106X_mcRun2_asymptotic_v16-v1/PREMIX
On campaign config: ['T1_RU_JINR_Disk', 'T1_US_FNAL_Disk']
On Rucio by wmcore_transferor: []
ACTION: The pileup is not protected by any wmcore_transferor rules, removing it

84. Inconsistency between campaigns.json and wmcore_transferor rules for campaign RunIISpring21UL16FSGSDR
/MinBias_TuneCP5_13TeV-pythia8/RunIISpring21UL16FSGSPremix-PUFSUL16CP5_106X_mcRun2_asymptotic_v16-v1/GEN-SIM-RECO
On campaign config: ['T1_RU_JINR_Disk']
On Rucio by wmcore_transferor: []
ACTION: The pileup is not protected by any wmcore_transferor rules, removing it

85. Inconsistency between campaigns.json and wmcore_transferor rules for campaign RunIISpring21UL16FSwmLHEGSDR
/MinBias_TuneCP5_13TeV-pythia8/RunIISpring21UL16FSGSPremix-PUFSUL16CP5_106X_mcRun2_asymptotic_v16-v1/GEN-SIM-RECO
On campaign config: ['T1_RU_JINR_Disk']
On Rucio by wmcore_transferor: []
ACTION: The pileup is not protected by any wmcore_transferor rules, removing it

86. Inconsistency between campaigns.json and wmcore_transferor rules for campaign RunIISpring21UL16FSGSPremix
/Neutrino_E-10_gun/RunIIFall17FSPrePremix-PUFSUL16_106X_mcRun2_asymptotic_v16-v1/PREMIX
On campaign config: ['T1_ES_PIC_Disk', 'T1_US_FNAL_Disk']
On Rucio by wmcore_transferor: []
ACTION: The pileup is not protected by any wmcore_transferor rules, removing it

87. Inconsistency between campaigns.json and wmcore_transferor rules for campaign RunIISpring21UL16FSGSPremix
/Neutrino_E-10_gun/RunIIFall17FSPrePremix-PUFSUL16CP5_106X_mcRun2_asymptotic_v16-v1/PREMIX
On campaign config: ['T1_RU_JINR_Disk', 'T1_US_FNAL_Disk']
On Rucio by wmcore_transferor: []
ACTION: The pileup is not protected by any wmcore_transferor rules, removing it

88. Inconsistency between campaigns.json and wmcore_transferor rules for campaign RunIISpring21UL16FSwmLHEGSPremix
/Neutrino_E-10_gun/RunIIFall17FSPrePremix-PUFSUL16_106X_mcRun2_asymptotic_v16-v1/PREMIX
On campaign config: ['T1_ES_PIC_Disk', 'T1_US_FNAL_Disk']
On Rucio by wmcore_transferor: []
ACTION: The pileup is not protected by any wmcore_transferor rules, removing it

89. Inconsistency between campaigns.json and wmcore_transferor rules for campaign RunIISpring21UL16FSwmLHEGSPremix
/Neutrino_E-10_gun/RunIIFall17FSPrePremix-PUFSUL16CP5_106X_mcRun2_asymptotic_v16-v1/PREMIX
On campaign config: ['T1_RU_JINR_Disk', 'T1_US_FNAL_Disk']
On Rucio by wmcore_transferor: []
ACTION: The pileup is not protected by any wmcore_transferor rules, removing it

90. Inconsistency between campaigns.json and wmcore_transferor rules for campaign RunIISpring22UL16FSwmLHEGSPremix
/Neutrino_E-10_gun/RunIIFall17FSPrePremix-PUFSUL16CP5_106X_mcRun2_asymptotic_v16-v1/PREMIX
On campaign config: ['T1_RU_JINR_Disk', 'T1_US_FNAL_Disk']
On Rucio by wmcore_transferor: []
ACTION: The pileup is not protected by any wmcore_transferor rules, removing it

91. Inconsistency between campaigns.json and wmcore_transferor rules for campaign RunIISpring21UL16FSGSPremixLLPBugFix
/Neutrino_E-10_gun/RunIIFall17FSPrePremix-PUFSUL16CP5_106X_mcRun2_asymptotic_v16-v1/PREMIX
On campaign config: ['T1_RU_JINR_Disk', 'T1_US_FNAL_Disk']
On Rucio by wmcore_transferor: []
ACTION: The pileup is not protected by any wmcore_transferor rules, removing it

92. Inconsistency between campaigns.json and wmcore_transferor rules for campaign RunIIFall17FSPrePremix
/MinBias_TuneCP2_13TeV-pythia8/RunIISpring21UL18FSGSPremix-PUFSUL18_106X_upgrade2018_realistic_v16-v1/GEN-SIM-RECO
On campaign config: ['T1_FR_CCIN2P3_Disk']
On Rucio by wmcore_transferor: []
ACTION: The pileup is not protected by any wmcore_transferor rules, removing it

93. Inconsistency between campaigns.json and wmcore_transferor rules for campaign RunIIFall17FSPrePremix
/MinBias_TuneCP2_13TeV-pythia8/RunIISpring21UL16FSGSPremix-PUFSUL16_106X_mcRun2_asymptotic_v16-v1/GEN-SIM-RECO
On campaign config: ['T2_US_Purdue']
On Rucio by wmcore_transferor: []
ACTION: The pileup is not protected by any wmcore_transferor rules, removing it

94. Inconsistency between campaigns.json and wmcore_transferor rules for campaign RunIIFall17FSPrePremix
/MinBias_TuneCP2_13TeV-pythia8/RunIISpring21UL17FSGSPremix-PUFSUL17_106X_mc2017_realistic_v9-v1/GEN-SIM-RECO
On campaign config: ['T1_ES_PIC_Disk']
On Rucio by wmcore_transferor: []
ACTION: The pileup is not protected by any wmcore_transferor rules, removing it

95. Inconsistency between campaigns.json and wmcore_transferor rules for campaign RunIIFall17FSPrePremix
/MinBias_TuneCP5_13TeV-pythia8/RunIISpring21UL16FSGSPremix-PUFSUL16CP5_106X_mcRun2_asymptotic_v16-v1/GEN-SIM-RECO
On campaign config: ['T1_RU_JINR_Disk']
On Rucio by wmcore_transferor: []
ACTION: The pileup is not protected by any wmcore_transferor rules, removing it

96. Inconsistency between campaigns.json and wmcore_transferor rules for campaign RunIIFall17FSPrePremix
/MinBias_TuneCP5_13TeV-pythia8/RunIISpring21UL18FSGSPremix-PUFSUL18CP5_106X_upgrade2018_realistic_v16-v1/GEN-SIM-RECO
On campaign config: ['T1_US_FNAL_Disk', 'T1_RU_JINR_Disk']
On Rucio by wmcore_transferor: ['T1_RU_JINR_Disk']
ACTION: The pileup is protected by at least onE wmcore_transferor rule, but it doesn't match that of the campaign config. Updating the campaign config

97. Inconsistency between campaigns.json and wmcore_transferor rules for campaign RunIIFall17FSPrePremix
/MinBias_TuneCP5_13TeV-pythia8/RunIISpring21UL17FSGSPremix-PUFSUL17CP5_106X_mc2017_realistic_v9-v1/GEN-SIM-RECO
On campaign config: ['T1_DE_KIT_Disk', 'T1_RU_JINR_Disk']
On Rucio by wmcore_transferor: []
ACTION: The pileup is not protected by any wmcore_transferor rules, removing it

Total number of inconsistencies:  98

```
