### PR TITLE
let checkor look at all comments

### DIFF
--- a/Unified/checkor.py
+++ b/Unified/checkor.py
@@ -197,7 +197,7 @@ def checkor(url, spec=None, options=None):
                         print(user, "is force-completing", keyword, "from JIRA")
                         bypasses.append(keyword)
                         overrides[user].append(keyword)
-                    break
+                        break
         bypass_jira_string = "cmsunified please do bypass"
         to_check = JC.find({'text': bypass_jira_string, "status": "!CLOSED"})
         for j in to_check:
@@ -210,7 +210,7 @@ def checkor(url, spec=None, options=None):
                     if keyword and user in actors:
                         print(user, "is bypassing", keyword, "from JIRA")
                         bypasses.append(keyword)
-                    break
+                        break
 
     if use_mcm:
         ## this is a list of prepids that are good to complete


### PR DESCRIPTION
checkor was stopping at the first comment that matched a pattern. change this to allow multiple comments to be checked. avoids cases when an user who isn't authorized to bypass tries to, and blocks the checking of any further comment.
