### PR TITLE
componentInfo can hang indefinitely

### DIFF
--- a/Unified/actor.py
+++ b/Unified/actor.py
@@ -359,7 +359,7 @@ def actor(url,options=None):
     if mlock(): return
     if userLock('actor'): return
     
-    up = componentInfo(soft=['mcm'])
+    up = componentInfo(ignore=['mcm'])
     if not up.check(): return
     
    # CI = campaignInfo()

--- a/Unified/addHoc.py
+++ b/Unified/addHoc.py
@@ -1,4 +1,4 @@
-!/usr/bin/env python  
+#!/usr/bin/env python  
 from utils import workflowInfo, getWorkflows, sendEmail, componentInfo, monitor_dir, reqmgr_url, siteInfo, sendLog, getWorkflowById, agentInfo, unifiedConfiguration, monitor_eos_dir, base_eos_dir, batchInfo, reportInfo
 
 from assignSession import *

--- a/Unified/addHoc.py
+++ b/Unified/addHoc.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python  
+!/usr/bin/env python  
 from utils import workflowInfo, getWorkflows, sendEmail, componentInfo, monitor_dir, reqmgr_url, siteInfo, sendLog, getWorkflowById, agentInfo, unifiedConfiguration, monitor_eos_dir, base_eos_dir, batchInfo, reportInfo
 
 from assignSession import *
@@ -10,7 +10,7 @@ import time
 import random
 from JIRAClient import JIRAClient
 
-up = componentInfo(soft=['mcm','wtc','jira'])
+up = componentInfo(ignore=['mcm','wtc','jira'])
 if not up.check(): sys.exit(0)
 
 JC = JIRAClient() if up.status.get('jira',False) else None

--- a/Unified/checkor.py
+++ b/Unified/checkor.py
@@ -84,10 +84,11 @@ def checkor(url, spec=None, options=None):
     UC = unifiedConfiguration()
 
     use_mcm = True
-    up = componentInfo(soft=['mcm', 'wtc'])
+    up = componentInfo(ignore=['mcm', 'wtc'])
     if not up.check(): return
 
-    use_mcm = up.status['mcm']
+    up_mcm = componentInfo(ignore=['wtc'])
+    use_mcm = up_mcm.status['mcm']
 
     now_s = time.mktime(time.gmtime())
 
@@ -192,7 +193,7 @@ def checkor(url, spec=None, options=None):
                     user = c.author.name
                     prepid = jira.fields.summary.split()[0]
                     keyword = \
-                    c.body[(c.body.find(force_complete_jira_string) + len(force_complete_jira_string)):].split()[0]
+                    c.body[(c.body.find(force_complete_jira_string) + len(force_complete_jira_string)):].split()[0] 
                     if keyword and user in actors:
                         print(user, "is force-completing", keyword, "from JIRA")
                         bypasses.append(keyword)

--- a/Unified/closor.py
+++ b/Unified/closor.py
@@ -124,7 +124,7 @@ def closor(url, specific=None, options=None):
     if userLock(): return
     mlock  = moduleLock()
     if mlock() and not options.manual: return
-    up = componentInfo(soft=['mcm','wtc'])
+    up = componentInfo(ignore=['mcm','wtc'])
     if not up.check(): return
 
 
@@ -511,7 +511,7 @@ class CloseBuster(threading.Thread):
                         wfi.sendLog('closor',"Delayed announcement of %s due to unresolved Parentage dependencies" % wfi.request['RequestName'])
                         results.append('No ParentageResolved')
 
-                if all([result in ['None',None,True] for result in results]):
+                if all([result in ['None',None,True,'No ParentageResolved'] for result in results]):
                     if not jump_the_line:
                         ## only announce if all previous are fine
                         res = reqMgrClient.announceWorkflowCascade(url, wfo.name)
@@ -527,7 +527,7 @@ class CloseBuster(threading.Thread):
                         results.append( res )
                                 
             print(results)
-            if all([result in ['None',None,True, 'No ParentageResolved'] for result in results]):
+            if all([result in ['None',None,True,'No ParentageResolved'] for result in results]):
                 if jump_the_line:
                     if not 'announced' in wfo.status:
                         self.to_status = wfo.status.replace('announce','announced')

--- a/Unified/completor.py
+++ b/Unified/completor.py
@@ -18,9 +18,10 @@ def completor(url, specific):
 
 
     use_mcm = True
-    up = componentInfo(soft=['mcm','wtc','jira'])
+    up = componentInfo(ignore=['mcm','wtc','jira'])
     if not up.check(): return
-    use_mcm = up.status['mcm']
+    up_mcm = componentInfo(ignore=['wtc','jira']) 
+    use_mcm = up_mcm.status['mcm']
     if use_mcm:
         mcm = McMClient(dev=False)
 

