### PR TITLE
added flag for probelematic wfs

### DIFF
--- a/autoACDC/runner.py
+++ b/autoACDC/runner.py
@@ -165,7 +165,7 @@ def updateConfigs(configs, solutions):
 
     return configs
 
-def isException(task, attributes):
+def isProblematicWf(task, attributes):
     skip = False
 
     # skip tasks that have been ACDCs more than 3 times
@@ -208,6 +208,7 @@ def main():
     parser.add_argument("-q", "--query", type=str, help="Query to pass to search tool, or path to .json file", required=True)
     parser.add_argument("-c", "--customise", type=str, help="Dictionary of exitCodes and solutions, or path to .json file containing dict.", required=True)
     parser.add_argument("-e", "--exceptions", type=str, help="Dictionary of exceptions, or path to .json file containing dict.", required=False, default=None)
+    parser.add_argument("-p", "--doProblematic", help="Submit ACDCs for problematic wfs (default = False)", required=False, default=False, action='store_true')
     parser.add_argument("-o", "--output", type=str, default="wf_list.txt", help="Output file")
     parser.add_argument("-t", "--test", action="store_true", help="Doesn't submit ACDCs")
 
@@ -252,7 +253,9 @@ def main():
 
             print('\t|-->', task)
 
-            if isException(task, attributes): continue
+            # skip problematic workflows, unless flag --doProblematic is True
+            if not options.doProblematic:
+                if isProblematicWf(task, attributes): continue
                
             # based on the tasks' attributes, apply the solutions
             # default configs


### PR DESCRIPTION
Follow up to previous PR, adds a minor fix, namely a renaming: workflows to be skipped are now named 'problematic', and I've added a flag --doProblematic to runner.py, which can be used to turn on/off the skipping of problematic workflows from the autoACDC, giving the user more control.
