### PR TITLE
Update McMClient to support 301 redirects. 

### DIFF
--- a/src/python/Services/McM/McMClient.py
+++ b/src/python/Services/McM/McMClient.py
@@ -51,6 +51,7 @@ class McMClient(object):
         self.connection.setopt(pycurl.SSL_VERIFYHOST, 2)
         self.connection.setopt(pycurl.CAPATH, "/etc/pki/tls/certs")
         self.connection.setopt(pycurl.WRITEFUNCTION, self.response.write)
+        self.connection.setopt(pycurl.FOLLOWLOCATION, 1)
 
     def _getResponse(self) -> dict:
         """


### PR DESCRIPTION
Invalidator was crashing after SSO change by @haozturk due to redirects. 

Added config in mcm client to handle redirects. 

checked on vocms0277, Invalidator is working.