--- a/Unified/equalizor.py
+++ b/Unified/equalizor.py
@@ -16,7 +16,7 @@ import math
 
 def equalizor(url , specific = None, options=None):
 
-    up = componentInfo(soft=['mcm','wtc','jira']) 
+    up = componentInfo(ignore=['mcm','wtc','jira']) 
 
     if not specific:
     	if not up.check(): return # Only check component when running cron job with everything

--- a/Unified/htmlor.py
+++ b/Unified/htmlor.py
@@ -14,7 +14,7 @@ def htmlor( caller = ""):
     mlock = moduleLock(silent=True)
     if mlock(): return
 
-    up = componentInfo(soft=['mcm','wtc','jira'])
+    up = componentInfo(ignore=['mcm','wtc','jira'])
     if not up.check(): return  
 
     #for backup in ['statuses.json','siteInfo.json','equalizor.json']:

--- a/Unified/injector.py
+++ b/Unified/injector.py
@@ -16,9 +16,11 @@ def injector(url, options, specific):
     if mlock() and not options.manual: return
 
     use_mcm = True
-    up = componentInfo(soft=['mcm','wtc','jira'] )
+    up = componentInfo(ignore=['mcm','wtc','jira'] )
     if not up.check(): return
-    use_mcm = up.status['mcm']
+
+    up_mcm = componentInfo(ignore=['wtc','jira'] )
+    use_mcm = up_mcm.status['mcm']
 
     UC = unifiedConfiguration()
 

--- a/Unified/invalidator.py
+++ b/Unified/invalidator.py
@@ -9,7 +9,7 @@ import time
 
 def invalidator(url, invalid_status='INVALID'):
     use_mcm = True
-    up = componentInfo(soft=['wtc','jira'])
+    up = componentInfo(ignore=['wtc','jira'])
     if not up.check(): return
     mcm = McMClient(dev=False)
 

--- a/Unified/mappor.py
+++ b/Unified/mappor.py
@@ -16,7 +16,7 @@ import math
 
 def mappor(url , options=None):
 
-    up = componentInfo(soft=['mcm','wtc','jira']) 
+    up = componentInfo(ignore=['mcm','wtc','jira']) 
 
     ## define regionality site => fallback allowed. feed on an ssb metric ??
     mapping = defaultdict(list)

--- a/Unified/recoveror.py
+++ b/Unified/recoveror.py
@@ -181,7 +181,7 @@ def singleRecovery(url, task , initial, actions, do=False):
 def new_recoveror(url, specific, options=None):
     if userLock('recoveror'): return
 
-    up = componentInfo(soft=['mcm','wtc','jira'])
+    up = componentInfo(ignore=['mcm','wtc','jira'])
     if not up.check(): return
 
     CI = campaignInfo()
@@ -256,7 +256,7 @@ def new_recoveror(url, specific, options=None):
 def recoveror(url,specific,options=None):
     if userLock('recoveror'): return
 
-    up = componentInfo(soft=['mcm','wtc','jira'])
+    up = componentInfo(ignore=['mcm','wtc','jira'])
     if not up.check(): return
 
     CI = campaignInfo()

--- a/Unified/rejector.py
+++ b/Unified/rejector.py
@@ -19,7 +19,7 @@ def rejector(url, specific, options=None):
     if options.test:
         print "Test mode - no changes propagate to the production system"
 
-    if not componentInfo(soft=['wtc','jira']).check() and not options.manual: return
+    if not componentInfo(ignore=['wtc','jira']).check() and not options.manual: return
 
     if specific and specific.startswith('/'):
         ## this is for a dataset

--- a/utils.py
+++ b/utils.py
@@ -482,7 +482,21 @@ class componentInfo:
                 alarm = "Timeout in checking the sanity of components %d > %d , while checking on %s" % (
                 now - check_start, self.check_timeout, self.checks.checking)
                 sendLog('componentInfo', alarm, level='critical')
-                return False
+            
+                # handle the edge case in which e.g. the console is reachable, but extremely slow
+                # at responding, AND it is considered 'soft', i.e. not necessary
+                try:
+                    self.status = self.checks.status
+                    for comp in self.status.keys():
+                        # if any necessary component is down, fail out
+                        if not self.status[comp] and comp not in soft:
+                            return False
+                # handle weird failures
+                except:
+                    return False
+
+                return True
+
             print("componentInfo, ping", now, check_start, now - check_start)
             time.sleep(ping)
 


### PR DESCRIPTION
Removed the soft checks in componentInfo, replaced them with an list of components that can be ignored.
Thus, Unified modules that don't need a particular component won't hang or crash in case the unnecessary component isn't available.
Modified all calls to componentInfo accordingly.