### PR TITLE
Add a secondary for RunIIAutumn18DR

### DIFF
--- a/campaigns.json
+++ b/campaigns.json
@@ -2227,6 +2227,15 @@
   "RunIIAutumn18DR": {
     "fractionpass": 0.95,
     "go": true,
+    "secondaries": {
+      "/MinBias_TuneCP5_13TeV-pythia8/RunIIFall18GS-102X_upgrade2018_realistic_v9-v1/GEN-SIM": {
+        "SiteWhitelist": [
+          "T2_US_Caltech",
+        ],
+        "keepOnDisk": true,
+        "fractionOnDisk": 1.0
+      }
+    },
     "lumisize": -1,
     "maxcopies": 1,
     "resize": "auto",


### PR DESCRIPTION
@z4027163 @tyjyang 

Add a secondary for RunIIAutumn18DR which is included in these requests [1] [2]
This commit restores some of PU from original requests [3]
SiteWhitelist is changed to T2_US_Caltech according to [4]

[1] https://[dmytro.web.cern.ch/dmytro/cmsprodmon/workflows.php?prep_id=task_BPH-RunIIFall18GS-00446](https://dmytro.web.cern.ch/dmytro/cmsprodmon/workflows.php?prep_id=task_BPH-RunIIFall18GS-00446)
[2]  https://[dmytro.web.cern.ch/dmytro/cmsprodmon/workflows.php?prep_id=task_BPH-RunIIFall18GS-00447](https://dmytro.web.cern.ch/dmytro/cmsprodmon/workflows.php?prep_id=task_BPH-RunIIFall18GS-00447)
[3] https://its.cern.ch/jira/browse/CMSCOMPPR-5516
[4] https://cmsweb.cern.ch/das/request?view=list&limit=50&instance=prod%2Fglobal&input=site+dataset%3D+%2FMinBias_TuneCP5_13TeV-pythia8%2FRunIIFall18GS-102X_upgrade2018_realistic_v9-v1%2FGEN-SIM