### PR TITLE
Use auth-get-sso-cookie package for requesting SSO cookies

### DIFF
--- a/McMClient.py
+++ b/McMClient.py
@@ -43,7 +43,7 @@ class McMClient:
 
             if not os.path.isfile(self.cookieFilename):
                 print "The required sso cookie file is absent. Trying to make one for you"
-                os.system('auth-get-sso-cookie -u https://%s -o %s'%( self.server, self.cookieFilename))
+                os.system('export REQUESTS_CA_BUNDLE="/etc/pki/tls/certs/ca-bundle.trust.crt"; auth-get-sso-cookie -u https://%s -o %s'%( self.server, self.cookieFilename))
                 if not os.path.isfile(self.cookieFilename):
                     print "The required sso cookie file cannot be made."
                     sys.exit(1)

--- a/McMClient.py
+++ b/McMClient.py
@@ -43,7 +43,7 @@ class McMClient:
 
             if not os.path.isfile(self.cookieFilename):
                 print "The required sso cookie file is absent. Trying to make one for you"
-                os.system('cern-get-sso-cookie -u https://%s -o %s --krb'%( self.server, self.cookieFilename))
+                os.system('auth-get-sso-cookie -u https://%s -o %s'%( self.server, self.cookieFilename))
                 if not os.path.isfile(self.cookieFilename):
                     print "The required sso cookie file cannot be made."
                     sys.exit(1)


### PR DESCRIPTION
Use “auth-get-sso-cookie” CLI package instead of “cern-get-sso-cookie” for requesting a SSO cookie to authenticate to McM. This update is related with CERN’s SSO migration [1]. Please be sure this new CLI package is available into your runtime environment. If you need more details about how to install it or how does the new package work, please see the documentation available in [2].

References

[1] CERN SSO migration: https://cern.service-now.com/service-portal?id=outage&n=OTG0072195
[2] Command line tools – CERN Authentication team docs: https://auth.docs.cern.ch/applications/command-line-tools/

Fixes #1202

#### Status
not-tested

#### Description
Update McM client

#### Is it backward compatible (if not, which system it affects?)
YES

#### External dependencies / deployment changes
External packages: auth-get-sso-cookie
For more details, please see: https://auth.docs.cern.ch/applications/command-line-tools/

#### Mention people to look at PRs
@z4027163
