### PR TITLE
removing JIRA logic from closor.py

### DIFF
--- a/Unified/closor.py
+++ b/Unified/closor.py
@@ -212,7 +212,6 @@ def closor(url, specific=None, options=None):
         #print "Waiting on closing threads",time.asctime(time.gmtime())
         time.sleep(5)
 
-    JC = JIRAClient() if up.status.get('jira',False) else None
     print((len(run_threads.threads),"finished thread to gather information from"))
     failed_threads = 0
     for to in run_threads.threads:
@@ -231,10 +230,6 @@ def closor(url, specific=None, options=None):
                 
         if to.to_status:
             to.wfo.status = to.to_status
-            if JC and to.to_status == "done" and to.wfi:
-                jiras = JC.find({"prepid" : to.wfi.request['PrepID']})
-                for jira in jiras:
-                    JC.close(jira.key)
 
         if to.to_wm_status:
             to.wfo.wm_status = to.to_wm_status
@@ -529,7 +524,7 @@ class CloseBuster(threading.Thread):
                                 res = None
                             else:
                                 res = reqMgrClient.announceWorkflowCascade(url, wfo.name) 
-                            
+
                         results.append( res )
                                 
             print(results)

--- a/Unified/closor.py
+++ b/Unified/closor.py
@@ -15,7 +15,6 @@ import copy
 import random
 import optparse
 import sqlalchemy 
-from JIRAClient import JIRAClient
 from campaignAPI import deleteCampaignConfig
 
 


### PR DESCRIPTION
Closor seems to be failing on the JIRA actions it takes.
While I don't understand why it hangs for so long, as a first attempt to solving this, we can try to remove the JIRA logic from the script.
The already-running Unified/jiraHandler.py is already closing out tickets with status = 'announced'.