### PR TITLE
Update McMClient to support 301 redirects in branch , migration-fast

### DIFF
--- a/McMClient.py
+++ b/McMClient.py
@@ -58,6 +58,7 @@ class McMClient:
             self.curl.setopt(pycurl.SSL_VERIFYHOST, 2)
             self.curl.setopt(pycurl.CAPATH, '/etc/pki/tls/certs')  
             self.curl.setopt(pycurl.WRITEFUNCTION, self.output.write)
+            self.curl.setopt(pycurl.FOLLOWLOCATION, 1)
         else:
             self.__http = http.client.HTTPConnection(self.server)
 


### PR DESCRIPTION
actor was crashing after SSO change by @haozturk due to redirects.

Added config in mcm client to handle redirects.

checked on vocms0277, actor is working.