### PR TITLE
remove T2_UA_KIPT from banned sites list

### DIFF
--- a/unifiedConfiguration.json
+++ b/unifiedConfiguration.json
@@ -95,7 +95,6 @@
           "T2_PL_Cyfronet",
           "T2_RU_INR",
           "T2_TR_METU",
-          "T2_UA_KIPT",
           "T2_UK_London_Brunel",
           "T3_BG_UNI_SOFIA",
           "T3_HU_Debrecen",


### PR DESCRIPTION
removed T2_UA_KIPT (Ukrainian site) from banned sites list.

@haozturk 
