### PR TITLE
Checking wmcore_pileup rule as well when getting allowed sites for a …

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -4571,6 +4571,7 @@ class workflowInfo:
                 for sec in secondary:
                     pileup_locations = rucioClient.getDatasetLocationsByAccount(sec, "wmcore_transferor")
                     pileup_locations += rucioClient.getDatasetLocationsByAccount(sec, "transfer_ops")
+                    pileup_locations += rucioClient.getDatasetLocationsByAccount(sec, "wmcore_pileup")
                     sites_allowed += pileup_locations
                 sites_allowed = sorted(set(sites_allowed))
                 print("Reading minbias")


### PR DESCRIPTION
Some WFs whose secondary rule is 'wmcore_pileup' can't be assigned because current getSiteWhiteList doesn't check the rule. \
Below is one example (Empty initially allowed site).

[task_HIN-HINPbPbAutumn18GSHIMix-00225](https://dmytro.web.cern.ch/dmytro/cmsprodmon/workflows.php?prep_id=task_HIN-HINPbPbAutumn18GSHIMix-00225)
```
Pending workflow check in ON: The following request has passed the check - okay to assign: pdmvserv_task_HIN-HINPbPbAutumn18GSHIMix-00226__v1_T_230517_225706_2317
Pending workflow check in ON: The following request has passed the check - okay to assign: pdmvserv_task_HIN-HINPbPbAutumn18GSHIMix-00226__v1_T_230517_225706_2317
pdmvserv_task_HIN-HINPbPbAutumn18GSHIMix-00226__v1_T_230517_225706_2317 to be assigned 
Exception while getting the dataset location
local variable 'RSEs' referenced before assignment
Exception while getting the dataset location
local variable 'RSEs' referenced before assignment
Reading minbias
Initially allow []
Reducing the whitelist due to black list in campaign configuration
Removing ['T1_US_FNAL', 'T2_CH_CERN_HLT', 'T2_CH_CERN_P5', 'T2_US_Caltech', 'T2_US_Florida', 'T2_US_Nebraska', 'T2_US_Purdue', 'T2_US_UCSD', 'T2_US_Wisconsin']
Reducing the whitelist due to black list in campaign configuration
Removing ['T1_US_FNAL', 'T2_US_Caltech', 'T2_US_Florida', 'T2_US_Nebraska', 'T2_US_Purdue', 'T2_US_UCSD', 'T2_US_Wisconsin', 'T3_US_NERSC']
Reducing the whitelist due to black list in campaign configuration
Removing ['T1_US_FNAL', 'T2_US_Caltech', 'T2_US_Florida', 'T2_US_Nebraska', 'T2_US_Purdue', 'T2_US_UCSD', 'T2_US_Wisconsin']
After all of these, allowing: []
After all of these, not allowing: ['T1_US_FNAL', 'T2_US_Caltech', 'T2_US_Florida', 'T2_US_Nebraska', 'T2_US_Purdue', 'T2_US_UCSD', 'T2_US_Wisconsin']
/Prompt_DstoPhiPi_pthat5_ptGT10_TuneCP5_HydjetDrumMB_5p02TeV_pythia8_evtgen/HINPbPbAutumn18DR-mva98_103X_upgrade2018_realistic_HI_v11-v*/AODSIM -> 0 match(es)
/Prompt_DstoPhiPi_pthat5_ptGT10_TuneCP5_HydjetDrumMB_5p02TeV_pythia8_evtgen/HINPbPbSpring21MiniAOD-mva98_112X_upgrade2018_realistic_HI_v9-v*/MINIAODSIM -> 0 match(es)
checking against /Prompt_DstoPhiPi_pthat5_ptGT10_TuneCP5_HydjetDrumMB_5p02TeV_pythia8_evtgen/HINPbPbAutumn18DR-mva98_103X_upgrade2018_realistic_HI_v11-v1/AODSIM
checking against /Prompt_DstoPhiPi_pthat5_ptGT10_TuneCP5_HydjetDrumMB_5p02TeV_pythia8_evtgen/HINPbPbSpring21MiniAOD-mva98_112X_upgrade2018_realistic_HI_v9-v1/MINIAODSIM
Site white list []
Allowed []
Initial values for primary_AAA=False and secondary_AAA=False
we need 15.10510357946018 CPUh
Allowed sites :[]
Selected for any data []
cannot be assign with no matched sites
```

PU rule \
```
ID                                ACCOUNT        SCOPE:NAME                                                                                              STATE[OK/REPL/STUCK]    RSE_EXPRESSION    COPIES    EXPIRES (UTC)    CREATED (UTC)
--------------------------------  -------------  ------------------------------------------------------------------------------------------------------  ----------------------  ----------------  --------  ---------------  -------------------
ce4edbacdeb34bcfaa5d085bc9afadc0  wmcore_pileup  cms:/MinBias_Hydjet_Drum5F_2018_5p02TeV/HINPbPbAutumn18GS-103X_upgrade2018_realistic_HI_v11-v1/GEN-SIM  OK[4076/0/0]            T2_US_Vanderbilt  1                          2023-07-31 15:17:17
```